### PR TITLE
Keep the passwordbox outline when it's disabled

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/PasswordBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/PasswordBox.xaml
@@ -287,8 +287,6 @@
 												Value="0.5" />
 										<Setter Target="PlaceholderElement.Opacity"
 												Value="0.5" />
-										<Setter Target="Root.BorderThickness"
-												Value="0" />
 									</VisualState.Setters>
 								</VisualState>
 


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description

Keep the passwordbox outline when it's disabled, as illustrated here: https://lh3.googleusercontent.com/kXJgwc3Xv0zxP0cRFpz1-VeDsJShkOm8cQ6Xjz3gXAjCWAv2CUH7ho3cT7z0GeE-mtbJP5nNq0T1uzNXzbkOYdtbglHyLwDJ91zdpg=w1064-v0


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [ ] ~~Tested Android~~
- [x] Tested WASM
- [ ] ~~Tested MacOS~~
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
