### PR TITLE
fix: Add workaround to get Lottie animation files working for UWP

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/ProgressRing.xaml
+++ b/src/library/Uno.Material/Styles/Controls/ProgressRing.xaml
@@ -1,40 +1,45 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:winui="using:Microsoft.UI.Xaml.Controls"
-					xmlns:lottie="using:Microsoft.Toolkit.Uwp.UI.Lottie"
-					mc:Ignorable="d">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                    xmlns:lottie="using:Microsoft.Toolkit.Uwp.UI.Lottie"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:not_win="http://uno.ui/not_win"
+                    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:winui="using:Microsoft.UI.Xaml.Controls"
+                    mc:Ignorable="d not_win">
 
 	<ResourceDictionary.MergedDictionaries>
 		<ResourceDictionary Source="../Application/Colors.xaml" />
+		<win:ResourceDictionary>
+			<lottie:LottieVisualSource x:Key="MaterialDeterminateAnimation"
+	                           UriSource="ms-appx:///Assets/MaterialDeterminate.json"  />
+			<lottie:LottieVisualSource x:Key="MaterialIndeterminateAnimation"
+	                           UriSource="ms-appx:///Assets/MaterialIndeterminate.json" />
+		</win:ResourceDictionary>
+		<not_win:ResourceDictionary>
+			<lottie:LottieVisualSource x:Key="MaterialDeterminateAnimation"
+	                           UriSource="ms-appx:///MaterialDeterminate.json"  />
+			<lottie:LottieVisualSource x:Key="MaterialIndeterminateAnimation"
+	                           UriSource="ms-appx:///MaterialIndeterminate.json" />
+		</not_win:ResourceDictionary>
 	</ResourceDictionary.MergedDictionaries>
 
-	<lottie:LottieVisualSource UriSource="embedded://Uno.Material/Uno.Material.Assets.MaterialDeterminate.json" x:Key="MaterialDeterminateAnimation"/>
-	<lottie:LottieVisualSource UriSource="embedded://Uno.Material/Uno.Material.Assets.MaterialIndeterminate.json" x:Key="MaterialIndeterminateAnimation"/>
+	
 
 	<Style x:Key="MaterialProgressRingStyle"
-		   TargetType="winui:ProgressRing">
-		<Setter Property="DeterminateSource"
-				Value="{StaticResource MaterialDeterminateAnimation}" />
-		<Setter Property="IndeterminateSource"
-				Value="{StaticResource MaterialIndeterminateAnimation}" />
-		<Setter Property="Foreground"
-				Value="{StaticResource MaterialPrimaryBrush}" />
-		<Setter Property="Background"
-				Value="{StaticResource MaterialPrimaryLowBrush}" />
+	       TargetType="winui:ProgressRing">
+		<Setter Property="DeterminateSource" Value="{StaticResource MaterialDeterminateAnimation}" />
+		<Setter Property="IndeterminateSource" Value="{StaticResource MaterialIndeterminateAnimation}" />
+		<Setter Property="Foreground" Value="{StaticResource MaterialPrimaryBrush}" />
+		<Setter Property="Background" Value="{StaticResource MaterialPrimaryLowBrush}" />
 	</Style>
 
 	<Style x:Key="MaterialSecondaryProgressRingStyle"
-		   TargetType="winui:ProgressRing">
-		<Setter Property="DeterminateSource"
-				Value="{StaticResource MaterialDeterminateAnimation}" />
-		<Setter Property="IndeterminateSource"
-				Value="{StaticResource MaterialIndeterminateAnimation}" />
-		<Setter Property="Foreground"
-				Value="{StaticResource MaterialSecondaryBrush}" />
-		<Setter Property="Background"
-				Value="{StaticResource MaterialSecondaryLowBrush}" />
+	       TargetType="winui:ProgressRing">
+		<Setter Property="DeterminateSource" Value="{StaticResource MaterialDeterminateAnimation}" />
+		<Setter Property="IndeterminateSource" Value="{StaticResource MaterialIndeterminateAnimation}" />
+		<Setter Property="Foreground" Value="{StaticResource MaterialSecondaryBrush}" />
+		<Setter Property="Background" Value="{StaticResource MaterialSecondaryLowBrush}" />
 	</Style>
 
 </ResourceDictionary>

--- a/src/library/Uno.Material/Uno.Material.csproj
+++ b/src/library/Uno.Material/Uno.Material.csproj
@@ -28,8 +28,12 @@
 		<Compile Update="**\*.xaml.cs">
 			<DependentUpon>%(Filename)</DependentUpon>
 		</Compile>
-		<EmbeddedResource Include="Assets\MaterialDeterminate.json" />
-		<EmbeddedResource Include="Assets\MaterialIndeterminate.json" />
+		<Content Include="Assets\MaterialDeterminate.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="Assets\MaterialIndeterminate.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
 		<Content Include="build\Uno.Material.targets" Pack="true" PackagePath="build" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
closes #480

## PR Type

What kind of change does this PR introduce?
- Bugfix

Asset was not loading for UWP while using an Embedded Resource

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
