### PR TITLE
fix(checkBox): Android opacity animation not needed...

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/CheckBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/CheckBox.xaml
@@ -175,13 +175,6 @@
 															 From="0"
 															 To="1" />
 
-											<android:DoubleAnimation Storyboard.TargetName="PressRing"
-																	 Storyboard.TargetProperty="Opacity"
-																	 Duration="0:0:0.5"
-																	 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-																	 From="1"
-																	 To="0" />
-
 											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
 																		   Storyboard.TargetName="PressRing">
 												<EasingDoubleKeyFrame KeyTime="0"
@@ -210,13 +203,6 @@
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
 															 To="1" />
-
-											<android:DoubleAnimation Storyboard.TargetName="PressRing"
-																	 Storyboard.TargetProperty="Opacity"
-																	 Duration="0:0:0.5"
-																	 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-																	 From="1"
-																	 To="0" />
 
 											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
 																		   Storyboard.TargetName="PressRing">
@@ -247,13 +233,6 @@
 															 From="0"
 															 To="1" />
 
-											<android:DoubleAnimation Storyboard.TargetName="PressRing"
-																	 Storyboard.TargetProperty="Opacity"
-																	 Duration="0:0:0.5"
-																	 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-																	 From="1"
-																	 To="0" />
-
 											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
 																		   Storyboard.TargetName="PressRing">
 												<EasingDoubleKeyFrame KeyTime="0"
@@ -282,13 +261,6 @@
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
 															 To="1" />
-
-											<android:DoubleAnimation Storyboard.TargetName="PressRing"
-																	 Storyboard.TargetProperty="Opacity"
-																	 Duration="0:0:0.5"
-																	 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-																	 From="1"
-																	 To="0" />
 
 											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
 																		   Storyboard.TargetName="PressRing">
@@ -320,13 +292,6 @@
 															 From="0"
 															 To="1" />
 
-											<android:DoubleAnimation Storyboard.TargetName="PressRing"
-																	 Storyboard.TargetProperty="Opacity"
-																	 Duration="0:0:0.5"
-																	 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-																	 From="1"
-																	 To="0" />
-
 											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
 																		   Storyboard.TargetName="PressRing">
 												<EasingDoubleKeyFrame KeyTime="0"
@@ -356,13 +321,6 @@
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
 															 To="1" />
-
-											<android:DoubleAnimation Storyboard.TargetName="PressRing"
-																	 Storyboard.TargetProperty="Opacity"
-																	 Duration="0:0:0.5"
-																	 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-																	 From="1"
-																	 To="0" />
 
 											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
 																		   Storyboard.TargetName="PressRing">


### PR DESCRIPTION
was causing opacity to get stuck

﻿GitHub Issue: #230

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description
- Remove android specific opacity animation
<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
