### PR TITLE
fix see code behind flyout issues

### DIFF
--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Styles/Button.xaml
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Styles/Button.xaml
@@ -1,9 +1,18 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:not_win="http://uno.ui/not_win"
+					xmlns:xamarin="http://nventive.com/xamarin"
+					xmlns:android="http://nventive.com/android"
+					xmlns:ios="http://nventive.com/ios"
+					xmlns:wasm="http://uno.ui/wasm"
+					mc:Ignorable="xamarin android ios wasm not_win">
 
 	<Style x:Key="SeeSourceFlyoutButtonStyle"
 		   TargetType="Button">
-		<Setter Property="Tag" Value="See Source" />
+		<Setter Property="Tag"
+				Value="See Source" />
 
 		<Setter Property="Template">
 			<Setter.Value>
@@ -14,11 +23,37 @@
 								Style="{StaticResource MaterialTextButtonStyle}">
 							<Button.Flyout>
 								<Flyout>
+									<Flyout.FlyoutPresenterStyle>
+										<Style TargetType="FlyoutPresenter">
+											<Setter Property="ScrollViewer.HorizontalScrollMode"
+													Value="Disabled" />
+											<Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
+													Value="Disabled" />
+											<Setter Property="ScrollViewer.VerticalScrollMode"
+													Value="Disabled" />
+											<Setter Property="ScrollViewer.VerticalScrollBarVisibility"
+													Value="Disabled" />
+											<Setter Property="MinHeight"
+													Value="0" />
+											<Setter Property="MinWidth"
+													Value="0" />
+											<Setter Property="Padding"
+													Value="0,0,0,2" />
+											<Setter Property="Margin"
+													not_win:Value="40,100,40,40"
+													win:Value="40,0,40,0" />
+										</Style>
+									</Flyout.FlyoutPresenterStyle>
+
 									<ScrollViewer HorizontalScrollMode="Enabled"
-												  HorizontalScrollBarVisibility="Visible">
+												  HorizontalScrollBarVisibility="Visible"
+												  VerticalScrollMode="Enabled"
+												  VerticalScrollBarVisibility="Visible">
+
 										<TextBlock Text="{TemplateBinding Content}"
+												   FontFamily="{StaticResource RobotoMonoFontFamily}"
 												   IsTextSelectionEnabled="True"
-												   FontFamily="{StaticResource RobotoMonoFontFamily}"/>
+												   Margin="16" />
 									</ScrollViewer>
 								</Flyout>
 							</Button.Flyout>
@@ -32,6 +67,7 @@
 	<Style x:Key="SeeXamlFlyoutButtonStyle"
 		   BasedOn="{StaticResource SeeSourceFlyoutButtonStyle}"
 		   TargetType="Button">
-		<Setter Property="Tag" Value="See Xaml" />
+		<Setter Property="Tag"
+				Value="See Xaml" />
 	</Style>
 </ResourceDictionary>


### PR DESCRIPTION

﻿GitHub Issue: #184 #183 #185

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

Fix for:
[WASM][NavigationView] Flyout when tapping See Code-behind has two scroll bars #185
[Android][NavigationView] Flyout displayed when tapping See Code-behind takes up the entire screen. Nowhere to dismiss flyout #184
[iOS][NavigationView][Notch Device] Flyout displayed when tapping See Code-behind goes in to the command bar #183


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
