### PR TITLE
fix(radioButton): Android opacity animation not needed...

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/RadioButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/RadioButton.xaml
@@ -83,13 +83,6 @@
 														 From="0"
 														 To="1" />
 
-										<android:DoubleAnimation Storyboard.TargetName="PressRing"
-																 Storyboard.TargetProperty="Opacity"
-																 Duration="0:0:0.5"
-																 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-																 From="1"
-																 To="0" />
-
 										<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity"
 																	   Storyboard.TargetName="PressRing">
 											<EasingDoubleKeyFrame KeyTime="0"
@@ -117,13 +110,6 @@
 														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 														 From="0"
 														 To="1" />
-
-										<android:DoubleAnimation Storyboard.TargetName="PressRing"
-																 Storyboard.TargetProperty="Opacity"
-																 Duration="0:0:0.5"
-																 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-																 From="1"
-																 To="0" />
 
 										<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity"
 																	   Storyboard.TargetName="PressRing">


### PR DESCRIPTION
﻿GitHub Issue: fixes https://github.com/unoplatform/Uno.Material/issues/230

## Bugfix
Triple clicking the `RadioButton` lets the pressed state visible on Android

## Description
Remove useless animations on Android

## PR Checklist 
- [x] Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [x] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information
Reproduce the bug fix did for the `Checkbox` : https://github.com/unoplatform/Uno.Material/pull/246
