### PR TITLE
fix: [All] [BottomBarNavigation] event registration

### DIFF
--- a/src/library/Uno.Material/Controls/BottomNavigationBar.cs
+++ b/src/library/Uno.Material/Controls/BottomNavigationBar.cs
@@ -15,7 +15,7 @@ namespace Uno.Material.Controls
 	{
 		private const string LayoutRootName = "PART_LayoutRoot";
 
-		private bool _initialized = false;
+		private bool _templateApplied = false;
 		private Grid _layoutRoot;
 
 		public BottomNavigationBar()
@@ -24,6 +24,7 @@ namespace Uno.Material.Controls
 			Items = new List<BottomNavigationBarItem>();
 
 			Unloaded += BottomNavigationBar_Unloaded;
+			Loaded += BottomNavigationBar_Loaded;
 		}
 
 		#region Property: Items
@@ -60,14 +61,14 @@ namespace Uno.Material.Controls
 			base.OnApplyTemplate();
 
 			_layoutRoot = this.GetTemplateChild<Grid>(GetTemplateChild, LayoutRootName);
-			_initialized = true;
+			_templateApplied = true;
 
 			GenerateTabItems();
 		}
 
 		internal void GenerateTabItems()
 		{
-			if (!_initialized) return;
+			if (!_templateApplied) return;
 			if (_layoutRoot != null)
 			{
 				// todo: diff update
@@ -96,9 +97,12 @@ namespace Uno.Material.Controls
 
 		private void BottomNavigationBar_Unloaded(object sender, RoutedEventArgs e)
 		{
-			Unloaded -= BottomNavigationBar_Unloaded;
-
 			UnregisterBarItemsEvents();
+		}
+
+		private void BottomNavigationBar_Loaded(object sender, RoutedEventArgs e)
+		{
+			RegisterBarItemsEvents();
 		}
 
 		private static void OnItemsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -137,8 +141,13 @@ namespace Uno.Material.Controls
 
 		private void RegisterBarItemsEvents()
 		{
+			if (!_templateApplied) return;
+
 			foreach (var item in Items.Safe())
 			{
+				item.Checked -= BottomNavigationBarItem_Checked;
+				item.Unchecked -= BottomNavigationBarItem_Unchecked;
+
 				item.Checked += BottomNavigationBarItem_Checked;
 				item.Unchecked += BottomNavigationBarItem_Unchecked;
 			}


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?

- Bugfix


## Description

- Fix event registration issue causing the bottom bar to behave uncorrectly (ex : navigating away from the page where the instance of bottom bar is and coming back caused events not to be registered correctly and so bottom navigation items "IsChecked" property was not unique (both could be checked) ) 


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [ ] Tested iOS 
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information /!\

Not tested on iOS/Android/WASM/MacOS for now as the given project where the bug was found is not ready for Material for these platforms yet. See ref [**here**](https://dev.azure.com/nventive/Channel%209/_git/Channel%209/commit/2154e2d07550302d26634827f7d93152852d4f4d?refName=refs%2Fheads%2Fdev%2Fvica%2Fbottom-bar)