### PR TITLE
fix(macOS): Border indicator animation

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/TextBox.xaml
@@ -1,6 +1,11 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:extensions="using:Uno.Material.Extensions">
+					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+					xmlns:not_macos="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:macos="http://uno.ui/macos"					
+					xmlns:extensions="using:Uno.Material.Extensions"
+					mc:Ignorable="d macos">
 
 	<ResourceDictionary.MergedDictionaries>
 		<ResourceDictionary Source="../Application/Colors.xaml" />
@@ -211,10 +216,11 @@
 								   VerticalAlignment="Bottom" />
 
 						<Rectangle x:Name="FocusedBorder"
-								   Fill="{StaticResource TextBoxOutlinedFocusStrokeColorBrush}"
-								   Height="{StaticResource TextBoxFocusStrokeWidth}"
-								   RenderTransformOrigin="0.5,0.5"
-								   VerticalAlignment="Bottom">
+									Fill="{StaticResource TextBoxOutlinedFocusStrokeColorBrush}"
+									Height="{StaticResource TextBoxFocusStrokeWidth}"
+									VerticalAlignment="Bottom"
+									not_macos:RenderTransformOrigin="0.5,0.5"
+									macos:RenderTransformOrigin="0.0,0.5">
 							<Rectangle.RenderTransform>
 								<ScaleTransform x:Name="FocusedBorder_ScaleTransform"
 												ScaleX="0" />
@@ -225,6 +231,7 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
+
 
 	<Style x:Key="MaterialOutlinedTextBoxStyle"
 		   TargetType="TextBox">


### PR DESCRIPTION
﻿GitHub Issue: #
closes: https://github.com/unoplatform/Uno.Material/issues/255

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description
Fixes the animation on TextBox when entering text.

<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [x] Tested Android
- [ ] Tested WASM
- [x] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information
This is a workaround. The root cause has not been found and will be addressed later.

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
