### PR TITLE
Fix back button on iOS (NavigationView)

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/NavigationView_PaneToggleButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/NavigationView_PaneToggleButton.xaml
@@ -18,7 +18,6 @@
 		<ResourceDictionary Source="../Application/Colors.xaml" />
 	</ResourceDictionary.MergedDictionaries>
 
-	<x:String x:Key="BackArrowIOSPathData">M24.2,0.5 L27.7,4 L7.5,24.2 L27.7,44.4 L24.2,47.9 L0.5,24.2 z</x:String>
 	<x:String x:Key="BackArrowPathData">M8,0 L9.4,1.4 L3.8,7 L16,7 L16,9 L3.8,9 L9.4,14.6 L8,16 L0,8 z</x:String>
 
 	<!-- PaneToggleButton Style-->
@@ -247,22 +246,11 @@
 
 								<Grid>
 									
-									<!--
-										work around for wasm: using not showing up
-									-->
-									<ios:Path Data="{StaticResource BackArrowIOSPathData}"
-											  Fill="{Binding Foreground, RelativeSource={RelativeSource TemplatedParent}}"
-											  Stretch="Fill"
-											  UseLayoutRounding="False" />
-									<!--
-										macOS only works with a stretch Uniform and a height or width set
-									-->
 									<Path Data="{StaticResource BackArrowPathData}"
 										  Fill="{Binding Foreground, RelativeSource={RelativeSource TemplatedParent}}"
 										  Stretch="Uniform"
 										  Height="20"
-										  UseLayoutRounding="False"
-										  ios:Visibility="Collapsed" />
+										  UseLayoutRounding="False" />
 								</Grid>
 							</Viewbox>
 						</Grid>


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description

The back button was not visible on iOS. There was some strange workaround for iOS which only seemed to break the back button's display.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] ~~Tested MacOS~~
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
