### PR TITLE
fix(ripple): Work around the missing rippling effects after first click

### DIFF
--- a/src/library/Uno.Material/Controls/BottomNavigationBarItem.cs
+++ b/src/library/Uno.Material/Controls/BottomNavigationBarItem.cs
@@ -1,7 +1,9 @@
-﻿using Uno.Material.Entities;
+﻿using Windows.Foundation;
+using Uno.Material.Entities;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
 
 namespace Uno.Material.Controls
 {
@@ -49,6 +51,28 @@ namespace Uno.Material.Controls
 		public BottomNavigationBarItem()
 		{
 			DefaultStyleKey = typeof(BottomNavigationBarItem);
+		}
+
+		private Ripple _ripple;
+
+		/// <inheritdoc />
+		protected override void OnApplyTemplate()
+		{
+			_ripple = GetTemplateChild("ContentPresenter") as Ripple;
+			if (_ripple != null)
+			{
+				_ripple.IsAutoRippleEnabled = false;
+			}
+
+			base.OnApplyTemplate();
+		}
+
+		/// <inheritdoc />
+		protected override void OnPointerPressed(PointerRoutedEventArgs args)
+		{
+			_ripple?.StartRippling(args);
+
+			base.OnPointerPressed(args);
 		}
 	}
 }

--- a/src/library/Uno.Material/Controls/Ripple.cs
+++ b/src/library/Uno.Material/Controls/Ripple.cs
@@ -64,6 +64,25 @@ namespace Uno.Material.Controls
 
 		protected override void OnPointerPressed(PointerRoutedEventArgs e)
 		{
+			if (IsAutoRippleEnabled)
+			{
+				StartRippling(e);
+			}
+
+			base.OnPointerPressed(e);
+		}
+
+		/// <summary>
+		/// On WASM when the Ripple control is nested into a control that does capture the pointer,
+		/// we won't receive the pointer events as we should.
+		/// ** Noticeably, it's the case for all buttons. **
+		/// To work around this issue, you can turn this flag on and then,
+		/// invoke the "StartRippling" in the OnPointerPressed of the parent control (i.e. the Button).
+		/// </summary>
+		internal bool IsAutoRippleEnabled { get; set; } = true;
+
+		internal void StartRippling(PointerRoutedEventArgs e)
+		{
 			var point = e.GetCurrentPoint(this);
 
 			RippleX = point.Position.X - RippleSize / 2;
@@ -71,8 +90,6 @@ namespace Uno.Material.Controls
 
 			VisualStateManager.GoToState(this, "Normal", true);
 			VisualStateManager.GoToState(this, "Pressed", true);
-
-			base.OnPointerPressed(e);
 		}
 
 		// Uncomment for hover effect


### PR DESCRIPTION
﻿GitHub Issue: fixes https://github.com/unoplatform/Uno.Material/issues/182

## Workaround
Workaround for issue https://github.com/unoplatform/uno/issues/3592

## PR Checklist 
- [x] Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information
This is a temporary fix until we fix the source issue ... or until we refactor this `Ripple` that should not be a `ContentControl` but just an attached property in my own opinion :)

