### PR TITLE
fix(menu): Workaround for android pointerover state being applied and…

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/NavigationView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/NavigationView.xaml
@@ -7,6 +7,7 @@
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:android="http://uno.ui/android"
 					xmlns:wasm="http://uno.ui/wasm"
+					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:not_win="http://uno.ui/not_win"
 					xmlns:xamarin="http://uno.ui/xamarin"
 					xmlns:converters="using:Uno.Material.Converters"
@@ -434,7 +435,7 @@
 											<RowDefinition Height="Auto" />
 											<RowDefinition Height="*" />
 										</Grid.RowDefinitions>
-										
+
 										<ContentControl x:Name="HeaderContent"
 														MinHeight="{StaticResource PaneToggleButtonHeight}"
 														IsTabStop="False"
@@ -1000,8 +1001,9 @@
 								<VisualState x:Name="Normal" />
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="HoverOverlay.Opacity"
-												Value="1" />
+										<!-- Workaround for #92 - Android PointerOver state is being applied and maintained on click -->
+										<not_android:Setter Target="HoverOverlay.Opacity"
+															Value="1" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="Pressed">
@@ -1116,8 +1118,9 @@
 								<VisualState x:Name="Normal" />
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="HoverOverlay.Opacity"
-												Value="1" />
+										<!-- Workaround for #92 - Android PointerOver state is being applied and maintained on click -->
+										<not_android:Setter Target="HoverOverlay.Opacity"
+															Value="1" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="Pressed">


### PR DESCRIPTION
… maintained

﻿GitHub Issue: #92

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description
- added not_android and comments to buttons pointerover state
<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [ ] Tested iOS
- [x] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
