### PR TITLE
ci: Fixed version of netcore installed on macOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,9 +133,9 @@ stages:
         provProfileSecureFile: 'UnoMaterial.mobileprovision' # Name of the .mobileprovision file in the secure files.
 
     - task: UseDotNet@2
-      displayName: 'Install .Net Core runtime 3.1.0'
+      displayName: 'Install .Net Core runtime 2.1.x'
       inputs:
-        version: 3.1.0
+        version: 2.1.x
         packageType: 'runtime'
         installationPath: '$(Agent.ToolsDirectory)/dotnet'
         


### PR DESCRIPTION
GitVersion requires 2.1

﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->
- Build or CI related changes

## Description

<!-- (Please describe the changes that this PR introduces.) -->
The version of .Net Core installed on macOS was 3.1. This has been changed to 2.1, which is the one required by GitVersion.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
