### PR TITLE
fix: [All][Buttons/BottomBar/Cards] ripple speed and size

### DIFF
--- a/src/library/Uno.Material/Controls/Ripple.cs
+++ b/src/library/Uno.Material/Controls/Ripple.cs
@@ -107,7 +107,7 @@ namespace Uno.Material.Controls
 		//}
 
 		public static readonly DependencyProperty RippleSizeMultiplierProperty = DependencyProperty.Register(
-			"RippleSizeMultiplier", typeof(double), typeof(Ripple), new PropertyMetadata(1.75));
+			"RippleSizeMultiplier", typeof(double), typeof(Ripple), new PropertyMetadata(8.0));
 
 		public double RippleSizeMultiplier
 		{

--- a/src/library/Uno.Material/Styles/Controls/BottomNavigationBarItem.xaml
+++ b/src/library/Uno.Material/Styles/Controls/BottomNavigationBarItem.xaml
@@ -99,7 +99,6 @@
 
 						<controls:Ripple x:Name="ContentPresenter"
 										 Feedback="{ThemeResource BottomNavPressedBrush}"
-										 RippleSizeMultiplier="0.75"
 										 BorderBrush="{TemplateBinding BorderBrush}"
 										 BorderThickness="{TemplateBinding BorderThickness}"
 										 ContentTransitions="{TemplateBinding ContentTransitions}"

--- a/src/library/Uno.Material/Styles/Controls/Button.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Button.xaml
@@ -30,9 +30,6 @@
 	<StaticResource x:Key="MaterialTextButtonLowBrush"
 					ResourceKey="MaterialOnSurfaceMediumBrush" />
 
-	<!-- Undocumented variables -->
-	<x:Double x:Key="MaterialButtonRippleMultiplier">2.0</x:Double>
-
 	<!-- Styles -->
 	<Style x:Key="MaterialContainedButtonStyle"
 		   TargetType="Button">
@@ -145,7 +142,6 @@
 						<controls:Ripple x:Name="ContentPresenter"
 										 Feedback="{TemplateBinding Foreground}"
 										 FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
-										 RippleSizeMultiplier="{StaticResource MaterialButtonRippleMultiplier}"
 										 BorderBrush="{TemplateBinding BorderBrush}"
 										 BorderThickness="{TemplateBinding BorderThickness}"
 										 Content="{TemplateBinding Content}"
@@ -292,7 +288,6 @@
 						<controls:Ripple x:Name="ContentPresenter"
 										 Feedback="{TemplateBinding Foreground}"
 										 FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
-										 RippleSizeMultiplier="{StaticResource MaterialButtonRippleMultiplier}"
 										 BorderBrush="{TemplateBinding BorderBrush}"
 										 BorderThickness="{TemplateBinding BorderThickness}"
 										 Content="{TemplateBinding Content}"
@@ -430,7 +425,6 @@
 						<controls:Ripple x:Name="ContentPresenter"
 										 Feedback="{TemplateBinding Foreground}"
 										 FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
-										 RippleSizeMultiplier="{StaticResource MaterialButtonRippleMultiplier}"
 										 BorderBrush="{TemplateBinding BorderBrush}"
 										 BorderThickness="{TemplateBinding BorderThickness}"
 										 Content="{TemplateBinding Content}"

--- a/src/library/Uno.Material/Styles/Controls/Card.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Card.xaml
@@ -169,7 +169,6 @@
 						<!-- Ripple effect -->
 						<controls:Ripple Grid.RowSpan="4"
 										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
-										 RippleSizeMultiplier="0.85"
 										 BorderBrush="{TemplateBinding BorderBrush}"
 										 BorderThickness="{TemplateBinding BorderThickness}"
 										 CornerRadius="{StaticResource CardsBorderRadius}"
@@ -357,7 +356,6 @@
 							<!-- Ripple effect -->
 							<controls:Ripple Grid.RowSpan="4"
 											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
-											 RippleSizeMultiplier="0.85"
 											 CornerRadius="{StaticResource CardsBorderRadius}"
 											 Padding="{TemplateBinding Padding}"
 											 AutomationProperties.AccessibilityView="Raw" />
@@ -545,7 +543,6 @@
 						<controls:Ripple Grid.RowSpan="2"
 										 Grid.ColumnSpan="3"
 										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
-										 RippleSizeMultiplier="0.85"
 										 BorderBrush="{TemplateBinding BorderBrush}"
 										 BorderThickness="{TemplateBinding BorderThickness}"
 										 CornerRadius="{StaticResource CardsBorderRadius}"
@@ -749,7 +746,6 @@
 							<controls:Ripple Grid.RowSpan="2"
 											 Grid.ColumnSpan="3"
 											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
-											 RippleSizeMultiplier="0.85"
 											 CornerRadius="{StaticResource CardsBorderRadius}"
 											 Padding="{TemplateBinding Padding}"
 											 AutomationProperties.AccessibilityView="Raw" />
@@ -952,7 +948,6 @@
 						<!-- Ripple effect -->
 						<controls:Ripple Grid.ColumnSpan="3"
 										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
-										 RippleSizeMultiplier="0.85"
 										 BorderBrush="{TemplateBinding BorderBrush}"
 										 BorderThickness="{TemplateBinding BorderThickness}"
 										 CornerRadius="{StaticResource CardsBorderRadius}"
@@ -1150,7 +1145,6 @@
 							<!-- Ripple effect -->
 							<controls:Ripple Grid.ColumnSpan="3"
 											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
-											 RippleSizeMultiplier="0.85"
 											 CornerRadius="{StaticResource CardsBorderRadius}"
 											 Padding="{TemplateBinding Padding}"
 											 AutomationProperties.AccessibilityView="Raw" />

--- a/src/library/Uno.Material/Styles/Controls/FloatingActionButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/FloatingActionButton.xaml
@@ -54,7 +54,6 @@
 	<Thickness x:Key="MaterialFabPadding_Small">12</Thickness>
 
 	<!-- Undocumented variables -->
-	<x:Double x:Key="MaterialFabRippleMultiplier">2.0</x:Double>
 	<x:Double x:Key="MaterialFabContentWidthOrHeight">16</x:Double>
 	<x:Double x:Key="MaterialFabIconTextPadding">12</x:Double>
 
@@ -98,8 +97,7 @@
 							<controls:Ripple x:Name="Ripple"
 											 CornerRadius="{TemplateBinding CornerRadius}"
 											 Feedback="{TemplateBinding Foreground}"
-											 FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
-											 RippleSizeMultiplier="{StaticResource MaterialFabRippleMultiplier}">
+											 FeedbackOpacity="{StaticResource MaterialPressedOpacity}">
 
 								<Grid x:Name="Root"
 									  Background="{TemplateBinding Background}">

--- a/src/library/Uno.Material/Styles/Controls/ToggleButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/ToggleButton.xaml
@@ -133,7 +133,6 @@
 						<!-- Ripple effect -->
 						<controls:Ripple x:Name="ContentPresenter"
 										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
-										 RippleSizeMultiplier="0.85"
 										 BorderBrush="{TemplateBinding BorderBrush}"
 										 BorderThickness="{TemplateBinding BorderThickness}"
 										 Content="{TemplateBinding Content}"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Bugfix : Ripple speed is to slow and size is to small. 


## Description

- Removed `RippleSizeMultiplier` value from any style using a ripple
- Bumped the default DP value for `RippleSizeMultiplier` to 8.0 to match the behavior of material ripple for ALL controls, thus the ripple effect is unified accross components. 

**GIFS platform order : UWP - Android - iOS - WASM** 

### Buttons 
![MaterialButtonRipple](https://user-images.githubusercontent.com/15191066/88846483-acff8700-d1b3-11ea-874a-da3f18fbc0d1.gif)


### Cards 
![MaterialCardRipple](https://user-images.githubusercontent.com/15191066/88846499-b4269500-d1b3-11ea-9907-f3f047a960ec.gif)

### FloatingButton(FAB) 

![MaterialFabButton](https://user-images.githubusercontent.com/15191066/88846520-ba1c7600-d1b3-11ea-81b7-2d77f71fdcd7.gif)

### BottomNavigationBar  
![MaterialBottomNavigationBar](https://user-images.githubusercontent.com/15191066/88846527-bdaffd00-d1b3-11ea-8376-d3a48f5dc975.gif)

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
