### PR TITLE
fix(fab): XamlDisplayer moved to underneath fabs

### DIFF
--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Content/Controls/FabSamplePage.xaml
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Content/Controls/FabSamplePage.xaml
@@ -26,17 +26,25 @@
 					   FontWeight="Bold"
 					   Foreground="{StaticResource MaterialPrimaryBrush}" />
 
-			<!-- Icon -->
+			<!-- Icon Only Text -->
 			<TextBlock Text="Icon only" />
+			
 			<StackPanel Orientation="Horizontal">
-				<smtx:XamlDisplay UniqueKey="FabSamplePage_IconFab">
+
+				<!-- Primary Fab -->
+				<smtx:XamlDisplay UniqueKey="FabSamplePage_IconFab"
+								  Style="{StaticResource XamlDisplayBelowStyle}">
 					<Button Style="{StaticResource MaterialFabStyle}">
 						<extensions:ControlExtensions.Icon>
 							<SymbolIcon Symbol="Add" />
 						</extensions:ControlExtensions.Icon>
 					</Button>
 				</smtx:XamlDisplay>
-				<smtx:XamlDisplay UniqueKey="FabSamplePage_IconFab2">
+
+				<!-- Secondary Fab -->
+				<smtx:XamlDisplay UniqueKey="FabSamplePage_IconFab2"
+								  Style="{StaticResource XamlDisplayBelowStyle}"
+								  Margin="16,10,16,0">
 					<Button Style="{StaticResource MaterialSecondaryFabStyle}">
 						<extensions:ControlExtensions.Icon>
 							<SymbolIcon Symbol="Add" />
@@ -45,23 +53,35 @@
 				</smtx:XamlDisplay>
 			</StackPanel>
 
-			<!-- Text -->
+			<!-- Text Only Text -->
 			<TextBlock Text="Text only" />
+			
 			<StackPanel Orientation="Horizontal">
-				<smtx:XamlDisplay UniqueKey="FabSamplePage_TextFab">
+
+				<!-- Primary Fab -->
+				<smtx:XamlDisplay UniqueKey="FabSamplePage_TextFab"
+								  Style="{StaticResource XamlDisplayBelowStyle}">
 					<Button Content="CREATE"
 							Style="{StaticResource MaterialFabStyle}" />
 				</smtx:XamlDisplay>
-				<smtx:XamlDisplay UniqueKey="FabSamplePage_TextFab2">
+
+				<!-- Secondary Fab -->
+				<smtx:XamlDisplay UniqueKey="FabSamplePage_TextFab2"
+								  Style="{StaticResource XamlDisplayBelowStyle}"
+								  Margin="16,10,16,0">
 					<Button Content="CREATE"
 							Style="{StaticResource MaterialSecondaryFabStyle}" />
 				</smtx:XamlDisplay>
 			</StackPanel>
 
-			<!-- Icon Text -->
+			<!-- Icon and Text Text-->
 			<TextBlock Text="Icon and text" />
+			
 			<StackPanel Orientation="Horizontal">
-				<smtx:XamlDisplay UniqueKey="FabSamplePage_IconTextFab">
+
+				<!-- Primary Fab -->
+				<smtx:XamlDisplay UniqueKey="FabSamplePage_IconTextFab"
+								  Style="{StaticResource XamlDisplayBelowStyle}">
 					<Button Content="CREATE"
 							Style="{StaticResource MaterialFabStyle}">
 						<extensions:ControlExtensions.Icon>
@@ -69,7 +89,11 @@
 						</extensions:ControlExtensions.Icon>
 					</Button>
 				</smtx:XamlDisplay>
-				<smtx:XamlDisplay UniqueKey="FabSamplePage_IconTextFab2">
+
+				<!-- Sedondary Fab -->
+				<smtx:XamlDisplay UniqueKey="FabSamplePage_IconTextFab2"
+								  Style="{StaticResource XamlDisplayBelowStyle}"
+								  Margin="16,10,16,0">
 					<Button Content="CREATE"
 							Style="{StaticResource MaterialSecondaryFabStyle}">
 						<extensions:ControlExtensions.Icon>


### PR DESCRIPTION
﻿GitHub Issue: #218

## PR Type

What kind of change does this PR introduce?
- Bugfix


## Description
- Moved xaml dispaly under Fabs
- Added margin to separate buttons
- Add some spacing and comments in xaml
<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
