### PR TITLE
fix(card): moved ripple inside of card, and alignment expand button to the left

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/Card.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Card.xaml
@@ -185,48 +185,31 @@
 							<RowDefinition Height="Auto" />
 							<RowDefinition Height="Auto" />
 							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
 						</Grid.RowDefinitions>
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="*" />
-							<ColumnDefinition Width="Auto" />
-						</Grid.ColumnDefinitions>
 
 						<!-- Border for PointerOver State-->
-						<Border Grid.RowSpan="4"
-								Grid.ColumnSpan="2"
+						<Border Grid.RowSpan="6"
 								x:Name="HoverOverlay"
 								Background="{StaticResource MaterialOnSurfaceHoverBrush}"
 								Opacity="0" />
 
 						<!-- Border for Focused State-->
-						<Border Grid.RowSpan="4"
-								Grid.ColumnSpan="2"
+						<Border Grid.RowSpan="6"
 								x:Name="FocusedOverlay"
 								Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
 								Opacity="0" />
 
 						<!-- Border for Dragged/Selected State-->
 						<!-- Todo: Add ElevatedView on Dragged/Selected state of button -->
-						<Border Grid.RowSpan="4"
-								Grid.ColumnSpan="2"
+						<Border Grid.RowSpan="6"
 								x:Name="SelectedOverlay"
 								Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
 								Opacity="0" />
 
-						<!-- Ripple effect -->
-						<controls:Ripple Grid.RowSpan="4"
-										 Grid.ColumnSpan="2"
-										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
-										 RippleSizeMultiplier="0.85"
-										 BorderBrush="{TemplateBinding BorderBrush}"
-										 BorderThickness="{TemplateBinding BorderThickness}"
-										 CornerRadius="{StaticResource CardsBorderRadius}"
-										 Padding="{TemplateBinding Padding}"
-										 AutomationProperties.AccessibilityView="Raw" />
-
 						<!-- Media content part -->
-						<ContentPresenter Grid.ColumnSpan="2"
-										  x:Name="MediaContentPresenter"
+						<ContentPresenter x:Name="MediaContentPresenter"
 										  Content="{TemplateBinding MediaContent}"
 										  ContentTemplate="{TemplateBinding MediaContentTemplate}"
 										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -235,39 +218,48 @@
 										  IsHitTestVisible="False"
 										  Visibility="{Binding MediaContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
 
-						<StackPanel Grid.Row="1"
-									Grid.ColumnSpan="2">
-							<!-- Header part-->
-							<ContentPresenter x:Name="HeaderContentPresenter"
-											  Content="{TemplateBinding HeaderContent}"
-											  ContentTemplate="{TemplateBinding HeaderContentTemplate}"
-											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-											  AutomationProperties.AccessibilityView="Raw"
-											  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
+						<!-- Header part-->
+						<ContentPresenter Grid.Row="1"
+										  x:Name="HeaderContentPresenter"
+										  Content="{TemplateBinding HeaderContent}"
+										  ContentTemplate="{TemplateBinding HeaderContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
 
-							<!-- SubHeader part-->
-							<ContentPresenter x:Name="SubHeaderContentPresenter"
-											  Content="{TemplateBinding SubHeaderContent}"
-											  ContentTemplate="{TemplateBinding SubHeaderContentTemplate}"
-											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-											  AutomationProperties.AccessibilityView="Raw"
-											  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
+						<!-- SubHeader part-->
+						<ContentPresenter Grid.Row="2"
+										  x:Name="SubHeaderContentPresenter"
+										  Content="{TemplateBinding SubHeaderContent}"
+										  ContentTemplate="{TemplateBinding SubHeaderContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
 
-							<!-- Supporting Content part-->
-							<ContentPresenter x:Name="SupportingContentPresenter"
-											  Content="{TemplateBinding SupportingContent}"
-											  ContentTemplate="{TemplateBinding SupportingContentTemplate}"
-											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-											  AutomationProperties.AccessibilityView="Raw"
-											  Visibility="{Binding SupportingContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
-						</StackPanel>
+						<!-- Ripple effect -->
+						<controls:Ripple Grid.RowSpan="4"
+										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
+										 RippleSizeMultiplier="0.85"
+										 BorderBrush="{TemplateBinding BorderBrush}"
+										 BorderThickness="{TemplateBinding BorderThickness}"
+										 CornerRadius="{StaticResource CardsBorderRadius}"
+										 Padding="{TemplateBinding Padding}"
+										 AutomationProperties.AccessibilityView="Raw" />
+
+						<!-- Supporting Content part-->
+						<ContentPresenter Grid.Row="3"
+										  x:Name="SupportingContentPresenter"
+										  Content="{TemplateBinding SupportingContent}"
+										  ContentTemplate="{TemplateBinding SupportingContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Visibility="{Binding SupportingContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
 
 						<!-- Icons section part -->
-						<ContentPresenter Grid.Row="1"
-										  Grid.ColumnSpan="2"
+						<ContentPresenter Grid.Row="3"
 										  x:Name="IconsContentPresenter"
 										  Content="{TemplateBinding IconsContent}"
 										  ContentTemplate="{TemplateBinding IconsContentTemplate}"
@@ -277,8 +269,7 @@
 										  Visibility="{Binding IconsContentTemplate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource NullToCollapsed}}" />
 
 						<!-- Expender part -->
-						<StackPanel Grid.Row="2"
-									Grid.ColumnSpan="2"
+						<StackPanel Grid.Row="4"
 									Visibility="{Binding ExpanderHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}">
 							<Rectangle x:Name="ExpanderSeparator"
 									   Height="1"
@@ -292,7 +283,7 @@
 											  Height="0" />
 
 							<ToggleButton IsChecked="{Binding IsOpened, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-										  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+										  HorizontalAlignment="Left"
 										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 										  Content="{TemplateBinding ExpanderHeaderContent}"
 										  ContentTemplate="{TemplateBinding ExpanderHeaderContentTemplate}"
@@ -477,6 +468,8 @@
 								<RowDefinition Height="Auto" />
 								<RowDefinition Height="Auto" />
 								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
 							</Grid.RowDefinitions>
 							<Grid.ColumnDefinitions>
 								<ColumnDefinition Width="*" />
@@ -484,41 +477,26 @@
 							</Grid.ColumnDefinitions>
 
 							<!-- Border for PointerOver State-->
-							<Border Grid.RowSpan="4"
-									Grid.ColumnSpan="2"
+							<Border Grid.RowSpan="6"
 									x:Name="HoverOverlay"
 									Background="{StaticResource MaterialOnSurfaceHoverBrush}"
 									Opacity="0" />
 
 							<!-- Border for Focused State-->
-							<Border Grid.RowSpan="4"
-									Grid.ColumnSpan="2"
+							<Border Grid.RowSpan="6"
 									x:Name="FocusedOverlay"
 									Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
 									Opacity="0" />
 
 							<!-- Border for Dragged/Selected State-->
 							<!-- Todo: Add ElevatedView on Dragged/Selected state of button -->
-							<Border Grid.RowSpan="4"
-									Grid.ColumnSpan="2"
+							<Border Grid.RowSpan="6"
 									x:Name="SelectedOverlay"
 									Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
 									Opacity="0" />
 
-							<!-- Ripple effect -->
-							<controls:Ripple Grid.RowSpan="4"
-											 Grid.ColumnSpan="2"
-											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
-											 RippleSizeMultiplier="0.85"
-											 BorderBrush="{TemplateBinding BorderBrush}"
-											 BorderThickness="{TemplateBinding BorderThickness}"
-											 CornerRadius="{StaticResource CardsBorderRadius}"
-											 Padding="{TemplateBinding Padding}"
-											 AutomationProperties.AccessibilityView="Raw" />
-
 							<!-- Media content part -->
-							<ContentPresenter Grid.ColumnSpan="2"
-											  x:Name="MediaContentPresenter"
+							<ContentPresenter x:Name="MediaContentPresenter"
 											  Content="{TemplateBinding MediaContent}"
 											  ContentTemplate="{TemplateBinding MediaContentTemplate}"
 											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -527,39 +505,48 @@
 											  IsHitTestVisible="False"
 											  Visibility="{Binding MediaContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
 
-							<StackPanel Grid.Row="1"
-										Grid.ColumnSpan="2">
-								<!-- Header part-->
-								<ContentPresenter x:Name="HeaderContentPresenter"
-												  Content="{TemplateBinding HeaderContent}"
-												  ContentTemplate="{TemplateBinding HeaderContentTemplate}"
-												  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-												  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-												  AutomationProperties.AccessibilityView="Raw"
-												  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
+							<!-- Header part-->
+							<ContentPresenter Grid.Row="1"
+											  x:Name="HeaderContentPresenter"
+											  Content="{TemplateBinding HeaderContent}"
+											  ContentTemplate="{TemplateBinding HeaderContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
 
-								<!-- SubHeader part-->
-								<ContentPresenter x:Name="SubHeaderContentPresenter"
-												  Content="{TemplateBinding SubHeaderContent}"
-												  ContentTemplate="{TemplateBinding SubHeaderContentTemplate}"
-												  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-												  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-												  AutomationProperties.AccessibilityView="Raw"
-												  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
+							<!-- SubHeader part-->
+							<ContentPresenter Grid.Row="2"
+											  x:Name="SubHeaderContentPresenter"
+											  Content="{TemplateBinding SubHeaderContent}"
+											  ContentTemplate="{TemplateBinding SubHeaderContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
 
-								<!-- Supporting Content part-->
-								<ContentPresenter x:Name="SupportingContentPresenter"
-												  Content="{TemplateBinding SupportingContent}"
-												  ContentTemplate="{TemplateBinding SupportingContentTemplate}"
-												  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-												  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-												  AutomationProperties.AccessibilityView="Raw"
-												  Visibility="{Binding SupportingContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
-							</StackPanel>
+							<!-- Ripple effect -->
+							<controls:Ripple Grid.RowSpan="4"
+											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
+											 RippleSizeMultiplier="0.85"
+											 BorderBrush="{TemplateBinding BorderBrush}"
+											 BorderThickness="{TemplateBinding BorderThickness}"
+											 CornerRadius="{StaticResource CardsBorderRadius}"
+											 Padding="{TemplateBinding Padding}"
+											 AutomationProperties.AccessibilityView="Raw" />
+
+							<!-- Supporting Content part-->
+							<ContentPresenter Grid.Row="3"
+											  x:Name="SupportingContentPresenter"
+											  Content="{TemplateBinding SupportingContent}"
+											  ContentTemplate="{TemplateBinding SupportingContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding SupportingContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
 
 							<!-- Icons section part -->
-							<ContentPresenter Grid.Row="1"
-											  Grid.ColumnSpan="2"
+							<ContentPresenter Grid.Row="3"
 											  x:Name="IconsContentPresenter"
 											  Content="{TemplateBinding IconsContent}"
 											  ContentTemplate="{TemplateBinding IconsContentTemplate}"
@@ -569,8 +556,7 @@
 											  Visibility="{Binding IconsContentTemplate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource NullToCollapsed}}" />
 
 							<!-- Expender part -->
-							<StackPanel Grid.Row="2"
-										Grid.ColumnSpan="2"
+							<StackPanel Grid.Row="4"
 										Visibility="{Binding ExpanderHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}">
 								<Rectangle x:Name="ExpanderSeparator"
 										   Height="1"
@@ -584,7 +570,7 @@
 												  Height="0" />
 
 								<ToggleButton IsChecked="{Binding IsOpened, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-											  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+											  HorizontalAlignment="Left"
 											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 											  Content="{TemplateBinding ExpanderHeaderContent}"
 											  ContentTemplate="{TemplateBinding ExpanderHeaderContentTemplate}"
@@ -787,17 +773,6 @@
 								Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
 								Opacity="0" />
 
-						<!-- Ripple effect -->
-						<controls:Ripple Grid.RowSpan="5"
-										 Grid.ColumnSpan="3"
-										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
-										 RippleSizeMultiplier="0.85"
-										 BorderBrush="{TemplateBinding BorderBrush}"
-										 BorderThickness="{TemplateBinding BorderThickness}"
-										 CornerRadius="{StaticResource CardsBorderRadius}"
-										 Padding="{TemplateBinding Padding}"
-										 AutomationProperties.AccessibilityView="Raw" />
-
 						<!-- Avatart part -->
 						<ContentPresenter x:Name="AvatarContentPresenter"
 										  Content="{TemplateBinding AvatarContent}"
@@ -829,6 +804,19 @@
 											  AutomationProperties.AccessibilityView="Raw"
 											  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
 						</StackPanel>
+
+						
+
+						<!-- Ripple effect -->
+						<controls:Ripple Grid.RowSpan="2"
+										 Grid.ColumnSpan="3"
+										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
+										 RippleSizeMultiplier="0.85"
+										 BorderBrush="{TemplateBinding BorderBrush}"
+										 BorderThickness="{TemplateBinding BorderThickness}"
+										 CornerRadius="{StaticResource CardsBorderRadius}"
+										 Padding="{TemplateBinding Padding}"
+										 AutomationProperties.AccessibilityView="Raw" />
 
 						<!-- Icons section part -->
 						<ContentPresenter Grid.Column="2"
@@ -879,7 +867,7 @@
 											  Height="0" />
 
 							<ToggleButton IsChecked="{Binding IsOpened, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-										  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+										  HorizontalAlignment="Left"
 										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 										  Content="{TemplateBinding ExpanderHeaderContent}"
 										  ContentTemplate="{TemplateBinding ExpanderHeaderContentTemplate}"
@@ -1087,17 +1075,6 @@
 									Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
 									Opacity="0" />
 
-							<!-- Ripple effect -->
-							<controls:Ripple Grid.RowSpan="5"
-											 Grid.ColumnSpan="3"
-											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
-											 RippleSizeMultiplier="0.85"
-											 BorderBrush="{TemplateBinding BorderBrush}"
-											 BorderThickness="{TemplateBinding BorderThickness}"
-											 CornerRadius="{StaticResource CardsBorderRadius}"
-											 Padding="{TemplateBinding Padding}"
-											 AutomationProperties.AccessibilityView="Raw" />
-
 							<!-- Avatart part -->
 							<ContentPresenter x:Name="AvatarContentPresenter"
 											  Content="{TemplateBinding AvatarContent}"
@@ -1129,6 +1106,16 @@
 												  AutomationProperties.AccessibilityView="Raw"
 												  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
 							</StackPanel>
+							<!-- Ripple effect -->
+							<controls:Ripple Grid.RowSpan="2"
+											 Grid.ColumnSpan="3"
+											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
+											 RippleSizeMultiplier="0.85"
+											 BorderBrush="{TemplateBinding BorderBrush}"
+											 BorderThickness="{TemplateBinding BorderThickness}"
+											 CornerRadius="{StaticResource CardsBorderRadius}"
+											 Padding="{TemplateBinding Padding}"
+											 AutomationProperties.AccessibilityView="Raw" />
 
 							<!-- Icons section part -->
 							<ContentPresenter Grid.Column="2"
@@ -1179,7 +1166,7 @@
 												  Height="0" />
 
 								<ToggleButton IsChecked="{Binding IsOpened, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-											  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+											  HorizontalAlignment="Left"
 											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 											  Content="{TemplateBinding ExpanderHeaderContent}"
 											  ContentTemplate="{TemplateBinding ExpanderHeaderContentTemplate}"
@@ -1383,17 +1370,6 @@
 								Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
 								Opacity="0" />
 
-						<!-- Ripple effect -->
-						<controls:Ripple Grid.RowSpan="3"
-										 Grid.ColumnSpan="2"
-										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
-										 RippleSizeMultiplier="0.85"
-										 BorderBrush="{TemplateBinding BorderBrush}"
-										 BorderThickness="{TemplateBinding BorderThickness}"
-										 CornerRadius="{StaticResource CardsBorderRadius}"
-										 Padding="{TemplateBinding Padding}"
-										 AutomationProperties.AccessibilityView="Raw" />
-
 						<!-- Media content part -->
 						<ContentPresenter x:Name="MediaContentPresenter"
 										  Content="{TemplateBinding MediaContent}"
@@ -1423,6 +1399,16 @@
 											  AutomationProperties.AccessibilityView="Raw"
 											  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
 						</StackPanel>
+
+						<!-- Ripple effect -->
+						<controls:Ripple Grid.ColumnSpan="3"
+										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
+										 RippleSizeMultiplier="0.85"
+										 BorderBrush="{TemplateBinding BorderBrush}"
+										 BorderThickness="{TemplateBinding BorderThickness}"
+										 CornerRadius="{StaticResource CardsBorderRadius}"
+										 Padding="{TemplateBinding Padding}"
+										 AutomationProperties.AccessibilityView="Raw" />
 
 						<!-- Supporting Content part-->
 						<ContentPresenter Grid.Row="1"
@@ -1462,7 +1448,7 @@
 											  Height="0" />
 
 							<ToggleButton IsChecked="{Binding IsOpened, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-										  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+										  HorizontalAlignment="Left"
 										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 										  Content="{TemplateBinding ExpanderHeaderContent}"
 										  ContentTemplate="{TemplateBinding ExpanderHeaderContentTemplate}"
@@ -1675,17 +1661,6 @@
 									Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
 									Opacity="0" />
 
-							<!-- Ripple effect -->
-							<controls:Ripple Grid.RowSpan="3"
-											 Grid.ColumnSpan="2"
-											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
-											 RippleSizeMultiplier="0.85"
-											 BorderBrush="{TemplateBinding BorderBrush}"
-											 BorderThickness="{TemplateBinding BorderThickness}"
-											 CornerRadius="{StaticResource CardsBorderRadius}"
-											 Padding="{TemplateBinding Padding}"
-											 AutomationProperties.AccessibilityView="Raw" />
-
 							<!-- Media content part -->
 							<ContentPresenter x:Name="MediaContentPresenter"
 											  Content="{TemplateBinding MediaContent}"
@@ -1715,6 +1690,16 @@
 												  AutomationProperties.AccessibilityView="Raw"
 												  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCollapsed}}" />
 							</StackPanel>
+
+							<!-- Ripple effect -->
+							<controls:Ripple Grid.ColumnSpan="3"
+											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
+											 RippleSizeMultiplier="0.85"
+											 BorderBrush="{TemplateBinding BorderBrush}"
+											 BorderThickness="{TemplateBinding BorderThickness}"
+											 CornerRadius="{StaticResource CardsBorderRadius}"
+											 Padding="{TemplateBinding Padding}"
+											 AutomationProperties.AccessibilityView="Raw" />
 
 							<!-- Supporting Content part-->
 							<ContentPresenter Grid.Row="1"
@@ -1754,7 +1739,7 @@
 												  Height="0" />
 
 								<ToggleButton IsChecked="{Binding IsOpened, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-											  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+											  HorizontalAlignment="Left"
 											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 											  Content="{TemplateBinding ExpanderHeaderContent}"
 											  ContentTemplate="{TemplateBinding ExpanderHeaderContentTemplate}"


### PR DESCRIPTION
﻿GitHub Issue: #193 #203

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description

- Moved ripple effect into the card, but above supporting content, icons, and expanded content
- Aligned Expanded button to the left
<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
