### PR TITLE
fix: removing space at the bottom of the navigation view

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/NavigationView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/NavigationView.xaml
@@ -355,7 +355,6 @@
 											<RowDefinition Height="*" />
 											<RowDefinition Height="Auto" />
 											<RowDefinition Height="Auto" />
-											<RowDefinition Height="8" />
 										</Grid.RowDefinitions>
 
 										<Grid x:Name="ContentPaneTopPadding"
@@ -401,7 +400,6 @@
 										<!-- Left nav list -->
 										<NavigationViewList x:Name="MenuItemsHost"
 															Grid.Row="7"
-															Margin="0,0,0,20"
 															SelectionMode="Single"
 															IsItemClickEnabled="True"
 															HorizontalAlignment="Stretch"
@@ -814,7 +812,6 @@
 											<RowDefinition Height="*" />
 											<RowDefinition Height="Auto" />
 											<RowDefinition Height="Auto" />
-											<RowDefinition Height="8" />
 										</Grid.RowDefinitions>
 
 										<Grid x:Name="ContentPaneTopPadding"
@@ -860,7 +857,6 @@
 										<!-- Left nav list -->
 										<NavigationViewList x:Name="MenuItemsHost"
 															Grid.Row="7"
-															Margin="0,0,0,20"
 															SelectionMode="Single"
 															IsItemClickEnabled="True"
 															HorizontalAlignment="Stretch"


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->
Removing space at the bottom of the navigation view.
This PR fixes for UWP, Android and Wasm but not iOS

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [ ] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://dev.azure.com/nventive/Uno%20Gallery/_workitems/edit/191277