### PR TITLE
fix(ProgressRing): Fix missing Lottie assets for UWP

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/ProgressRing.xaml
+++ b/src/library/Uno.Material/Styles/Controls/ProgressRing.xaml
@@ -12,9 +12,9 @@
 		<ResourceDictionary Source="../Application/Colors.xaml" />
 		<win:ResourceDictionary>
 			<lottie:LottieVisualSource x:Key="MaterialDeterminateAnimation"
-	                           UriSource="ms-appx:///Assets/MaterialDeterminate.json"  />
+	                           UriSource="ms-appx:///Uno.Material/Assets/MaterialDeterminate.json"  />
 			<lottie:LottieVisualSource x:Key="MaterialIndeterminateAnimation"
-	                           UriSource="ms-appx:///Assets/MaterialIndeterminate.json" />
+	                           UriSource="ms-appx:///Uno.Material/Assets/MaterialIndeterminate.json" />
 		</win:ResourceDictionary>
 		<not_win:ResourceDictionary>
 			<lottie:LottieVisualSource x:Key="MaterialDeterminateAnimation"

--- a/src/library/Uno.Material/Uno.Material.csproj
+++ b/src/library/Uno.Material/Uno.Material.csproj
@@ -28,12 +28,8 @@
 		<Compile Update="**\*.xaml.cs">
 			<DependentUpon>%(Filename)</DependentUpon>
 		</Compile>
-		<Content Include="Assets\MaterialDeterminate.json">
-		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="Assets\MaterialIndeterminate.json">
-		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
+		<Content Include="Assets\MaterialDeterminate.json"/>
+		<Content Include="Assets\MaterialIndeterminate.json"/>
 		<Content Include="build\Uno.Material.targets" Pack="true" PackagePath="build" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
﻿GitHub Issue: https://github.com/unoplatform/Uno.Gallery/issues/174

## PR Type

What kind of change does this PR introduce?
- Bugfix


## Description

Fix the way we access the Lottie animation json filed for ProgressRing for UWP

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
