### PR TITLE
fix(navView): missing ios icons

### DIFF
--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/SamplesPage.xaml.cs
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/SamplesPage.xaml.cs
@@ -107,7 +107,14 @@ namespace Uno.Material.Samples
 				NavView.MenuItems.Add(new NavigationViewItem()
 				{
 					Content = content ?? Regex.Replace(typeof(TSamplePage).Name, @"SamplePage$", string.Empty),
-					Icon = new BitmapIcon() { UriSource = new Uri("ms-appx:///Assets/NavigationViewIcons/" + icon + ".png") },
+					Icon = new BitmapIcon()
+					{
+						UriSource = new Uri("ms-appx:///Assets/NavigationViewIcons/" + icon + ".png"),
+#if __IOS__
+						// workaround for BitmapIcon not displaying on ios
+						ShowAsMonochrome = false
+#endif
+					},
 					Tag = typeof(TSamplePage),
 				});
 			}


### PR DESCRIPTION
﻿GitHub Issue: #169 

## PR Type

What kind of change does this PR introduce?

- Bugfix


## Description
added workaround for BitmapIcon not appearing on iOS

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [x] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information
resolved: #169