### PR TITLE
Add style without compact mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ SurfaceVariantLightColor is the Surface color however in "Light" Palette is an o
 | CheckBox         | MaterialCheckBoxStyle                                                             | TODO             |
 | ComboBox         | MaterialComboBoxStyle                                                             | TODO             |
 | CommandBar       | MaterialCommandBarStyle                                                           | TODO             |
-| NavigationView   | MaterialNavigationViewStyle                                                       | TODO             |
+| NavigationView   | MaterialNavigationViewStyle <br> MaterialNoCompactMenuNavigationViewStyle         | TODO             |
 | PasswordBox      | MaterialFilledPasswordBoxStyle <br> MaterialOutlinedPasswordBoxStyle              | TODO             |
 | RadioButton      | MaterialRadioButtonStyle                                                          | TODO             |
 | TextBlock        | Headline1 <br> Headline2 <br> Headline3 <br> Headline4 <br> Headline5 <br> Headline6 <br> Subtitle1 <br> Subtitle2 <br> Body1 <br> Body2 <br> Button <br> Caption <br> Overline                                 | TODO             |

--- a/src/library/Uno.Material/Styles/Controls/NavigationView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/NavigationView.xaml
@@ -499,6 +499,475 @@
 		</Setter>
 	</Style>
 
+
+	<!--Style which ensures the navigation never displays the menu in "Compact" mode-->
+	<Style x:Key="MaterialNoCompactMenuNavigationViewStyle"
+		   BasedOn="{StaticResource MaterialNavigationViewStyle}"
+		   TargetType="NavigationView">
+		<Setter Property="CompactPaneLength"
+				Value="0" />
+		<Setter Property="ExpandedModeThresholdWidth"
+				Value="600" />
+		<Setter Property="CompactModeThresholdWidth"
+				Value="100000" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="NavigationView">
+					<Grid x:Name="RootGrid">
+
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="DisplayModeGroup">
+								<VisualState x:Name="Compact" />
+								<VisualState x:Name="Expanded">
+									<VisualState.Setters>
+										<Setter Target="TopNavGrid.Visibility"
+												Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+
+								<VisualState x:Name="Minimal">
+									<VisualState.Setters>
+										<Setter Target="HeaderContent.Margin"
+												Value="52,5,0,0" />
+									</VisualState.Setters>
+								</VisualState>
+
+								<VisualState x:Name="MinimalWithBackButton">
+									<VisualState.Setters>
+										<Setter Target="HeaderContent.Margin"
+												Value="104,5,0,0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="TogglePaneGroup">
+								<VisualState x:Name="TogglePaneButtonVisible" />
+								<VisualState x:Name="TogglePaneButtonCollapsed">
+									<VisualState.Setters>
+										<Setter Target="PaneContentGridToggleButtonRow.Height"
+												Value="4" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="HeaderGroup">
+								<VisualState x:Name="HeaderVisible" />
+								<VisualState x:Name="HeaderCollapsed">
+									<VisualState.Setters>
+										<Setter Target="HeaderContent.Visibility"
+												Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="SettingsGroup">
+								<VisualState x:Name="SettingsVisible" />
+								<VisualState x:Name="SettingsCollapsed">
+									<VisualState.Setters>
+										<Setter Target="SettingsNavPaneItem.Visibility"
+												Value="Collapsed" />
+										<Setter Target="SettingsTopNavPaneItem.Visibility"
+												Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="AutoSuggestGroup">
+								<VisualState x:Name="AutoSuggestBoxVisible" />
+								<VisualState x:Name="AutoSuggestBoxCollapsed">
+									<VisualState.Setters>
+										<Setter Target="AutoSuggestArea.Visibility"
+												Value="Collapsed" />
+										<Setter Target="TopPaneAutoSuggestArea.Visibility"
+												Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="PaneStateGroup">
+								<VisualState x:Name="NotClosedCompact" />
+								<VisualState x:Name="ClosedCompact">
+									<VisualState.Setters>
+										<Setter Target="PaneAutoSuggestBoxPresenter.Visibility"
+												Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="PaneStateListSizeGroup">
+								<VisualState x:Name="ListSizeFull" />
+								
+								<!--Display the list as empty instead of compact-->
+								<VisualState x:Name="ListSizeCompact">
+									<VisualState.Setters>
+										<Setter Target="MenuItemsHost.Width"
+												Value="0" />
+										<Setter Target="SettingsNavPaneItem.Width"
+												Value="0" />
+										<Setter Target="PaneTopContent.Visibility"
+												Value="Collapsed" />
+										<Setter Target="PaneHeaderContentBorder.Visibility"
+												Value="Collapsed" />
+										<Setter Target="PaneCustomContentBorder.HorizontalAlignment"
+												Value="Left" />
+										<Setter Target="PaneCustomContentBorder.Width"
+												Value="0" />
+										<Setter Target="FooterContentBorder.Width"
+												Value="0" />
+										<Setter Target="ListSizeCompactPadding.Visibility"
+												Value="Visible" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="TitleBarVisibilityGroup">
+								<VisualState x:Name="TitleBarVisible" />
+								<VisualState x:Name="TitleBarCollapsed">
+									<VisualState.Setters>
+										<Setter Target="PaneContentGrid.Margin"
+												Value="0,32,0,0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="OverflowLabelGroup">
+								<VisualState x:Name="OverflowButtonWithLabel" />
+								<VisualState x:Name="OverflowButtonNoLabel">
+									<VisualState.Setters>
+										<Setter Target="TopNavOverflowButton.Style"
+												Value="{ThemeResource NavigationViewOverflowButtonNoLabelStyleWhenPaneOnTop}" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="BackButtonGroup">
+								<VisualState x:Name="BackButtonVisible" />
+								<VisualState x:Name="BackButtonCollapsed">
+									<VisualState.Setters>
+										<Setter Target="BackButtonPlaceholderOnTopNav.Width"
+												Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+						</VisualStateManager.VisualStateGroups>
+
+						<Grid>
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="*" />
+							</Grid.RowDefinitions>
+
+							<StackPanel x:Name="TopNavArea"
+										Background="{StaticResource NavDrawersBackgroundColor}"
+										Grid.Row="0"
+										HorizontalAlignment="Stretch"
+										VerticalAlignment="Top"
+										Canvas.ZIndex="1">
+
+								<Grid x:Name="TopNavTopPadding"
+									  Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}"
+									  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPaneVisibility}" />
+
+								<Grid x:Name="TopNavGrid"
+									  Height="{ThemeResource NavigationViewTopPaneHeight}"
+									  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPaneVisibility}">
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition x:Name="BackButtonPlaceholderOnTopNav"
+														  Width="{ThemeResource NavigationBackButtonWidth}" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="*"
+														  MinWidth="48" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="Auto" />
+									</Grid.ColumnDefinitions>
+
+									<Grid x:Name="TopNavLeftPadding"
+										  Grid.Column="1"
+										  Width="0" />
+
+									<ContentControl x:Name="PaneHeaderOnTopPane"
+													IsTabStop="False"
+													VerticalContentAlignment="Stretch"
+													HorizontalContentAlignment="Stretch"
+													Grid.Column="2" />
+
+									<!-- Top nav list -->
+									<NavigationViewList AutomationProperties.LandmarkType="Navigation"
+														x:Name="TopNavMenuItemsHost"
+														Grid.Column="3"
+														SelectionMode="Single"
+														IsItemClickEnabled="True"
+														ItemTemplate="{TemplateBinding MenuItemTemplate}"
+														ItemTemplateSelector="{TemplateBinding MenuItemTemplateSelector}"
+														ItemContainerStyle="{TemplateBinding MenuItemContainerStyle}"
+														ItemContainerStyleSelector="{TemplateBinding MenuItemContainerStyleSelector}"
+														ScrollViewer.HorizontalScrollMode="Disabled"
+														ScrollViewer.HorizontalScrollBarVisibility="Hidden"
+														ScrollViewer.VerticalScrollMode="Disabled"
+														ScrollViewer.VerticalScrollBarVisibility="Hidden"
+														SingleSelectionFollowsFocus="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.SingleSelectionFollowsFocus}">
+										<ListView.ItemsPanel>
+											<ItemsPanelTemplate>
+												<ItemsStackPanel Orientation="Horizontal" />
+											</ItemsPanelTemplate>
+										</ListView.ItemsPanel>
+										<ListView.ItemContainerTransitions>
+											<TransitionCollection />
+										</ListView.ItemContainerTransitions>
+									</NavigationViewList>
+
+									<Button x:Name="TopNavOverflowButton"
+											Grid.Column="4"
+											Content="More"
+											Style="{StaticResource NavigationViewOverflowButtonStyleWhenPaneOnTop}"
+											Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.OverflowButtonVisibility}">
+
+										<Button.Flyout>
+											<Flyout Placement="Bottom">
+												<Flyout.FlyoutPresenterStyle>
+													<!-- Based on is required until https://github.com/unoplatform/uno/issues/119 is fixed -->
+													<Style TargetType="FlyoutPresenter"
+														   BasedOn="{StaticResource DefaultFlyoutPresenter}">
+														<Setter Property="Padding"
+																Value="0,8" />
+														<!-- Set negative top margin to make the flyout align exactly with the button -->
+														<Setter Property="Margin"
+																Value="0,-4,0,0" />
+													</Style>
+												</Flyout.FlyoutPresenterStyle>
+												<NavigationViewList x:Name="TopNavMenuItemsOverflowHost"
+																	ItemTemplate="{TemplateBinding MenuItemTemplate}"
+																	ItemTemplateSelector="{TemplateBinding MenuItemTemplateSelector}"
+																	ItemContainerStyle="{TemplateBinding MenuItemContainerStyle}"
+																	ItemContainerStyleSelector="{TemplateBinding MenuItemContainerStyleSelector}"
+																	ScrollViewer.HorizontalScrollBarVisibility="Hidden"
+																	ScrollViewer.VerticalScrollBarVisibility="Hidden"
+																	SingleSelectionFollowsFocus="False"
+																	IsItemClickEnabled="True">
+													<ListView.ItemContainerTransitions>
+														<TransitionCollection />
+													</ListView.ItemContainerTransitions>
+												</NavigationViewList>
+											</Flyout>
+										</Button.Flyout>
+									</Button>
+
+									<ContentControl x:Name="PaneCustomContentOnTopPane"
+													IsTabStop="False"
+													VerticalContentAlignment="Stretch"
+													HorizontalContentAlignment="Stretch"
+													Grid.Column="5" />
+
+									<Grid x:Name="TopPaneAutoSuggestArea"
+										  Height="{ThemeResource NavigationViewTopPaneHeight}"
+										  Grid.Column="6">
+
+										<ContentControl x:Name="TopPaneAutoSuggestBoxPresenter"
+														Margin="12,0,12,0"
+														MinWidth="48"
+														IsTabStop="False"
+														HorizontalContentAlignment="Stretch"
+														VerticalContentAlignment="Center" />
+									</Grid>
+
+									<ContentControl x:Name="PaneFooterOnTopPane"
+													IsTabStop="False"
+													VerticalContentAlignment="Stretch"
+													HorizontalContentAlignment="Stretch"
+													Grid.Column="7" />
+
+									<NavigationViewItem x:Name="SettingsTopNavPaneItem"
+														Style="{ThemeResource NavigationViewSettingsItemStyleWhenOnTopPane}"
+														Grid.Column="8"
+														Icon="Setting" />
+
+								</Grid>
+
+								<Border x:Name="TopNavContentOverlayAreaGrid"
+										Child="{TemplateBinding ContentOverlay}" />
+							</StackPanel>
+
+							<SplitView x:Name="RootSplitView"
+									   Background="{TemplateBinding Background}"
+									   CompactPaneLength="{TemplateBinding CompactPaneLength}"
+									   DisplayMode="Inline"
+									   IsPaneOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPaneOpen, Mode=TwoWay}"
+									   IsTabStop="False"
+									   OpenPaneLength="{TemplateBinding OpenPaneLength}"
+									   PaneBackground="{StaticResource NavDrawersBackgroundColor}"
+									   Grid.Row="1">
+
+								<!-- Known Issue ElevatedView creates abnormal and unwanted behavior inside splitview pane -->
+								<SplitView.Pane>
+									<Grid x:Name="PaneContentGrid"
+										  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}">
+										<Grid.RowDefinitions>
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="0" />
+											<!-- above button margin + back button space -->
+											<RowDefinition x:Name="PaneContentGridToggleButtonRow"
+														   Height="Auto" />
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="8" />
+											<!-- above list margin -->
+											<RowDefinition Height="*" />
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="8" />
+										</Grid.RowDefinitions>
+
+										<Grid x:Name="ContentPaneTopPadding"
+											  Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}" />
+
+										<Grid x:Name="PaneToggleButton_GridRow"
+											  Grid.Row="2"
+											  Height="{StaticResource PaneToggleButtonHeight}" />
+
+										<Grid x:Name="PaneTopContent"
+											  Grid.Row="3">
+
+											<ContentControl x:Name="PaneHeaderContentBorder"
+															IsTabStop="False"
+															VerticalContentAlignment="Stretch"
+															HorizontalContentAlignment="Stretch"
+															Grid.Column="1" />
+										</Grid>
+
+										<Grid x:Name="AutoSuggestArea"
+											  Grid.Row="4"
+											  Height="{ThemeResource NavigationViewTopPaneHeight}"
+											  VerticalAlignment="Center">
+
+											<ContentControl x:Name="PaneAutoSuggestBoxPresenter"
+															Margin="{ThemeResource NavigationViewAutoSuggestBoxMargin}"
+															IsTabStop="False"
+															HorizontalContentAlignment="Stretch"
+															VerticalContentAlignment="Center" />
+
+											<Button x:Name="PaneAutoSuggestButton"
+													Visibility="Collapsed"
+													Style="{ThemeResource NavigationViewPaneSearchButtonStyle}"
+													Width="{TemplateBinding CompactPaneLength}" />
+										</Grid>
+
+										<ContentControl x:Name="PaneCustomContentBorder"
+														IsTabStop="False"
+														VerticalContentAlignment="Stretch"
+														HorizontalContentAlignment="Stretch"
+														Grid.Row="5" />
+
+										<!-- Left nav list -->
+										<NavigationViewList x:Name="MenuItemsHost"
+															Grid.Row="7"
+															Margin="0,0,0,20"
+															SelectionMode="Single"
+															IsItemClickEnabled="True"
+															HorizontalAlignment="Stretch"
+															SelectedItem="{TemplateBinding SelectedItem}"
+															ItemTemplate="{TemplateBinding MenuItemTemplate}"
+															ItemTemplateSelector="{TemplateBinding MenuItemTemplateSelector}"
+															ItemContainerStyle="{TemplateBinding MenuItemContainerStyle}"
+															ItemContainerStyleSelector="{TemplateBinding MenuItemContainerStyleSelector}"
+															SingleSelectionFollowsFocus="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.SingleSelectionFollowsFocus}" />
+
+										<ContentControl x:Name="FooterContentBorder"
+														IsTabStop="False"
+														VerticalContentAlignment="Stretch"
+														HorizontalContentAlignment="Stretch"
+														Grid.Row="8" />
+
+										<NavigationViewItem x:Name="SettingsNavPaneItem"
+															Grid.Row="9"
+															Icon="Setting" />
+									</Grid>
+								</SplitView.Pane>
+
+								<SplitView.Content>
+									<Grid x:Name="ContentGrid">
+										<Grid.RowDefinitions>
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="*" />
+										</Grid.RowDefinitions>
+
+										<!--Padding to compensate for the fact that there is no side panel in ListSizeCompact for this style, so we must
+										ensure that the content is not placed behind the ToggleButton-->
+										<Grid x:Name="ListSizeCompactPadding"
+											  Height="{StaticResource PaneToggleButtonHeight}"
+											  Visibility="Collapsed" />
+
+										<ContentControl x:Name="HeaderContent"
+														MinHeight="{StaticResource PaneToggleButtonHeight}"
+														IsTabStop="False"
+														Margin="4,4,0,0"
+														Content="{TemplateBinding Header}"
+														ContentTemplate="{TemplateBinding HeaderTemplate}"
+														VerticalContentAlignment="Stretch"
+														HorizontalContentAlignment="Stretch"
+														Style="{StaticResource NavigationViewTitleHeaderContentControlTextStyle}"
+														Grid.Row="1"/>
+
+										<ContentPresenter AutomationProperties.LandmarkType="Main"
+														  Grid.Row="2"
+														  Padding="0"
+														  Content="{TemplateBinding Content}" />
+									</Grid>
+								</SplitView.Content>
+							</SplitView>
+
+						</Grid>
+
+						<!--
+							Notes:
+							- InternalVisibleBoundsPadding is added to this control to make this template compatible
+							  with notched devices by default. This behavior is not present in Microsoft's default UWP default.
+
+							- Canvas.ZIndex is not supported in Uno Grid yet, see https://github.com/unoplatform/uno/issues/325
+						-->
+						<Grid x:Name="PaneToggleButtonGrid"
+							  Margin="0,0,0,8"
+							  HorizontalAlignment="Left"
+							  VerticalAlignment="Top"
+							  Canvas.ZIndex="100">
+
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+							</Grid.RowDefinitions>
+
+							<Grid x:Name="TogglePaneTopPadding"
+								  Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}" />
+
+							<Grid x:Name="ButtonHolderGrid"
+								  Grid.Row="1">
+
+								<Button x:Name="NavigationViewBackButton"
+										Style="{StaticResource NavigationBackButtonNormalStyle}"
+										VerticalAlignment="Top"
+										Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.BackButtonVisibility}"
+										IsEnabled="{TemplateBinding IsBackEnabled}" />
+
+								<Button x:Name="TogglePaneButton"
+										Style="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPaneOpen, Converter={StaticResource OpenToPaneButtonStyle}}"
+										AutomationProperties.LandmarkType="Navigation"
+										Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.PaneToggleButtonVisibility}"
+										Background="Transparent"
+										VerticalAlignment="Top" />
+							</Grid>
+						</Grid>
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
 	<Style TargetType="NavigationViewItem">
 		<Setter Property="Foreground"
 				Value="{StaticResource NavDrawersTextColor}" />


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

Add style without compact mode, i.e. the menu does not shrink to compact mode when the user presses the toggle button, it disappears completely and adds appropriate padding so that the menu button does not hover over the NavigationView's panel content.


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [X] Tested Android
- [X] Tested WASM
- [ ] ~~Tested MacOS~~
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
