### PR TITLE
fix(macOS): TextBox text cut off

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/TextBox.xaml
@@ -3,7 +3,7 @@
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_macos="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:macos="http://uno.ui/macos"					
+					xmlns:macos="http://uno.ui/macos"
 					xmlns:extensions="using:Uno.Material.Extensions"
 					mc:Ignorable="d macos">
 
@@ -66,8 +66,13 @@
 				Value="Left" />
 		<Setter Property="VerticalContentAlignment"
 				Value="Center" />
-		<Setter Property="Padding"
-				Value="12,16" />
+
+		<macos:Setter Property="Padding"
+					  Value="12,4" />
+
+		<not_macos:Setter Property="Padding"
+						  Value="12,16" />
+
 		<Setter Property="MinHeight"
 				Value="50" />
 
@@ -164,9 +169,11 @@
 											  MaxHeight="34"
 											  MaxWidth="34"
 											  MinWidth="25"
-											  VerticalAlignment="Top"
+											  not_macos:VerticalAlignment="Top"
+											  macos:VerticalAlignment="Center"
 											  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource Material_NullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
+							
 							<ScrollViewer x:Name="ContentElement"
 										  Grid.Column="1"
 										  HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
@@ -175,7 +182,8 @@
 										  IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
 										  IsTabStop="False"
 										  IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
-										  VerticalAlignment="Bottom"
+										  macos:VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+										  not_macos:VerticalAlignment="Bottom"
 										  VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
 										  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
 										  ZoomMode="Disabled"
@@ -194,7 +202,8 @@
 									   Text="{TemplateBinding PlaceholderText}"
 									   TextAlignment="{TemplateBinding TextAlignment}"
 									   TextWrapping="{TemplateBinding TextWrapping}"
-									   VerticalAlignment="Top">
+									   not_macos:VerticalAlignment="Top"
+									   macos:VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
 								<TextBlock.RenderTransform>
 									<CompositeTransform x:Name="PlaceholderElement_CompositeTransform" />
 								</TextBlock.RenderTransform>
@@ -205,7 +214,8 @@
 									Foreground="{TemplateBinding BorderBrush}"
 									IsTabStop="False"
 									Style="{StaticResource DeleteButtonStyle}"
-									VerticalAlignment="Bottom"
+									not_macos:VerticalAlignment="Bottom"
+									macos:VerticalAlignment="Stretch"
 									Visibility="Collapsed"
 									AutomationProperties.AccessibilityView="Raw" />
 						</Grid>


### PR DESCRIPTION
﻿GitHub Issue: #


## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description
Update the styling so that the TextBox Text is not cut off on macOS.

<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [x] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [x] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
https://nventive.visualstudio.com/Uno%20Gallery/_workitems/edit/191238

<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
