### PR TITLE
normalize elevatedview shadowcolor property for cards and FAB

### DIFF
--- a/src/library/Uno.Material/Controls/Card.Properties.cs
+++ b/src/library/Uno.Material/Controls/Card.Properties.cs
@@ -9,6 +9,12 @@ namespace Uno.Material.Controls
 {
 	public partial class Card : Control
 	{
+#if __ANDROID__
+		private static readonly Color _defaultShadowColor = Colors.Black;
+#else
+		private static readonly Color _defaultShadowColor = Color.FromArgb(64, 0, 0, 0);
+#endif
+
 		#region HeaderContent and HeaderContentTemplate
 		public object HeaderContent
 		{
@@ -148,7 +154,7 @@ namespace Uno.Material.Controls
 		}
 
 		public static readonly DependencyProperty ShadowColorProperty =
-			DependencyProperty.Register("ShadowColor", typeof(Color), typeof(Card), new PropertyMetadata(Color.FromArgb(64, 0, 0, 0)));
+			DependencyProperty.Register("ShadowColor", typeof(Color), typeof(Card), new PropertyMetadata(_defaultShadowColor));
 		#endregion
 	}
 }

--- a/src/library/Uno.Material/Styles/Controls/Card.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Card.xaml
@@ -14,7 +14,6 @@
 	<Thickness x:Key="CardStrokeWidth">1</Thickness>
 	<x:Double x:Key="CardElevation">6</x:Double>
 	<Thickness x:Key="CardElevationMargin">6</Thickness>
-	<Color x:Key="CardElevationShadowColor">#60000000</Color>
 
 	<Style x:Key="MaterialOutlinedCardStyle"
 		   TargetType="controls:Card">
@@ -225,8 +224,6 @@
 				Value="{StaticResource CardElevationMargin}" />
 		<Setter Property="Elevation"
 				Value="{StaticResource CardElevation}" />
-		<Setter Property="ShadowColor"
-				Value="{StaticResource CardElevationShadowColor}" />
 
 		<Setter Property="Template">
 			<Setter.Value>
@@ -608,8 +605,6 @@
 				Value="{StaticResource CardElevationMargin}" />
 		<Setter Property="Elevation"
 				Value="{StaticResource CardElevation}" />
-		<Setter Property="ShadowColor"
-				Value="{StaticResource CardElevationShadowColor}" />
 
 		<Setter Property="Template">
 			<Setter.Value>
@@ -1010,8 +1005,6 @@
 				Value="{StaticResource CardElevationMargin}" />
 		<Setter Property="Elevation"
 				Value="{StaticResource CardElevation}" />
-		<Setter Property="ShadowColor"
-				Value="{StaticResource CardElevationShadowColor}" />
 
 		<Setter Property="Template">
 			<Setter.Value>

--- a/src/library/Uno.Material/Styles/Controls/FloatingActionButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/FloatingActionButton.xaml
@@ -90,7 +90,6 @@
 						<toolkit:ElevatedView x:Name="ElevatedView"
 											  Margin="0,0,6,6"
 											  Elevation="6"
-											  ShadowColor="Black"
 											  CornerRadius="{TemplateBinding CornerRadius}"
 											  Background="Transparent">
 


### PR DESCRIPTION
﻿GitHub Issue: #94 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

I've normalize the shadow color we use for the material styles (Card and FAB) for every platoform

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] ~~Tested MacOS~~
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
