### PR TITLE
fix(ripple):  Make the Ripple working properly on Button

### DIFF
--- a/src/library/Uno.Material/Controls/BottomNavigationBarItem.cs
+++ b/src/library/Uno.Material/Controls/BottomNavigationBarItem.cs
@@ -52,27 +52,5 @@ namespace Uno.Material.Controls
 		{
 			DefaultStyleKey = typeof(BottomNavigationBarItem);
 		}
-
-		private Ripple _ripple;
-
-		/// <inheritdoc />
-		protected override void OnApplyTemplate()
-		{
-			_ripple = GetTemplateChild("ContentPresenter") as Ripple;
-			if (_ripple != null)
-			{
-				_ripple.IsAutoRippleEnabled = false;
-			}
-
-			base.OnApplyTemplate();
-		}
-
-		/// <inheritdoc />
-		protected override void OnPointerPressed(PointerRoutedEventArgs args)
-		{
-			_ripple?.StartRippling(args);
-
-			base.OnPointerPressed(args);
-		}
 	}
 }


### PR DESCRIPTION
## Bugfix
The "ripple effect" works only once on `Button` on WASM

## Description
We now directly subscribe to the `PointerPressed` (including handled events) on the templated parent, so we make sure to receive all meaning full pointer pressed

## PR Checklist 
- [x] Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
