### PR TITLE
refactor: Use default content templates in Material Card styles

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/Card.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Card.xaml
@@ -5,14 +5,83 @@
 					xmlns:controls="using:Uno.Material.Controls"
 					xmlns:toolkit="using:Uno.UI.Toolkit">
 
-	<!-- Card Variables -->
+	<!--  Card Variables  -->
 	<CornerRadius x:Key="MaterialCardCornerRadius">4</CornerRadius>
 	<Thickness x:Key="MaterialCardBorderThickness">1</Thickness>
 	<x:Double x:Key="MaterialCardElevation">6</x:Double>
 	<Thickness x:Key="MaterialCardElevationMargin">6</Thickness>
 
-	<Style x:Key="MaterialOutlinedCardStyle"
+	<DataTemplate x:Key="DefaultHeaderContentTemplate">
+		<TextBlock Text="{Binding}"
+				   MaxLines="1"
+				   Margin="16,14,16,0"
+				   Style="{ThemeResource MaterialHeadline6}" />
+	</DataTemplate>
+
+	<DataTemplate x:Key="DefaultSubHeaderContentTemplate">
+		<TextBlock Text="{Binding}"
+				   MaxLines="2"
+				   Margin="16,0,16,14"
+				   Style="{ThemeResource MaterialBody2}" />
+	</DataTemplate>
+
+	<DataTemplate x:Key="DefaultSupportingContentTemplate">
+		<TextBlock Text="{Binding}"
+				   Margin="16,0,16,14"
+				   Style="{ThemeResource MaterialBody2}" />
+	</DataTemplate>
+
+	<DataTemplate x:Key="DefaultAvatarSupportingContentTemplate">
+		<TextBlock Text="{Binding}"
+				   Margin="16,12,16,14"
+				   Style="{ThemeResource MaterialBody2}" />
+	</DataTemplate>
+
+	<DataTemplate x:Key="DefaultSmallMediaSupportingContentTemplate">
+		<Border BorderThickness="0,1,0,0"
+				BorderBrush="{StaticResource MaterialOnSurfaceFocusedBrush}">
+			<TextBlock Text="{Binding}"
+					   Margin="16,12,16,14"
+					   Style="{ThemeResource MaterialBody2}" />
+		</Border>
+	</DataTemplate>
+
+	<DataTemplate x:Key="DefaultMediaContentTemplate">
+		<Image Source="{Binding}"
+			   Stretch="Uniform"
+			   MaxHeight="194" />
+	</DataTemplate>
+
+	<DataTemplate x:Key="DefaultSmallMediaContentTemplate">
+		<Image Source="{Binding}"
+			   Stretch="Uniform"
+			   MaxHeight="94"
+			   VerticalAlignment="Top" />
+	</DataTemplate>
+
+	<DataTemplate x:Key="DefaultAvatarContentTemplate">
+		<Image Source="{Binding}"
+			   Stretch="Uniform"
+			   MaxHeight="40" />
+	</DataTemplate>
+
+
+
+	<Style x:Key="MaterialBaseCardStyle"
 		   TargetType="controls:Card">
+		<Setter Property="HeaderContentTemplate"
+				Value="{StaticResource DefaultHeaderContentTemplate}" />
+		<Setter Property="SubHeaderContentTemplate"
+				Value="{StaticResource DefaultSubHeaderContentTemplate}" />
+		<Setter Property="SupportingContentTemplate"
+				Value="{StaticResource DefaultSupportingContentTemplate}" />
+		<Setter Property="MediaContentTemplate"
+				Value="{StaticResource DefaultMediaContentTemplate}" />
+	</Style>
+
+	<Style x:Key="MaterialOutlinedCardStyle"
+		   TargetType="controls:Card"
+		   BasedOn="{StaticResource MaterialBaseCardStyle}">
 
 		<Setter Property="MinHeight"
 				Value="72" />
@@ -38,6 +107,7 @@
 				Value="Stretch" />
 		<Setter Property="VerticalContentAlignment"
 				Value="Stretch" />
+
 
 		<Setter Property="Template">
 			<Setter.Value>
@@ -135,19 +205,19 @@
 							<RowDefinition Height="Auto" />
 						</Grid.RowDefinitions>
 
-						<!-- Border for PointerOver State-->
+						<!--  Border for PointerOver State  -->
 						<Border Grid.RowSpan="4"
 								x:Name="HoverOverlay"
 								Background="{StaticResource MaterialOnSurfaceHoverBrush}"
 								Opacity="0" />
 
-						<!-- Border for Focused State-->
+						<!--  Border for Focused State  -->
 						<Border Grid.RowSpan="4"
 								x:Name="FocusedOverlay"
 								Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
 								Opacity="0" />
 
-						<!-- Media content part -->
+						<!--  Media content part  -->
 						<ContentPresenter x:Name="MediaContentPresenter"
 										  Content="{TemplateBinding MediaContent}"
 										  ContentTemplate="{TemplateBinding MediaContentTemplate}"
@@ -157,7 +227,7 @@
 										  IsHitTestVisible="False"
 										  Visibility="{Binding MediaContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-						<!-- Header part-->
+						<!--  Header part  -->
 						<ContentPresenter Grid.Row="1"
 										  x:Name="HeaderContentPresenter"
 										  Content="{TemplateBinding HeaderContent}"
@@ -167,7 +237,7 @@
 										  AutomationProperties.AccessibilityView="Raw"
 										  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-						<!-- SubHeader part-->
+						<!--  SubHeader part  -->
 						<ContentPresenter Grid.Row="2"
 										  x:Name="SubHeaderContentPresenter"
 										  Content="{TemplateBinding SubHeaderContent}"
@@ -177,7 +247,7 @@
 										  AutomationProperties.AccessibilityView="Raw"
 										  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-						<!-- Ripple effect -->
+						<!--  Ripple effect  -->
 						<controls:Ripple Grid.RowSpan="4"
 										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
 										 BorderBrush="{TemplateBinding BorderBrush}"
@@ -186,7 +256,7 @@
 										 Padding="{TemplateBinding Padding}"
 										 AutomationProperties.AccessibilityView="Raw" />
 
-						<!-- Supporting Content part-->
+						<!--  Supporting Content part  -->
 						<ContentPresenter Grid.Row="3"
 										  x:Name="SupportingContentPresenter"
 										  Content="{TemplateBinding SupportingContent}"
@@ -196,7 +266,7 @@
 										  AutomationProperties.AccessibilityView="Raw"
 										  Visibility="{Binding SupportingContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-						<!-- Icons section part -->
+						<!--  Icons section part  -->
 						<ContentPresenter Grid.Row="3"
 										  x:Name="IconsContentPresenter"
 										  Content="{TemplateBinding IconsContent}"
@@ -212,6 +282,7 @@
 	</Style>
 
 	<Style x:Key="MaterialElevatedCardStyle"
+		   BasedOn="{StaticResource MaterialBaseCardStyle}"
 		   TargetType="controls:Card">
 
 		<Setter Property="MinHeight"
@@ -240,7 +311,7 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="controls:Card">
-					<!-- Elevated View -->
+					<!--  Elevated View  -->
 					<toolkit:ElevatedView x:Name="ElevatedRoot"
 										  MinWidth="{TemplateBinding MinWidth}"
 										  MinHeight="{TemplateBinding MinHeight}"
@@ -335,19 +406,19 @@
 								<RowDefinition Height="Auto" />
 							</Grid.RowDefinitions>
 
-							<!-- Border for PointerOver State-->
+							<!--  Border for PointerOver State  -->
 							<Border Grid.RowSpan="4"
 									x:Name="HoverOverlay"
 									Background="{StaticResource MaterialOnSurfaceHoverBrush}"
 									Opacity="0" />
 
-							<!-- Border for Focused State-->
+							<!--  Border for Focused State  -->
 							<Border Grid.RowSpan="4"
 									x:Name="FocusedOverlay"
 									Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
 									Opacity="0" />
 
-							<!-- Media content part -->
+							<!--  Media content part  -->
 							<ContentPresenter x:Name="MediaContentPresenter"
 											  Content="{TemplateBinding MediaContent}"
 											  ContentTemplate="{TemplateBinding MediaContentTemplate}"
@@ -357,7 +428,7 @@
 											  IsHitTestVisible="False"
 											  Visibility="{Binding MediaContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-							<!-- Header part-->
+							<!--  Header part  -->
 							<ContentPresenter Grid.Row="1"
 											  x:Name="HeaderContentPresenter"
 											  Content="{TemplateBinding HeaderContent}"
@@ -367,7 +438,7 @@
 											  AutomationProperties.AccessibilityView="Raw"
 											  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-							<!-- SubHeader part-->
+							<!--  SubHeader part  -->
 							<ContentPresenter Grid.Row="2"
 											  x:Name="SubHeaderContentPresenter"
 											  Content="{TemplateBinding SubHeaderContent}"
@@ -377,14 +448,14 @@
 											  AutomationProperties.AccessibilityView="Raw"
 											  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-							<!-- Ripple effect -->
+							<!--  Ripple effect  -->
 							<controls:Ripple Grid.RowSpan="4"
 											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
 											 CornerRadius="{StaticResource MaterialCardCornerRadius}"
 											 Padding="{TemplateBinding Padding}"
 											 AutomationProperties.AccessibilityView="Raw" />
 
-							<!-- Supporting Content part-->
+							<!--  Supporting Content part  -->
 							<ContentPresenter Grid.Row="3"
 											  x:Name="SupportingContentPresenter"
 											  Content="{TemplateBinding SupportingContent}"
@@ -394,7 +465,7 @@
 											  AutomationProperties.AccessibilityView="Raw"
 											  Visibility="{Binding SupportingContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-							<!-- Icons section part -->
+							<!--  Icons section part  -->
 							<ContentPresenter Grid.Row="3"
 											  x:Name="IconsContentPresenter"
 											  Content="{TemplateBinding IconsContent}"
@@ -411,6 +482,7 @@
 	</Style>
 
 	<Style x:Key="MaterialAvatarOutlinedCardStyle"
+		   BasedOn="{StaticResource MaterialBaseCardStyle}"
 		   TargetType="controls:Card">
 		<Setter Property="MinHeight"
 				Value="72" />
@@ -432,6 +504,10 @@
 				Value="Stretch" />
 		<Setter Property="HorizontalContentAlignment"
 				Value="Stretch" />
+		<Setter Property="SupportingContentTemplate"
+				Value="{StaticResource DefaultAvatarSupportingContentTemplate}" />
+		<Setter Property="AvatarContentTemplate"
+				Value="{StaticResource DefaultAvatarContentTemplate}" />
 
 		<Setter Property="Template">
 			<Setter.Value>
@@ -531,21 +607,21 @@
 							<ColumnDefinition Width="Auto" />
 						</Grid.ColumnDefinitions>
 
-						<!-- Border for PointedOver state -->
+						<!--  Border for PointedOver state  -->
 						<Border Grid.RowSpan="3"
 								Grid.ColumnSpan="3"
 								x:Name="HoverOverlay"
 								Background="{StaticResource MaterialOnSurfaceHoverBrush}"
 								Opacity="0" />
 
-						<!-- Border for Focus state -->
+						<!--  Border for Focus state  -->
 						<Border Grid.RowSpan="3"
 								Grid.ColumnSpan="3"
 								x:Name="FocusedOverlay"
 								Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
 								Opacity="0" />
 
-						<!-- Avatart part -->
+						<!--  Avatart part  -->
 						<ContentPresenter x:Name="AvatarContentPresenter"
 										  Content="{TemplateBinding AvatarContent}"
 										  ContentTemplate="{TemplateBinding AvatarContentTemplate}"
@@ -558,7 +634,7 @@
 
 						<StackPanel Grid.Column="1"
 									IsHitTestVisible="False">
-							<!-- Header part-->
+							<!--  Header part  -->
 							<ContentPresenter x:Name="HeaderContentPresenter"
 											  Content="{TemplateBinding HeaderContent}"
 											  ContentTemplate="{TemplateBinding HeaderContentTemplate}"
@@ -567,7 +643,7 @@
 											  AutomationProperties.AccessibilityView="Raw"
 											  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-							<!-- SubHeader part-->
+							<!--  SubHeader part  -->
 							<ContentPresenter x:Name="SubHeaderContentPresenter"
 											  Content="{TemplateBinding SubHeaderContent}"
 											  ContentTemplate="{TemplateBinding SubHeaderContentTemplate}"
@@ -577,7 +653,7 @@
 											  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 						</StackPanel>
 
-						<!-- Ripple effect -->
+						<!--  Ripple effect  -->
 						<controls:Ripple Grid.RowSpan="3"
 										 Grid.ColumnSpan="3"
 										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
@@ -587,7 +663,7 @@
 										 Padding="{TemplateBinding Padding}"
 										 AutomationProperties.AccessibilityView="Raw" />
 
-						<!-- Icons section part -->
+						<!--  Icons section part  -->
 						<ContentPresenter Grid.Column="2"
 										  x:Name="IconsContentPresenter"
 										  Content="{TemplateBinding IconsContent}"
@@ -597,7 +673,7 @@
 										  AutomationProperties.AccessibilityView="Raw"
 										  Visibility="{Binding IconsContentTemplate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-						<!-- Media content part -->
+						<!--  Media content part  -->
 						<ContentPresenter Grid.Row="1"
 										  Grid.ColumnSpan="3"
 										  x:Name="MediaContentPresenter"
@@ -609,7 +685,7 @@
 										  IsHitTestVisible="False"
 										  Visibility="{Binding MediaContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-						<!-- Supporting Content part-->
+						<!--  Supporting Content part  -->
 						<ContentPresenter Grid.Row="2"
 										  Grid.ColumnSpan="3"
 										  x:Name="SupportingContentPresenter"
@@ -626,6 +702,7 @@
 	</Style>
 
 	<Style x:Key="MaterialAvatarElevatedCardStyle"
+		   BasedOn="{StaticResource MaterialBaseCardStyle}"
 		   TargetType="controls:Card">
 		<Setter Property="MinHeight"
 				Value="72" />
@@ -645,11 +722,15 @@
 				Value="{StaticResource MaterialCardElevationMargin}" />
 		<Setter Property="Elevation"
 				Value="{StaticResource MaterialCardElevation}" />
+		<Setter Property="SupportingContentTemplate"
+				Value="{StaticResource DefaultAvatarSupportingContentTemplate}" />
+		<Setter Property="AvatarContentTemplate"
+				Value="{StaticResource DefaultAvatarContentTemplate}" />
 
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="controls:Card">
-					<!-- Elevated View -->
+					<!--  Elevated View  -->
 					<toolkit:ElevatedView x:Name="ElevatedRoot"
 										  MinWidth="{TemplateBinding MinWidth}"
 										  MinHeight="{TemplateBinding MinHeight}"
@@ -749,21 +830,21 @@
 								<ColumnDefinition Width="Auto" />
 							</Grid.ColumnDefinitions>
 
-							<!-- Border for PointedOver state -->
+							<!--  Border for PointedOver state  -->
 							<Border Grid.RowSpan="3"
 									Grid.ColumnSpan="3"
 									x:Name="HoverOverlay"
 									Background="{StaticResource MaterialOnSurfaceHoverBrush}"
 									Opacity="0" />
 
-							<!-- Border for Focus state -->
+							<!--  Border for Focus state  -->
 							<Border Grid.RowSpan="3"
 									Grid.ColumnSpan="3"
 									x:Name="FocusedOverlay"
 									Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
 									Opacity="0" />
 
-							<!-- Avatart part -->
+							<!--  Avatart part  -->
 							<ContentPresenter x:Name="AvatarContentPresenter"
 											  Content="{TemplateBinding AvatarContent}"
 											  ContentTemplate="{TemplateBinding AvatarContentTemplate}"
@@ -776,7 +857,7 @@
 
 							<StackPanel Grid.Column="1"
 										IsHitTestVisible="False">
-								<!-- Header part-->
+								<!--  Header part  -->
 								<ContentPresenter x:Name="HeaderContentPresenter"
 												  Content="{TemplateBinding HeaderContent}"
 												  ContentTemplate="{TemplateBinding HeaderContentTemplate}"
@@ -785,7 +866,7 @@
 												  AutomationProperties.AccessibilityView="Raw"
 												  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-								<!-- SubHeader part-->
+								<!--  SubHeader part  -->
 								<ContentPresenter x:Name="SubHeaderContentPresenter"
 												  Content="{TemplateBinding SubHeaderContent}"
 												  ContentTemplate="{TemplateBinding SubHeaderContentTemplate}"
@@ -794,7 +875,7 @@
 												  AutomationProperties.AccessibilityView="Raw"
 												  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 							</StackPanel>
-							<!-- Ripple effect -->
+							<!--  Ripple effect  -->
 							<controls:Ripple Grid.RowSpan="3"
 											 Grid.ColumnSpan="3"
 											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
@@ -802,7 +883,7 @@
 											 Padding="{TemplateBinding Padding}"
 											 AutomationProperties.AccessibilityView="Raw" />
 
-							<!-- Icons section part -->
+							<!--  Icons section part  -->
 							<ContentPresenter Grid.Column="2"
 											  x:Name="IconsContentPresenter"
 											  Content="{TemplateBinding IconsContent}"
@@ -812,7 +893,7 @@
 											  AutomationProperties.AccessibilityView="Raw"
 											  Visibility="{Binding IconsContentTemplate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}}" />
 
-							<!-- Media content part -->
+							<!--  Media content part  -->
 							<ContentPresenter Grid.Row="1"
 											  Grid.ColumnSpan="3"
 											  x:Name="MediaContentPresenter"
@@ -824,7 +905,7 @@
 											  IsHitTestVisible="False"
 											  Visibility="{Binding MediaContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-							<!-- Supporting Content part-->
+							<!--  Supporting Content part  -->
 							<ContentPresenter Grid.Row="2"
 											  Grid.ColumnSpan="3"
 											  x:Name="SupportingContentPresenter"
@@ -842,6 +923,7 @@
 	</Style>
 
 	<Style x:Key="MaterialSmallMediaOutlinedCardStyle"
+		   BasedOn="{StaticResource MaterialBaseCardStyle}"
 		   TargetType="controls:Card">
 
 		<Setter Property="MinHeight"
@@ -868,6 +950,10 @@
 				Value="Stretch" />
 		<Setter Property="VerticalContentAlignment"
 				Value="Stretch" />
+		<Setter Property="MediaContentTemplate"
+				Value="{StaticResource DefaultSmallMediaContentTemplate}" />
+		<Setter Property="SupportingContentTemplate"
+				Value="{StaticResource DefaultSmallMediaSupportingContentTemplate}" />
 
 		<Setter Property="Template">
 			<Setter.Value>
@@ -967,21 +1053,21 @@
 							<ColumnDefinition Width="Auto" />
 						</Grid.ColumnDefinitions>
 
-						<!-- Border for PointerOver State-->
+						<!--  Border for PointerOver State  -->
 						<Border Grid.RowSpan="3"
 								Grid.ColumnSpan="3"
 								x:Name="HoverOverlay"
 								Background="{StaticResource MaterialOnSurfaceHoverBrush}"
 								Opacity="0" />
 
-						<!-- Border for Focused State-->
+						<!--  Border for Focused State  -->
 						<Border Grid.RowSpan="3"
 								Grid.ColumnSpan="3"
 								x:Name="FocusedOverlay"
 								Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
 								Opacity="0" />
 
-						<!-- Media content part -->
+						<!--  Media content part  -->
 						<ContentPresenter x:Name="MediaContentPresenter"
 										  Content="{TemplateBinding MediaContent}"
 										  ContentTemplate="{TemplateBinding MediaContentTemplate}"
@@ -992,7 +1078,7 @@
 										  Visibility="{Binding MediaContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
 						<StackPanel Grid.Column="1">
-							<!-- Header part-->
+							<!--  Header part  -->
 							<ContentPresenter x:Name="HeaderContentPresenter"
 											  Content="{TemplateBinding HeaderContent}"
 											  ContentTemplate="{TemplateBinding HeaderContentTemplate}"
@@ -1001,7 +1087,7 @@
 											  AutomationProperties.AccessibilityView="Raw"
 											  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-							<!-- SubHeader part-->
+							<!--  SubHeader part  -->
 							<ContentPresenter x:Name="SubHeaderContentPresenter"
 											  Content="{TemplateBinding SubHeaderContent}"
 											  ContentTemplate="{TemplateBinding SubHeaderContentTemplate}"
@@ -1011,7 +1097,7 @@
 											  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 						</StackPanel>
 
-						<!-- Ripple effect -->
+						<!--  Ripple effect  -->
 						<controls:Ripple Grid.RowSpan="3"
 										 Grid.ColumnSpan="3"
 										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
@@ -1021,7 +1107,7 @@
 										 Padding="{TemplateBinding Padding}"
 										 AutomationProperties.AccessibilityView="Raw" />
 
-						<!-- Supporting Content part-->
+						<!--  Supporting Content part  -->
 						<ContentPresenter Grid.Row="1"
 										  Grid.ColumnSpan="3"
 										  x:Name="SupportingContentPresenter"
@@ -1032,7 +1118,7 @@
 										  AutomationProperties.AccessibilityView="Raw"
 										  Visibility="{Binding SupportingContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-						<!-- Icons section part -->
+						<!--  Icons section part  -->
 						<ContentPresenter Grid.Row="2"
 										  Grid.ColumnSpan="3"
 										  x:Name="IconsContentPresenter"
@@ -1049,6 +1135,7 @@
 	</Style>
 
 	<Style x:Key="MaterialSmallMediaElevatedCardStyle"
+		   BasedOn="{StaticResource MaterialBaseCardStyle}"
 		   TargetType="controls:Card">
 
 		<Setter Property="MinHeight"
@@ -1073,11 +1160,15 @@
 				Value="{StaticResource MaterialCardElevationMargin}" />
 		<Setter Property="Elevation"
 				Value="{StaticResource MaterialCardElevation}" />
+		<Setter Property="MediaContentTemplate"
+				Value="{StaticResource DefaultSmallMediaContentTemplate}" />
+		<Setter Property="SupportingContentTemplate"
+				Value="{StaticResource DefaultSmallMediaSupportingContentTemplate}" />
 
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="controls:Card">
-					<!-- Elevated View -->
+					<!--  Elevated View  -->
 					<toolkit:ElevatedView x:Name="ElevatedRoot"
 										  MinWidth="{TemplateBinding MinWidth}"
 										  MinHeight="{TemplateBinding MinHeight}"
@@ -1177,21 +1268,21 @@
 								<ColumnDefinition Width="Auto" />
 							</Grid.ColumnDefinitions>
 
-							<!-- Border for PointerOver State-->
+							<!--  Border for PointerOver State  -->
 							<Border Grid.RowSpan="3"
 									Grid.ColumnSpan="3"
 									x:Name="HoverOverlay"
 									Background="{StaticResource MaterialOnSurfaceHoverBrush}"
 									Opacity="0" />
 
-							<!-- Border for Focused State-->
+							<!--  Border for Focused State  -->
 							<Border Grid.RowSpan="3"
 									Grid.ColumnSpan="3"
 									x:Name="FocusedOverlay"
 									Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
 									Opacity="0" />
 
-							<!-- Media content part -->
+							<!--  Media content part  -->
 							<ContentPresenter x:Name="MediaContentPresenter"
 											  Content="{TemplateBinding MediaContent}"
 											  ContentTemplate="{TemplateBinding MediaContentTemplate}"
@@ -1202,7 +1293,7 @@
 											  Visibility="{Binding MediaContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
 							<StackPanel Grid.Column="1">
-								<!-- Header part-->
+								<!--  Header part  -->
 								<ContentPresenter x:Name="HeaderContentPresenter"
 												  Content="{TemplateBinding HeaderContent}"
 												  ContentTemplate="{TemplateBinding HeaderContentTemplate}"
@@ -1211,7 +1302,7 @@
 												  AutomationProperties.AccessibilityView="Raw"
 												  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-								<!-- SubHeader part-->
+								<!--  SubHeader part  -->
 								<ContentPresenter x:Name="SubHeaderContentPresenter"
 												  Content="{TemplateBinding SubHeaderContent}"
 												  ContentTemplate="{TemplateBinding SubHeaderContentTemplate}"
@@ -1221,7 +1312,7 @@
 												  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 							</StackPanel>
 
-							<!-- Ripple effect -->
+							<!--  Ripple effect  -->
 							<controls:Ripple Grid.RowSpan="3"
 											 Grid.ColumnSpan="3"
 											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
@@ -1229,7 +1320,7 @@
 											 Padding="{TemplateBinding Padding}"
 											 AutomationProperties.AccessibilityView="Raw" />
 
-							<!-- Supporting Content part-->
+							<!--  Supporting Content part  -->
 							<ContentPresenter Grid.Row="1"
 											  Grid.ColumnSpan="3"
 											  x:Name="SupportingContentPresenter"
@@ -1240,7 +1331,7 @@
 											  AutomationProperties.AccessibilityView="Raw"
 											  Visibility="{Binding SupportingContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
 
-							<!-- Icons section part -->
+							<!--  Icons section part  -->
 							<ContentPresenter Grid.Row="2"
 											  Grid.ColumnSpan="3"
 											  x:Name="IconsContentPresenter"

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/CardSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/CardSamplePage.xaml
@@ -13,7 +13,7 @@
 	  mc:Ignorable="d android ios">
 
 	<Page.Resources>
-		<!-- Sample Button Styles -->
+		<!--  Sample Button Styles  -->
 		<Style x:Key="IconsSampleButtonStyle"
 			   BasedOn="{StaticResource MaterialTextButtonStyle}"
 			   TargetType="Button">
@@ -25,50 +25,10 @@
 					Value="Center" />
 		</Style>
 
-		<!-- Text Sample -->
+		<!--  Text Sample  -->
 		<x:String x:Key="SupportingTextSample">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.</x:String>
 
-		<!-- Sample Header Template -->
-		<DataTemplate x:Key="HeaderTemplate">
-			<TextBlock Text="{Binding}"
-					   MaxLines="1"
-					   Margin="16,14,16,0"
-					   Style="{ThemeResource MaterialHeadline6}" />
-		</DataTemplate>
-
-		<!-- Sample SubHeader Template -->
-		<DataTemplate x:Key="SubHeaderTemplate">
-			<TextBlock Text="{Binding}"
-					   MaxLines="2"
-					   Margin="16,0,16,14"
-					   Style="{ThemeResource MaterialBody2}" />
-		</DataTemplate>
-
-		<!-- Sample Supporting Template -->
-		<DataTemplate x:Key="SupportingTemplate">
-			<TextBlock Text="{Binding}"
-					   Margin="16,0,16,14"
-					   Style="{ThemeResource MaterialBody2}" />
-		</DataTemplate>
-
-		<!-- Sample Supporting Template with Avatar -->
-		<DataTemplate x:Key="SupportingTemplateForAvatarLayout">
-			<TextBlock Text="{Binding}"
-					   Margin="16,12,16,14"
-					   Style="{ThemeResource MaterialBody2}" />
-		</DataTemplate>
-
-		<!-- Sample Supporting Template with Small Media -->
-		<DataTemplate x:Key="SupportingTemplateForSmallMediaLayout">
-			<Border BorderThickness="0,1,0,0"
-					BorderBrush="{StaticResource MaterialOnSurfaceFocusedBrush}">
-				<TextBlock Text="{Binding}"
-						   Margin="16,12,16,14"
-						   Style="{ThemeResource MaterialBody2}" />
-			</Border>
-		</DataTemplate>
-
-		<!-- Sample Supporting Content With Buttons Template -->
+		<!--  Sample Supporting Content With Buttons Template  -->
 		<DataTemplate x:Key="SupportingWithButtonsTemplate">
 			<StackPanel>
 				<TextBlock Text="{Binding}"
@@ -87,13 +47,13 @@
 			</StackPanel>
 		</DataTemplate>
 
-		<!-- Sample Top Icon Template -->
+		<!--  Sample Top Icon Template  -->
 		<DataTemplate x:Key="TopIconsTemplate">
 			<Button Content="{Binding}"
 					Style="{StaticResource IconsSampleButtonStyle}">
 				<Button.ContentTemplate>
 					<DataTemplate>
-						<!-- Material more icon -->
+						<!--  Material more icon  -->
 						<Path Fill="{StaticResource MaterialOnSurfaceBrush}"
 							  Data="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
 					</DataTemplate>
@@ -101,7 +61,7 @@
 			</Button>
 		</DataTemplate>
 
-		<!-- Sample Bottom Icon Template -->
+		<!--  Sample Bottom Icon Template  -->
 		<DataTemplate x:Key="BottomIconTemplate">
 			<Button Content="{Binding}"
 					VerticalAlignment="Bottom"
@@ -109,34 +69,12 @@
 					Style="{StaticResource IconsSampleButtonStyle}">
 				<Button.ContentTemplate>
 					<DataTemplate>
-						<!-- Material share icon -->
+						<!--  Material share icon  -->
 						<Path Fill="{StaticResource MaterialOnSurfaceBrush}"
 							  Data="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z" />
 					</DataTemplate>
 				</Button.ContentTemplate>
 			</Button>
-		</DataTemplate>
-
-		<!-- Sample Avatar Image -->
-		<DataTemplate x:Key="AvatarImageTemplate">
-			<Image Source="{Binding}"
-				   Stretch="Uniform"
-				   MaxHeight="40" />
-		</DataTemplate>
-
-		<!-- Sample Image -->
-		<DataTemplate x:Key="SampleImageTemplate">
-			<Image Source="{Binding}"
-				   Stretch="Uniform"
-				   MaxHeight="194" />
-		</DataTemplate>
-
-		<!-- Sample Small Image -->
-		<DataTemplate x:Key="SampleSmallImageTemplate">
-			<Image Source="{Binding}"
-				   Stretch="Uniform"
-				   MaxHeight="94"
-				   VerticalAlignment="Top" />
 		</DataTemplate>
 	</Page.Resources>
 
@@ -146,305 +84,229 @@
 				<DataTemplate>
 					<StackPanel>
 
-						<!-- Card Outlined -->
+						<!--  Card Outlined  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_1"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Outlined card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With title and subtitle only"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   Style="{StaticResource MaterialOutlinedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Outlined disabled Card -->
+						<!--  Outlined disabled Card  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_2"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Outlined disabled Card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With title and subtitle only"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   Style="{StaticResource MaterialOutlinedCardStyle}"
 										   IsEnabled="False" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Elevated -->
+						<!--  Card Elevated  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_3"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Elevated card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With title and subtitle only"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   Style="{StaticResource MaterialElevatedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Elevated disabled Card -->
+						<!--  Elevated disabled Card  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_4"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Elevated disabled Card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With title and subtitle only"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   Style="{StaticResource MaterialElevatedCardStyle}"
 										   IsEnabled="False" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Outlined With supporting text -->
+						<!--  Card Outlined With supporting text  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_5"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Outlined card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With supporting text"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
-										   SupportingContentTemplate="{StaticResource SupportingTemplate}"
 										   Style="{StaticResource MaterialOutlinedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Elevated With supporting text -->
+						<!--  Card Elevated With supporting text  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_6"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Elevated card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With supporting text"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
-										   SupportingContentTemplate="{StaticResource SupportingTemplate}"
 										   Style="{StaticResource MaterialElevatedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Outlined with media -->
+						<!--  Card Outlined with media  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_9"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Outlined card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With media"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/LargeMedia.png"
-										   MediaContentTemplate="{StaticResource SampleImageTemplate}"
 										   Style="{StaticResource MaterialOutlinedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Elevated with media -->
+						<!--  Card Elevated with media  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_10"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Elevated card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With media"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/LargeMedia.png"
-										   MediaContentTemplate="{StaticResource SampleImageTemplate}"
 										   Style="{StaticResource MaterialElevatedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Outlined with media and supporting text -->
+						<!--  Card Outlined with media and supporting text  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_11"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Outlined card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With media and supporting text"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/LargeMedia.png"
-										   MediaContentTemplate="{StaticResource SampleImageTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
-										   SupportingContentTemplate="{StaticResource SupportingTemplate}"
 										   Style="{StaticResource MaterialOutlinedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Elevated with media and supporting text -->
+						<!--  Card Elevated with media and supporting text  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_12"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Elevated card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With media and supporting text"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/LargeMedia.png"
-										   MediaContentTemplate="{StaticResource SampleImageTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
-										   SupportingContentTemplate="{StaticResource SupportingTemplate}"
 										   Style="{StaticResource MaterialElevatedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Outlined with media, supporting text and action buttons -->
+						<!--  Card Outlined with media, supporting text and action buttons  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_13"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Outlined card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With media, supporting text and action buttons"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/LargeMedia.png"
-										   MediaContentTemplate="{StaticResource SampleImageTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
 										   SupportingContentTemplate="{StaticResource SupportingWithButtonsTemplate}"
 										   Style="{StaticResource MaterialOutlinedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Elevated with media, supporting text and action buttons -->
+						<!--  Card Elevated with media, supporting text and action buttons  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_14"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Elevated card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With media, supporting text and action buttons"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/LargeMedia.png"
-										   MediaContentTemplate="{StaticResource SampleImageTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
 										   SupportingContentTemplate="{StaticResource SupportingWithButtonsTemplate}"
 										   Style="{StaticResource MaterialElevatedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Outlined with media, supporting text, action buttons and supplemental action buttons -->
+						<!--  Card Outlined with media, supporting text, action buttons and supplemental action buttons  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_15"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Outlined card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With media, supporting text, action buttons and supplemental action buttons"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/LargeMedia.png"
-										   MediaContentTemplate="{StaticResource SampleImageTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
 										   SupportingContentTemplate="{StaticResource SupportingWithButtonsTemplate}"
 										   IconsContentTemplate="{StaticResource BottomIconTemplate}"
 										   Style="{StaticResource MaterialOutlinedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Elevated with media, supporting text, action buttons and supplemental action buttons -->
+						<!--  Card Elevated with media, supporting text, action buttons and supplemental action buttons  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_16"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Elevated card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With media, supporting text, action buttons and supplemental action buttons"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/LargeMedia.png"
-										   MediaContentTemplate="{StaticResource SampleImageTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
 										   SupportingContentTemplate="{StaticResource SupportingWithButtonsTemplate}"
 										   IconsContentTemplate="{StaticResource BottomIconTemplate}"
 										   Style="{StaticResource MaterialElevatedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Outlined with small media and supporting text -->
+						<!--  Card Outlined with small media and supporting text  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_17"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Outlined card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With small media and supporting text"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/SmallMedia.png"
-										   MediaContentTemplate="{StaticResource SampleSmallImageTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
-										   SupportingContentTemplate="{StaticResource SupportingTemplateForSmallMediaLayout}"
 										   Style="{StaticResource MaterialSmallMediaOutlinedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Outlined disabled with small media and supporting text -->
+						<!--  Card Outlined disabled with small media and supporting text  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_18"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Disabled outlined card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With small media and supporting text"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/SmallMedia.png"
-										   MediaContentTemplate="{StaticResource SampleSmallImageTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
-										   SupportingContentTemplate="{StaticResource SupportingTemplateForSmallMediaLayout}"
 										   Style="{StaticResource MaterialSmallMediaOutlinedCardStyle}"
 										   IsEnabled="False" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Elevated with small media and supporting text -->
+						<!--  Card Elevated with small media and supporting text  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_19"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Elevated card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With small media and supporting text"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/SmallMedia.png"
-										   MediaContentTemplate="{StaticResource SampleSmallImageTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
-										   SupportingContentTemplate="{StaticResource SupportingTemplateForSmallMediaLayout}"
 										   Style="{StaticResource MaterialSmallMediaElevatedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Elevated disabled with small media and supporting text -->
+						<!--  Card Elevated disabled with small media and supporting text  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_20"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Disabled elevated card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With small media and supporting text"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/SmallMedia.png"
-										   MediaContentTemplate="{StaticResource SampleSmallImageTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
-										   SupportingContentTemplate="{StaticResource SupportingTemplateForSmallMediaLayout}"
 										   Style="{StaticResource MaterialSmallMediaElevatedCardStyle}"
 										   IsEnabled="False" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Outlined with Avatar -->
+						<!--  Card Outlined with Avatar  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_21"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Outlined card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With avatar"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   AvatarContent="ms-appx:///Assets/Cards/Avatar.png"
-										   AvatarContentTemplate="{StaticResource AvatarImageTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/LargeMedia.png"
-										   MediaContentTemplate="{StaticResource SampleImageTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
-										   SupportingContentTemplate="{StaticResource SupportingTemplateForAvatarLayout}"
 										   IconsContentTemplate="{StaticResource TopIconsTemplate}"
 										   Style="{StaticResource MaterialAvatarOutlinedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Outlined disabled with Avatar -->
+						<!--  Card Outlined disabled with Avatar  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_22"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Disabled outlined card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With avatar"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   AvatarContent="ms-appx:///Assets/Cards/Avatar.png"
-										   AvatarContentTemplate="{StaticResource AvatarImageTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/LargeMedia.png"
-										   MediaContentTemplate="{StaticResource SampleImageTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
-										   SupportingContentTemplate="{StaticResource SupportingTemplateForAvatarLayout}"
 										   IconsContentTemplate="{StaticResource TopIconsTemplate}"
 										   Style="{StaticResource MaterialAvatarOutlinedCardStyle}"
 										   IsEnabled="False" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Elevated with Avatar -->
+						<!--  Card Elevated with Avatar  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_23"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Elevated card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With avatar"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   AvatarContent="ms-appx:///Assets/Cards/Avatar.png"
-										   AvatarContentTemplate="{StaticResource AvatarImageTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/LargeMedia.png"
-										   MediaContentTemplate="{StaticResource SampleImageTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
-										   SupportingContentTemplate="{StaticResource SupportingTemplateForAvatarLayout}"
 										   IconsContentTemplate="{StaticResource TopIconsTemplate}"
 										   Style="{StaticResource MaterialAvatarElevatedCardStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Card Elevated disabled with Avatar -->
+						<!--  Card Elevated disabled with Avatar  -->
 						<smtx:XamlDisplay UniqueKey="CardSamplePage_24"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<controls:Card HeaderContent="Disabled elevated card"
-										   HeaderContentTemplate="{StaticResource HeaderTemplate}"
 										   SubHeaderContent="With avatar"
-										   SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
 										   AvatarContent="ms-appx:///Assets/Cards/Avatar.png"
-										   AvatarContentTemplate="{StaticResource AvatarImageTemplate}"
 										   MediaContent="ms-appx:///Assets/Cards/LargeMedia.png"
-										   MediaContentTemplate="{StaticResource SampleImageTemplate}"
 										   SupportingContent="{StaticResource SupportingTextSample}"
-										   SupportingContentTemplate="{StaticResource SupportingTemplateForAvatarLayout}"
 										   IconsContentTemplate="{StaticResource TopIconsTemplate}"
 										   Style="{StaticResource MaterialAvatarElevatedCardStyle}"
 										   IsEnabled="False" />
@@ -452,12 +314,6 @@
 					</StackPanel>
 				</DataTemplate>
 			</sample:SamplePageLayout.MaterialTemplate>
-			<sample:SamplePageLayout.CupertinoTemplate>
-				<DataTemplate>
-					<StackPanel>
-					</StackPanel>
-				</DataTemplate>
-			</sample:SamplePageLayout.CupertinoTemplate>
 		</sample:SamplePageLayout>
 	</Grid>
 </Page>


### PR DESCRIPTION
closes #536

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)


## Description

Add default ContentTemplates for Header/SubHeader/Supporting Templates - including default templates for Avatar/SmallMedia styles

Removes the need for defining your own Templates when simply presenting a TextBlock for things like Header/SubHeader

Before:
```xml
<controls:Card HeaderContent="Elevated card"
            HeaderContentTemplate="{StaticResource HeaderTemplate}"
            SubHeaderContent="With avatar"
            SubHeaderContentTemplate="{StaticResource SubHeaderTemplate}"
            AvatarContent="ms-appx:///Assets/Cards/Avatar.png"
            AvatarContentTemplate="{StaticResource AvatarImageTemplate}"
            MediaContent="ms-appx:///Assets/Cards/LargeMedia.png"
            MediaContentTemplate="{StaticResource SampleImageTemplate}"
            SupportingContent="{StaticResource SupportingTextSample}"
            SupportingContentTemplate="{StaticResource SupportingTemplateForAvatarLayout}"
            IconsContentTemplate="{StaticResource TopIconsTemplate}"
            Style="{StaticResource MaterialAvatarElevatedCardStyle}" />
```
After:
```xml
<controls:Card HeaderContent="Elevated card"
            SubHeaderContent="With avatar"
            AvatarContent="ms-appx:///Assets/Cards/Avatar.png"
            MediaContent="ms-appx:///Assets/Cards/LargeMedia.png"
            SupportingContent="{StaticResource SupportingTextSample}"
            IconsContentTemplate="{StaticResource TopIconsTemplate}"
            Style="{StaticResource MaterialAvatarElevatedCardStyle}" />
```

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
