### PR TITLE
fix(ios): workaround for broken radio&check pressed overlay on last tick

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/CheckBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/CheckBox.xaml
@@ -169,14 +169,14 @@
 															 Duration="0:0:0.4"
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
-															 To="1" />
+															 To="0.99" />
 
 											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
 															 Storyboard.TargetProperty="ScaleY"
 															 Duration="0:0:0.4"
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
-															 To="1" />
+															 To="0.99" />
 
 											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
 																		   Storyboard.TargetName="PressRing">
@@ -189,7 +189,7 @@
 											</DoubleAnimationUsingKeyFrames>
 										</Storyboard>
 									</VisualTransition>
-									
+
 									<VisualTransition From="UncheckedPointerOver"
 													  To="UncheckedPressed">
 										<Storyboard>
@@ -198,14 +198,14 @@
 															 Duration="0:0:0.4"
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
-															 To="1" />
+															 To="0.99" />
 
 											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
 															 Storyboard.TargetProperty="ScaleY"
 															 Duration="0:0:0.4"
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
-															 To="1" />
+															 To="0.99" />
 
 											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
 																		   Storyboard.TargetName="PressRing">
@@ -218,7 +218,7 @@
 											</DoubleAnimationUsingKeyFrames>
 										</Storyboard>
 									</VisualTransition>
-									
+
 									<VisualTransition From="CheckedNormal"
 													  To="CheckedPressed">
 										<Storyboard>
@@ -227,14 +227,14 @@
 															 Duration="0:0:0.4"
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
-															 To="1" />
+															 To="0.99" />
 
 											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
 															 Storyboard.TargetProperty="ScaleY"
 															 Duration="0:0:0.4"
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
-															 To="1" />
+															 To="0.99" />
 
 											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
 																		   Storyboard.TargetName="PressRing">
@@ -247,7 +247,7 @@
 											</DoubleAnimationUsingKeyFrames>
 										</Storyboard>
 									</VisualTransition>
-									
+
 									<VisualTransition From="CheckedPointerOver"
 													  To="CheckedPressed">
 										<Storyboard>
@@ -256,14 +256,14 @@
 															 Duration="0:0:0.4"
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
-															 To="1" />
+															 To="0.99" />
 
 											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
 															 Storyboard.TargetProperty="ScaleY"
 															 Duration="0:0:0.4"
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
-															 To="1" />
+															 To="0.99" />
 
 											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
 																		   Storyboard.TargetName="PressRing">
@@ -276,7 +276,7 @@
 											</DoubleAnimationUsingKeyFrames>
 										</Storyboard>
 									</VisualTransition>
-									
+
 									<VisualTransition From="IndeterminateNormal"
 													  To="IndeterminatePressed">
 
@@ -286,14 +286,14 @@
 															 Duration="0:0:0.4"
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
-															 To="1" />
+															 To="0.99" />
 
 											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
 															 Storyboard.TargetProperty="ScaleY"
 															 Duration="0:0:0.4"
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
-															 To="1" />
+															 To="0.99" />
 
 											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
 																		   Storyboard.TargetName="PressRing">
@@ -306,7 +306,7 @@
 											</DoubleAnimationUsingKeyFrames>
 										</Storyboard>
 									</VisualTransition>
-									
+
 									<VisualTransition From="IndeterminatePointerOver"
 													  To="IndeterminatePressed">
 
@@ -316,14 +316,14 @@
 															 Duration="0:0:0.4"
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
-															 To="1" />
+															 To="0.99" />
 
 											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
 															 Storyboard.TargetProperty="ScaleY"
 															 Duration="0:0:0.4"
 															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 															 From="0"
-															 To="1" />
+															 To="0.99" />
 
 											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
 																		   Storyboard.TargetName="PressRing">
@@ -394,13 +394,13 @@
 						<Grid x:Name="CheckBoxContainer"
 							  Height="{StaticResource CheckAreaSize}"
 							  Width="{StaticResource CheckAreaSize}">
-							
+
 							<Grid x:Name="BackgroundBorder"
 								  Background="{ThemeResource MaterialBackgroundColor}"
 								  BorderBrush="{TemplateBinding BorderBrush}"
 								  BorderThickness="{TemplateBinding BorderThickness}"
 								  CornerRadius="2" />
-							
+
 							<Grid x:Name="CheckedBackgroundBorder"
 								  Background="{TemplateBinding Background}"
 								  Opacity="0"

--- a/src/library/Uno.Material/Styles/Controls/RadioButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/RadioButton.xaml
@@ -72,14 +72,14 @@
 														 Duration="0:0:0.4"
 														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 														 From="0"
-														 To="1" />
+														 To="0.99" />
 
 										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
 														 Storyboard.TargetProperty="ScaleY"
 														 Duration="0:0:0.4"
 														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 														 From="0"
-														 To="1" />
+														 To="0.99" />
 
 										<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity"
 																	   Storyboard.TargetName="PressRing">
@@ -100,14 +100,14 @@
 														 Duration="0:0:0.4"
 														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 														 From="0"
-														 To="1" />
+														 To="0.99" />
 
 										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
 														 Storyboard.TargetProperty="ScaleY"
 														 Duration="0:0:0.4"
 														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 														 From="0"
-														 To="1" />
+														 To="0.99" />
 
 										<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity"
 																	   Storyboard.TargetName="PressRing">


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type
What kind of change does this PR introduce?

- Bugfix

## Description
https://dev.azure.com/nventive/Uno%20Gallery/_workitems/edit/190646

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [x] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information
On iOS, it seems like CenterXY becomes TranslateXY on the very last frame (presumably that is when ScaleXY becomes 1).
Setting the initial values to 0 instead of 20, and the blinking issue on last frame is gone.
However, the ring will expand from the top-left, instead of from center...
So, instead of doing a cubic ease between [0, 1], we use [0, 0.99] as boundaries.

## Internal Issue (If applicable):
https://dev.azure.com/nventive/Uno%20Gallery/_workitems/edit/190646