### PR TITLE
fix(macOS): PasswordBox on focused animation

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/PasswordBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/PasswordBox.xaml
@@ -6,7 +6,9 @@
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:android="http://uno.ui/android"
 					xmlns:wasm="http://uno.ui/wasm"
-					mc:Ignorable="xamarin ios android wasm">
+					xmlns:not_macos="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:macos="http://uno.ui/macos"
+					mc:Ignorable="xamarin ios android wasm macos">
 
 	<ResourceDictionary.MergedDictionaries>
 		<ResourceDictionary Source="../Application/Colors.xaml" />
@@ -230,7 +232,8 @@
 								   VerticalAlignment="Bottom"
 								   Grid.ColumnSpan="3"
 								   Fill="{StaticResource TextBoxOutlinedFocusStrokeColorBrush}"
-								   RenderTransformOrigin="0.5,0.5">
+								   not_macos:RenderTransformOrigin="0.5,0.5"
+								   macos:RenderTransformOrigin="0.0,0.5">
 							<Rectangle.RenderTransform>
 								<ScaleTransform x:Name="Scale"
 												ScaleX="0" />


### PR DESCRIPTION
﻿GitHub Issue: #
https://github.com/unoplatform/Uno.Material/issues/255

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [x] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [x] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, the commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information
Fixed on the TextBox in a different PR but now reported the same issue on the PasswordBox.

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
