### PR TITLE
fix(macos): add back arrow when navigation pane is exanded

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/NavigationView_PaneToggleButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/NavigationView_PaneToggleButton.xaml
@@ -253,10 +253,13 @@
 											  Fill="{Binding Foreground, RelativeSource={RelativeSource TemplatedParent}}"
 											  Stretch="Fill"
 											  UseLayoutRounding="False" />
-
+									<!--
+										macOS only works with a stretch Uniform and a height or width set
+									-->
 									<Path Data="{StaticResource BackArrowPathData}"
 										  Fill="{Binding Foreground, RelativeSource={RelativeSource TemplatedParent}}"
-										  Stretch="Fill"
+										  Stretch="Uniform"
+										  Height="16"
 										  UseLayoutRounding="False"
 										  ios:Visibility="Collapsed" />
 								</Grid>


### PR DESCRIPTION
﻿GitHub Issue: [#260]( https://github.com/unoplatform/Uno.Material/issues/260)

## PR Type

What kind of change does this PR introduce?
- Bugfix


## Description
When the navigation view was expanded on macOS, the back arrow button used to collapse it was not showing.


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [ ] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [x] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

It does not work on WASM and probably not on IOS but i could not test. There is another issue open for those #325
