### PR TITLE
fix: NavigationViewItem Icons were not showing the proper foreground on update

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/NavigationView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/NavigationView.xaml
@@ -939,7 +939,8 @@
 							<Viewbox x:Name="IconBox"
 									 Margin="18,10">
 								<ContentPresenter x:Name="Icon"
-												  Content="{TemplateBinding Icon}" />
+												  Content="{TemplateBinding Icon}"
+												  Foreground="{TemplateBinding Foreground}" />
 							</Viewbox>
 
 							<ContentPresenter x:Name="ContentPresenter"


### PR DESCRIPTION
﻿GitHub Issue: #199

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Other... Please describe:


## Description
- Set the foreground color of the icons to templatebinding enforcing that the icon foreground color needs to change on update
<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
