### PR TITLE
fix: 190079 BottomBarNavigation icons do not change color when using Dark theme

### DIFF
--- a/src/library/Uno.Material/Styles/Application/ColorPalette.xaml
+++ b/src/library/Uno.Material/Styles/Application/ColorPalette.xaml
@@ -28,27 +28,24 @@
 			<Color x:Key="MaterialOnSurfaceColor">#000000</Color>
 			<Color x:Key="MaterialOnErrorColor">#000000</Color>
 			<Color x:Key="MaterialOverlayColor">#51000000</Color>
-
-			<!-- TODO: Temporary until we figure out how to propertly set Theme Colors in BottomNavigationBar -->
-			<Color x:Key="BottomNavBackgroundColor">#5B4CF5</Color>
-
-			<!-- TODO: Temporary until we figure out how to propertly set Theme Colors in BottomNavigationBarItem -->
-			<Color x:Key="BottomNavLabelFocusColor">#FFFFFF</Color>
-			<Color x:Key="BottomNavIconFocusColor">#FFFFFF</Color>
-			<Color x:Key="BottomNavLabelColor">#FFFFFF</Color>
-			<Color x:Key="BottomNavIconColor">#FFFFFF</Color>
-			<Color x:Key="BottomNavNotifBackgroundColor">#F85977</Color>
-			<Color x:Key="BottomNavNotifLabelColor">#000000</Color>
-
-			<SolidColorBrush x:Key="BottomNavPressedBrush"
-							 Color="{StaticResource MaterialOnPrimaryColor}"
-							 Opacity="0.10" />
-
+			
 			<!-- Variant Colors: Needed for android thumbtints. If a thumbtint color contains opacity, it will actually turn the thumb transparent. -->
 			<!-- Non-opaque/transparent primary disabled color -->
 			<Color x:Key="PrimaryVariantLowThumbColor">#E9E5FA</Color>
 			<!-- Non-opaque/transparent white color that shows on white surfaces -->
 			<Color x:Key="SurfaceVariantLightColor">#F7F7F7</Color>
+
+			<!-- Bottom Bar Navigation -->
+			<Color x:Key="MaterialBottomNavBackgroundColor">#5B4CF5</Color>
+			<Color x:Key="MaterialBottomNavForegroundColor">#FFFFFF</Color>
+			
+			<SolidColorBrush x:Key="MaterialBottomNavPressedBrush"
+							 Color="{ThemeResource MaterialOnPrimaryColor}"
+							 Opacity="0.10" />
+			
+			<SolidColorBrush x:Key="MaterialBottomNavUncheckedForegroundBrush"
+							 Color="{ThemeResource MaterialOnPrimaryColor}"
+							 Opacity="0.60" />
 		</ResourceDictionary>
 
 		<!-- Dark Theme -->
@@ -70,25 +67,22 @@
 			<Color x:Key="MaterialOnErrorColor">#000000</Color>
 			<Color x:Key="MaterialOverlayColor">#51FFFFFF</Color>
 
-			<SolidColorBrush x:Key="BottomNavPressedBrush"
-							 Color="{StaticResource MaterialOnSurfaceColor}"
-							 Opacity="0.10" />
-
-			<!-- TODO: Temporary until we figure out how to propertly set Theme Colors in BottomNavigationBar -->
-			<Color x:Key="BottomNavBackgroundColor">#121212</Color>
-
-			<!-- TODO: Temporary until we figure out how to propertly set Theme Colors in BottomNavigationBarItem -->
-			<Color x:Key="BottomNavLabelFocusColor">#B6A8FB</Color>
-			<Color x:Key="BottomNavIconFocusColor">#B6A8FB</Color>
-			<Color x:Key="BottomNavLabelColor">#DEFFFFFF</Color>
-			<Color x:Key="BottomNavIconColor">#DEFFFFFF</Color>
-			<Color x:Key="BottomNavNotifBackgroundColor">#CF6679</Color>
-			<Color x:Key="BottomNavNotifLabelColor">#000000</Color>
-
 			<!-- Variant Colors: Needed for android thumbtints. If a thumbtint color contains opacity, it will actually turn the thumb transparent. -->
 			<!-- Non-opaque/transparent primary medium color -->
 			<Color x:Key="MaterialPrimaryVariantLowThumbColor">#57507C</Color>
 			<Color x:Key="MaterialSurfaceVariantLightColor">#121212</Color>
+
+			<!-- Bottom Bar Navigation -->
+			<Color x:Key="MaterialBottomNavBackgroundColor">#292929</Color>
+			<Color x:Key="MaterialBottomNavForegroundColor">#B6A8FB</Color>
+			
+			<SolidColorBrush x:Key="MaterialBottomNavPressedBrush"
+							 Color="{StaticResource MaterialOnSurfaceColor}"
+							 Opacity="0.10" />
+			
+			<SolidColorBrush x:Key="MaterialBottomNavUncheckedForegroundBrush"
+							 Color="{StaticResource MaterialOnSurfaceColor}"
+							 Opacity="0.60" />
 		</ResourceDictionary>
 	</ResourceDictionary.ThemeDictionaries>
 

--- a/src/library/Uno.Material/Styles/Application/Colors.xaml
+++ b/src/library/Uno.Material/Styles/Application/Colors.xaml
@@ -6,7 +6,6 @@
 	https://material.io/design/color/the-color-system.html#color-theme-creation 
 	
 	-->
-
 	<!-- Global brushes -->
 	<SolidColorBrush x:Key="MaterialPrimaryBrush"
 					 Color="{ThemeResource MaterialPrimaryColor}" />
@@ -33,7 +32,7 @@
 	<SolidColorBrush x:Key="MaterialOverlayBrush"
 					 Color="{ThemeResource MaterialOverlayColor}" />
 
-	<!-- Primary Brushes -->
+		<!-- Primary Brushes -->
 	<SolidColorBrush x:Key="MaterialPrimaryMediumBrush"
 					 Color="{ThemeResource MaterialPrimaryColor}"
 					 Opacity="{StaticResource MatedialMediumOpacity}" />
@@ -130,30 +129,8 @@
 	<SolidColorBrush x:Key="MaterialOnSurfaceLowVariantBrush"
 					 Color="{ThemeResource MaterialOnSurfaceColor}"
 					 Opacity="0.20" />
-
-	<!-- TODO: Temporary until we figure out how to propertly set Theme Colors in BottomNavigationBar -->
-	<SolidColorBrush x:Key="BottomNavBackgroundColorBrush"
-					 Color="{ThemeResource BottomNavBackgroundColor}" />
-
-	<!-- TODO: Temporary until we figure out how to propertly set Theme Colors in BottomNavigationBarItem -->
-	<SolidColorBrush x:Key="BottomNavLabelFocusColorBrush"
-					 Color="{ThemeResource BottomNavLabelFocusColor}" />
-	<SolidColorBrush x:Key="BottomNavIconFocusColorBrush"
-					 Color="{ThemeResource BottomNavIconFocusColor}" />
-	<SolidColorBrush x:Key="BottomNavLabelColorBrush"
-					 Color="{ThemeResource BottomNavLabelColor}"
-					 Opacity="{StaticResource MaterialMediumOpacity}" />
-	<SolidColorBrush x:Key="BottomNavIconColorBrush"
-					 Color="{ThemeResource BottomNavIconColor}"
-					 Opacity="{StaticResource MaterialMediumOpacity}" />
-	<SolidColorBrush x:Key="BottomNavNotifBackgroundColorBrush"
-					 Color="{ThemeResource BottomNavNotifBackgroundColor}" />
-	<SolidColorBrush x:Key="BottomNavNotifLabelColorBrush"
-					 Color="{ThemeResource BottomNavNotifLabelColor}" />
-
-
 	<StaticResource x:Key="NavDrawersBackgroundBrush"
-					 ResourceKey="MaterialSurfaceBrush" />
+					ResourceKey="MaterialSurfaceBrush" />
 	<StaticResource x:Key="NavDrawersTextBrush"	
 					ResourceKey="MaterialOnSurfaceMediumBrush" />
 	<StaticResource x:Key="NavDrawersIconBrush"	
@@ -161,7 +138,19 @@
 	<StaticResource x:Key="NavDrawersSelectedBrush"
 					ResourceKey="MaterialPrimarySelectedBrush" />
 	<StaticResource x:Key="NavDrawersSelectedTextBrush"
-					 ResourceKey="MaterialPrimaryBrush" />
+					ResourceKey="MaterialPrimaryBrush" />
 	<StaticResource x:Key="NavDrawersSelectedIconBrush"
-					 ResourceKey="MaterialPrimaryBrush" />
+					ResourceKey="MaterialPrimaryBrush" />
+
+	<!-- Bottom Bar Navigation -->
+	<SolidColorBrush x:Key="MaterialBottomNavBackgroundBrush"
+					 Color="{ThemeResource MaterialBottomNavBackgroundColor}" />
+	<SolidColorBrush x:Key="MaterialBottomNavForegroundBrush"
+					 Color="{ThemeResource MaterialBottomNavForegroundColor}" />
+	
+	<SolidColorBrush x:Key="MaterialBottomNavNotifBackgroundBrush"
+					 Color="#CF6679" />
+	<SolidColorBrush x:Key="MaterialBottomNavNotifLabelBrush"
+					 Color="#000000" />
+	
 </ResourceDictionary>

--- a/src/library/Uno.Material/Styles/Controls/BottomNavigationBar.xaml
+++ b/src/library/Uno.Material/Styles/Controls/BottomNavigationBar.xaml
@@ -2,25 +2,24 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:controls="using:Uno.Material.Controls">
 
-	<!-- TODO: Temporary until we figure out how to propertly set Theme Colors in BottomNavigationBar -->
-
-	<!--<StaticResource x:Key="BottomNavBackgroundColorBrush"
-							ResourceKey="MaterialPrimaryBrush" />-->
-
 	<Style x:Key="MaterialBottomNavigationBarStyle"
 		   TargetType="controls:BottomNavigationBar">
+		
+		<Setter Property="Background"
+				Value="{StaticResource MaterialBottomNavBackgroundBrush}" />
+		<Setter Property="Foreground"
+				Value="{StaticResource MaterialBottomNavForegroundBrush}" />
 		<Setter Property="Height"
 				Value="64" />
 		<Setter Property="VerticalAlignment"
 				Value="Bottom" />
-		<Setter Property="Background"
-				Value="{ThemeResource BottomNavBackgroundColorBrush}" />
+
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="controls:BottomNavigationBar">
 					<Grid x:Name="PART_LayoutRoot"
 						  Height="{TemplateBinding Height}"
-						  Background="{TemplateBinding Background}" />
+						  Background="{TemplateBinding Background}"/>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>

--- a/src/library/Uno.Material/Styles/Controls/BottomNavigationBarItem.xaml
+++ b/src/library/Uno.Material/Styles/Controls/BottomNavigationBarItem.xaml
@@ -10,53 +10,62 @@
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:not_wasm="http://uno.ui/not_wasm"
 					mc:Ignorable="not_win xamarin ios android wasm not_wasm">
-
-	<!-- TODO: Temporary until we figure out how to propertly set Theme Colors in BottomNavigationBar -->
-
-	<!--<StaticResource x:Key="BottomNavLabelFocusColorBrush"
-					ResourceKey="MaterialOnPrimaryBrush" />
-	<StaticResource x:Key="BottomNavIconFocusColorBrush"
-					ResourceKey="MaterialOnPrimaryBrush" />
-	<StaticResource x:Key="BottomNavLabelColorBrush"
-					ResourceKey="MaterialOnPrimaryMediumBrush" />
-	<StaticResource x:Key="BottomNavIconColorBrush"
-					ResourceKey="MaterialOnPrimaryMediumBrush" />
-	<StaticResource x:Key="BottomNavNotifBackgroundColorBrush"
-					ResourceKey="MaterialErrorBrush" />
-	<StaticResource x:Key="BottomNavNotifLabelColorBrush"
-					ResourceKey="MaterialOnErrorBrush" />-->
-
-	<x:Double x:Key="BottomNavLabelFontSize">12</x:Double>
-	<x:Double x:Key="BottomNavUncheckedOpacity">0.6</x:Double>
-	<x:Double x:Key="BottomNavLabelCheckedOpacity">0.8</x:Double>
+	
+	<x:Double x:Key="MaterialBottomNavLabelFontSize">12</x:Double>
+	<x:Double x:Key="MaterialBottomNavUncheckedOpacity">0.8</x:Double>
+	<x:Double x:Key="MaterialBottomNavLabelCheckedOpacity">0.74</x:Double>
 
 	<Style x:Key="MaterialBottomNavigationBarItemStyle"
 		   TargetType="controls:BottomNavigationBarItem">
 
-		<Setter Property="Foreground"
-				Value="{ThemeResource BottomNavLabelColorBrush}" />
 		<Setter Property="Margin"
 				Value="0" />
+		<Setter Property="Background"
+				Value="Transparent" />
 
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="controls:BottomNavigationBarItem">
 
-					<Grid Margin="{TemplateBinding Margin}"
-						  Background="Transparent">
+					<Grid Background="{TemplateBinding Background}"
+						  Margin="{TemplateBinding Margin}">
 
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">
-								<VisualState x:Name="Normal" />
-								<VisualState x:Name="PointerOver" />
-								<VisualState x:Name="Pressed" />
+
+								<VisualState x:Name="Normal">
+									<VisualState.Setters>
+										<Setter Target="Icon.Foreground"
+												Value="{ThemeResource MaterialBottomNavUncheckedForegroundBrush}" />
+										<Setter Target="Label.Foreground"
+												Value="{ThemeResource MaterialBottomNavUncheckedForegroundBrush}" />
+									</VisualState.Setters>
+								</VisualState>
+
+								<VisualState x:Name="PointerOver">
+									<VisualState.Setters>
+										<Setter Target="Icon.Foreground"
+												Value="{ThemeResource MaterialBottomNavUncheckedForegroundBrush}" />
+										<Setter Target="Label.Foreground"
+												Value="{ThemeResource MaterialBottomNavUncheckedForegroundBrush}" />
+									</VisualState.Setters>
+								</VisualState>
+
+								<VisualState x:Name="Pressed">
+									<VisualState.Setters>
+										<Setter Target="Icon.Foreground"
+												Value="{ThemeResource MaterialBottomNavUncheckedForegroundBrush}" />
+										<Setter Target="Label.Foreground"
+												Value="{ThemeResource MaterialBottomNavUncheckedForegroundBrush}" />
+									</VisualState.Setters>
+								</VisualState>
 
 								<VisualState x:Name="CheckedPointerOver">
 									<VisualState.Setters>
 										<Setter Target="Icon.Opacity"
 												Value="1" />
 										<Setter Target="Label.Opacity"
-												Value="{StaticResource BottomNavLabelCheckedOpacity}" />
+												Value="{StaticResource MaterialBottomNavLabelCheckedOpacity}" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -65,7 +74,7 @@
 										<Setter Target="Icon.Opacity"
 												Value="1" />
 										<Setter Target="Label.Opacity"
-												Value="{StaticResource BottomNavLabelCheckedOpacity}" />
+												Value="{StaticResource MaterialBottomNavLabelCheckedOpacity}" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -75,7 +84,7 @@
 										<Setter Target="Icon.Opacity"
 												Value="1" />
 										<Setter Target="Label.Opacity"
-												Value="{StaticResource BottomNavLabelCheckedOpacity}" />
+												Value="{StaticResource MaterialBottomNavLabelCheckedOpacity}" />
 									</VisualState.Setters>
 
 									<xamarin:Storyboard>
@@ -83,22 +92,22 @@
 																  Storyboard.TargetProperty="Opacity"
 																  Duration="0:0:0.4"
 																  EasingFunction="{StaticResource Material_EaseInOutFunction}"
-																  From="{StaticResource BottomNavUncheckedOpacity}"
+																  From="{StaticResource MaterialBottomNavUncheckedOpacity}"
 																  To="1" />
 
 										<not_wasm:DoubleAnimation Storyboard.TargetName="Label"
 																  Storyboard.TargetProperty="Opacity"
 																  Duration="0:0:0.4"
 																  EasingFunction="{StaticResource Material_EaseInOutFunction}"
-																  From="{StaticResource BottomNavUncheckedOpacity}"
-																  To="{StaticResource BottomNavLabelCheckedOpacity}" />
+																  From="{StaticResource MaterialBottomNavUncheckedOpacity}"
+																  To="{StaticResource MaterialBottomNavLabelCheckedOpacity}" />
 									</xamarin:Storyboard>
 								</VisualState>
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 
 						<controls:Ripple x:Name="ContentPresenter"
-										 Feedback="{ThemeResource BottomNavPressedBrush}"
+										 Feedback="{ThemeResource MaterialBottomNavPressedBrush}"
 										 BorderBrush="{TemplateBinding BorderBrush}"
 										 BorderThickness="{TemplateBinding BorderThickness}"
 										 ContentTransitions="{TemplateBinding ContentTransitions}"
@@ -124,7 +133,8 @@
 									<!-- Icon -->
 									<ContentPresenter x:Name="Icon"
 													  Content="{Binding Path=Icon, RelativeSource={RelativeSource TemplatedParent}}"
-													  Opacity="{StaticResource BottomNavUncheckedOpacity}"
+													  Foreground="{TemplateBinding Foreground}"
+													  Opacity="{StaticResource MaterialBottomNavUncheckedOpacity}"
 													  Height="20"
 													  Width="20"
 													  Margin="12,0" />
@@ -139,16 +149,16 @@
 										<Ellipse Height="14"
 												 Width="14"
 												 Stretch="Uniform"
-												 Fill="{ThemeResource BottomNavNotifBackgroundColorBrush}"
+												 Fill="{ThemeResource MaterialBottomNavNotifBackgroundBrush}"
 												 Visibility="{Binding Text, Converter={StaticResource Material_EmptyToVisible}}" />
 
 										<!-- Badge Text Notification -->
 										<Border CornerRadius="6"
-												Background="{ThemeResource BottomNavNotifBackgroundColorBrush}"
+												Background="{ThemeResource MaterialBottomNavNotifBackgroundBrush}"
 												Visibility="{Binding Text, Converter={StaticResource Material_EmptyToCollapsed}}">
 
 											<TextBlock Text="{Binding Text}"
-													   Foreground="{ThemeResource BottomNavNotifLabelColorBrush}"
+													   Foreground="{ThemeResource MaterialBottomNavNotifLabelBrush}"
 													   FontSize="10"
 													   TextTrimming="CharacterEllipsis"
 													   Margin="4,2" />
@@ -166,7 +176,7 @@
 										   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 										   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
 										   Visibility="{Binding Label, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource Material_EmptyToCollapsed}}"
-										   Opacity="{StaticResource BottomNavUncheckedOpacity}"
+										   Opacity="{StaticResource MaterialBottomNavUncheckedOpacity}"
 										   Grid.Row="1" />
 							</Grid>
 						</controls:Ripple>

--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Content/Controls/BottomNavigationBarSamplePage.xaml
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Content/Controls/BottomNavigationBarSamplePage.xaml
@@ -1,14 +1,13 @@
 ﻿<Page x:Class="Uno.Material.Samples.Content.Controls.BottomNavigationBarSamplePage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:controls="using:Uno.Material.Controls"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:entities="using:Uno.Material.Entities"
 	  xmlns:smtx="using:ShowMeTheXAML"
 	  xmlns:wasm="http://uno.ui/wasm"
 	  xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	  mc:Ignorable="d wasm">
+	  mc:Ignorable="wasm">
 
 	<!-- No Border on phones, to emphasize the position of the BottomBar -->
 	<Grid wasm:BorderBrush="{StaticResource MaterialOnSurfaceBrush}"
@@ -20,7 +19,6 @@
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
-
 
 		<TextBlock Grid.Row="0"
 				   Text="{x:Bind BottomNavBar.SelectedItem.Tag, Mode=OneWay}"
@@ -34,38 +32,48 @@
 		<smtx:XamlDisplay Grid.Row="2"
 						  UniqueKey="BottomNavigationBarSamplePage_Content"
 						  Style="{StaticResource ContentOnlyXamlDisplayStyle}">
+			
 			<controls:BottomNavigationBar x:Name="BottomNavBar">
 				<controls:BottomNavigationBar.Items>
+
 					<controls:BottomNavigationBarItem Label="Favorites"
 													  Tag="My Favorites">
 						<controls:BottomNavigationBarItem.Icon>
 							<SymbolIcon Symbol="Favorite" />
 						</controls:BottomNavigationBarItem.Icon>
 					</controls:BottomNavigationBarItem>
+
 					<controls:BottomNavigationBarItem Label="Search"
 													  Tag="Search Something">
 						<controls:BottomNavigationBarItem.Icon>
 							<SymbolIcon Symbol="Find" />
 						</controls:BottomNavigationBarItem.Icon>
 					</controls:BottomNavigationBarItem>
+
 					<controls:BottomNavigationBarItem Tag="Important Stuff">
+
 						<controls:BottomNavigationBarItem.Icon>
 							<SymbolIcon Symbol="Important" />
 						</controls:BottomNavigationBarItem.Icon>
+
 						<controls:BottomNavigationBarItem.Badge>
 							<entities:BottomNavigationBarBadge IsVisible="True" />
 						</controls:BottomNavigationBarItem.Badge>
 					</controls:BottomNavigationBarItem>
+
 					<controls:BottomNavigationBarItem Label="Notifications"
 													  Tag="12 Unread Notifications">
+
 						<controls:BottomNavigationBarItem.Icon>
 							<SymbolIcon Symbol="Flag" />
 						</controls:BottomNavigationBarItem.Icon>
+
 						<controls:BottomNavigationBarItem.Badge>
 							<entities:BottomNavigationBarBadge IsVisible="True"
 															   Text="12" />
 						</controls:BottomNavigationBarItem.Badge>
 					</controls:BottomNavigationBarItem>
+
 					<controls:BottomNavigationBarItem Tag="App Settings">
 						<controls:BottomNavigationBarItem.Icon>
 							<SymbolIcon Symbol="Setting" />


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Fix for 190079 BottomBarNavigation icons do not change color when using Dark theme


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
