### PR TITLE
fix(bindableDrawerLayout): Closes navigation pane prior to async navigation

### DIFF
--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Content/Controls/NavigationViewSamplePage.xaml.cs
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Content/Controls/NavigationViewSamplePage.xaml.cs
@@ -73,8 +73,19 @@ private void NavView_ItemInvoked(NavigationView sender, NavigationViewItemInvoke
 	else if (args.InvokedItemContainer is NavigationViewItem item)
 	{
 		NavView.Header = item.Content;
-		ContentFrame.Navigate((Type)item.Tag);
+		ContentNavigation((Type)item.Tag);
 	}
+}
+
+private async void ContentNavigation(Type page)
+{
+#if __ANDROID__
+	// By closing the navigation pane with a delay, prior to navigation, we avoid flickers from too much work being done on the UI Thread.
+	NavView.IsPaneOpen = false;
+	await Task.Delay(TimeSpan.FromSeconds(.2));
+#endif
+
+	ContentFrame.Navigate(page);
 }
 
 private void InitializeNavigationViewItems()

--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/SamplesPage.xaml.cs
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/SamplesPage.xaml.cs
@@ -1,14 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Uno.Disposables;
 using Uno.Material.Samples.Content.Controls;
 using Uno.Material.Samples.Content.Styles;
 using Uno.Material.Samples.Shared.Content.Extensions;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-
 
 namespace Uno.Material.Samples
 {
@@ -64,8 +63,19 @@ namespace Uno.Material.Samples
 			else if (args.InvokedItemContainer is NavigationViewItem item)
 			{
 				NavView.Header = item.Content;
-				ContentFrame.Navigate((Type)item.Tag);
+				ContentNavigation((Type)item.Tag);
 			}
+		}
+
+		private async void ContentNavigation(Type page)
+		{
+#if __ANDROID__
+			// Workaround #251 - By closing the navigation pane with a delay, prior to navigation, we avoid flickers from too much work being done on the UI Thread.
+			NavView.IsPaneOpen = false;
+			await Task.Delay(TimeSpan.FromSeconds(.2));
+#endif
+
+			ContentFrame.Navigate(page);
 		}
 
 		private void InitializeNavigationViewItems()
@@ -130,7 +140,7 @@ namespace Uno.Material.Samples
 			}
 		}
 
-		#endregion
+#endregion
 
 		void ToggleTheme()
 		{


### PR DESCRIPTION
﻿GitHub Issue: #173

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description
- Added async synchronous method to close pane with delay before navigation. Resolving previous issue
<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
