### PR TITLE
fix(toggleButton): Togglebutton in card would remain checked, focused

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/ToggleButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/ToggleButton.xaml
@@ -91,6 +91,7 @@
 												Value="{StaticResource MaterialOnSurfaceDisabledBrush}" />
 									</VisualState.Setters>
 								</VisualState>
+								<VisualState x:Name="Checked" />
 							</VisualStateGroup>
 							<VisualStateGroup x:Name="FocusStates">
 								<VisualState x:Name="Focused">


### PR DESCRIPTION
﻿GitHub Issue: #202

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description
- Added default checked state to togglebutton, so that the previously defaulted behavior doesn't appear. This fixes the collapse button of cards
<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
