### PR TITLE
feat(DatePicker): Add Cupertino and Material DatePicker Styles

### DIFF
--- a/src/library/Uno.Cupertino/Converters/StringFormatConverter.cs
+++ b/src/library/Uno.Cupertino/Converters/StringFormatConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.UI.Xaml.Data;
+
+namespace Uno.Cupertino.Converters
+{
+	public class StringFormatConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, string language)
+		{
+			var format = parameter as string;
+			if (!String.IsNullOrEmpty(format))
+				return String.Format(format, value);
+
+			return value;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, string language)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/src/library/Uno.Cupertino/CupertinoResources.cs
+++ b/src/library/Uno.Cupertino/CupertinoResources.cs
@@ -25,6 +25,7 @@ namespace Uno.Cupertino
 			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Cupertino/Styles/Controls/Button.xaml") });
 			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Cupertino/Styles/Controls/CheckBox.xaml") });
 			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Cupertino/Styles/Controls/ComboBox.xaml") });
+			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Cupertino/Styles/Controls/DatePicker.xaml") });
 			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Cupertino/Styles/Controls/HyperlinkButton.xaml") });
 			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Cupertino/Styles/Controls/PasswordBox.xaml") });
 			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Cupertino/Styles/Controls/ProgressBar.xaml") });

--- a/src/library/Uno.Cupertino/Styles/Application/Converters.xaml
+++ b/src/library/Uno.Cupertino/Styles/Application/Converters.xaml
@@ -1,17 +1,18 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:converters="using:Uno.Cupertino.Converters">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="using:Uno.Cupertino.Converters">
 
 	<converters:FromEmptyStringToValueConverter x:Key="CupertinoEmptyToFalse"
-												NotNullOrEmptyValue="True"
-												NullOrEmptyValue="False" />
+	                                            NotNullOrEmptyValue="True"
+	                                            NullOrEmptyValue="False" />
 
 	<converters:FromEmptyStringToValueConverter x:Key="CupertinoEmptyToTrue"
-												NotNullOrEmptyValue="False"
-												NullOrEmptyValue="True" />
+	                                            NotNullOrEmptyValue="False"
+	                                            NullOrEmptyValue="True" />
 
 	<converters:FromNullToValueConverter x:Key="CupertinoNullToCollapsedConverter"
-										 NotNullValue="Visible"
-										 NullValue="Collapsed" />
+	                                     NotNullValue="Visible"
+	                                     NullValue="Collapsed" />
 
+	<converters:StringFormatConverter x:Key="StringFormatConverter" />
 </ResourceDictionary>

--- a/src/library/Uno.Cupertino/Styles/Controls/Button.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/Button.xaml
@@ -46,9 +46,7 @@
 		<Setter Property="BorderThickness"
 				Value="0" />
 		<Setter Property="Padding"
-				Value="{ThemeResource CupertinoButtonPadding}" />
-		<Setter Property="CornerRadius"
-				Value="{StaticResource CupertinoButtonCornerRadius}" />
+				Value="0" />
 		<Setter Property="MinHeight"
 				Value="40" />
 		<Setter Property="FontFamily"

--- a/src/library/Uno.Cupertino/Styles/Controls/DatePicker.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/DatePicker.xaml
@@ -7,26 +7,29 @@
 					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:wasm="http://uno.ui/wasm"
 					mc:Ignorable="ios android wasm not_win">
+	<ResourceDictionary.MergedDictionaries>
+		<ResourceDictionary Source="../Application/Converters.xaml" />
+		<ResourceDictionary Source="../Application/Colors.xaml" />
+	</ResourceDictionary.MergedDictionaries>
 
-	<FontFamily x:Key="MaterialDatePickerFlyoutPresenterFontFamily">Roboto</FontFamily>
-	<x:Double x:Key="MaterialDateTimeFlyoutBorderThickness">1</x:Double>
+	<FontFamily x:Key="CupertinoDatePickerFlyoutPresenterFontFamily">SF Pro</FontFamily>
+	<x:Double x:Key="CupertinoDateTimeFlyoutBorderThickness">1</x:Double>
 	<x:Double x:Key="MaterialDatePickerSpacerThemeWidth">1</x:Double>
-	<StaticResource x:Key="MaterialDatePickerFlyoutPresenterBackgroundBrush"
-					ResourceKey="MaterialSurfaceBrush" />
 	<Thickness x:Key="MaterialDatePickerHostPadding">24,24,8,8</Thickness>
 
-	<StaticResource x:Key="MaterialDatePickerFlyoutPresenterBorderBrush"
-					ResourceKey="MaterialOnSurfaceFocusedBrush" />
-	<SolidColorBrush x:Key="MaterialDatePickerFlyoutPresenterHighlightFill"
-					 Opacity="0.20"
-					 Color="{ThemeResource MaterialPrimaryColor}" />
+	<SolidColorBrush x:Key="CupertinoDatePickerFlyoutPresenterHighlightFill"
+					 Color="{ThemeResource CupertinoQuinaryGrayColor}" />
 	<x:Double x:Key="MaterialDatePickerFlyoutElevation">8</x:Double>
 	<StaticResource x:Key="MaterialDatePickerFlyoutPresenterSpacerFill"
 					ResourceKey="MaterialOnSurfaceFocusedBrush" />
+	<SolidColorBrush x:Key="CupertinoDatePickerBorderBrush"
+					 Opacity="0.2"
+					 Color="{ThemeResource LabelColor}" />
 
+	<CornerRadius x:Key="CupertinoDatePickerCornerRadius">5</CornerRadius>
 
 	<!-- DatePicker Style -->
-	<Style x:Key="DatePickerFlyoutButtonStyle"
+	<Style x:Key="CupertinoDatePickerFlyoutButtonStyle"
 		   TargetType="Button">
 
 		<Setter Property="Background"
@@ -74,7 +77,7 @@
 		</Setter>
 	</Style>
 
-	<not_win:Style x:Key="MaterialDatePickerFlyoutPresenterStyle"
+	<not_win:Style x:Key="CupertinoDatePickerFlyoutPresenterStyle"
 				   TargetType="DatePickerFlyoutPresenter">
 		<Setter Property="Width"
 				Value="296" />
@@ -85,26 +88,26 @@
 		<Setter Property="IsTabStop"
 				Value="False" />
 		<Setter Property="FontFamily"
-				Value="{StaticResource MaterialDatePickerFlyoutPresenterFontFamily}" />
+				Value="{StaticResource CupertinoDatePickerFlyoutPresenterFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="Normal" />
 		<Setter Property="FontSize"
 				Value="{ThemeResource ControlContentThemeFontSize}" />
 		<Setter Property="Background"
-				Value="{StaticResource MaterialDatePickerFlyoutPresenterBackgroundBrush}" />
+				Value="{ThemeResource SystemBackgroundColor}" />
 		<Setter Property="AutomationProperties.AutomationId"
 				Value="DatePickerFlyoutPresenter" />
 		<Setter Property="BorderThickness"
-				Value="{StaticResource MaterialDateTimeFlyoutBorderThickness}" />
+				Value="{StaticResource CupertinoDateTimeFlyoutBorderThickness}" />
 		<Setter Property="BorderBrush"
-				Value="{ThemeResource MaterialDatePickerFlyoutPresenterBorderBrush}" />
+				Value="{ThemeResource CupertinoDatePickerBorderBrush}" />
 		<Setter Property="CornerRadius"
-				Value="{ThemeResource OverlayCornerRadius}" />
+				Value="6" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="DatePickerFlyoutPresenter">
 					<toolkit:ElevatedView MaxHeight="398"
-										  Background="{TemplateBinding Background}"
+										  Background="{StaticResource CupertinoQuinaryGrayBrush}"
 										  BorderBrush="{TemplateBinding BorderBrush}"
 										  BorderThickness="{TemplateBinding BorderThickness}"
 										  CornerRadius="{TemplateBinding CornerRadius}"
@@ -114,9 +117,46 @@
 							<Grid x:Name="ContentPanel">
 
 								<Grid.RowDefinitions>
+									<RowDefinition Height="Auto" />
 									<RowDefinition Height="*" />
 								</Grid.RowDefinitions>
-								<Grid x:Name="PickerHostGrid">
+								<Grid x:Name="AcceptDismissHostGrid"
+									  Height="{ThemeResource DatePickerFlyoutPresenterAcceptDismissHostGridHeight}"
+									  Background="{TemplateBinding Background}">
+
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="*" />
+										<ColumnDefinition Width="Auto" />
+									</Grid.ColumnDefinitions>
+									<Rectangle Grid.ColumnSpan="3"
+											   Height="{ThemeResource MaterialDatePickerSpacerThemeWidth}"
+											   VerticalAlignment="Bottom"
+											   Fill="{ThemeResource CupertinoOpaqueSeparatorBrush}" />
+									<Button x:Name="DismissButton"
+											x:Uid="DatePickerFlyoutDismissButton"
+											Grid.Column="0"
+											Margin="12,0,0,0"
+											Content="Cancel"
+											Style="{StaticResource CupertinoButtonStyle}" />
+									<TextBlock x:Name="DatePickerFlyoutHeader"
+											   Grid.Column="1"
+											   x:Uid="DatePickerFlyoutDismissButton"
+											   Text="Enter Date"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center"
+											   FontWeight="Bold"
+											   Style="{StaticResource BodyTextBlockStyle}" />
+									<Button x:Name="AcceptButton"
+											x:Uid="DatePickerFlyoutAcceptButton"
+											Grid.Column="2"
+											Margin="0,0,12,0"
+											Content="Done"
+											Style="{StaticResource CupertinoButtonStyle}" />
+								</Grid>
+								<Grid x:Name="PickerHostGrid"
+									  Grid.Row="1"
+									  Background="{TemplateBinding Background}">
 
 									<Grid.ColumnDefinitions>
 										<ColumnDefinition x:Name="DayColumn"
@@ -134,49 +174,23 @@
 											   Grid.Column="0"
 											   Grid.ColumnSpan="5"
 											   Height="{ThemeResource DatePickerFlyoutPresenterHighlightHeight}"
+											   Margin="6,0,6,0"
 											   VerticalAlignment="Center"
-											   Fill="{ThemeResource MaterialDatePickerFlyoutPresenterHighlightFill}" />
+											   Fill="{ThemeResource CupertinoDatePickerFlyoutPresenterHighlightFill}"
+											   RadiusX="6"
+											   RadiusY="6" />
 									<Rectangle x:Name="FirstPickerSpacing"
 											   Grid.Column="1"
-											   Width="{ThemeResource MaterialDatePickerSpacerThemeWidth}"
+											   Width="0"
 											   HorizontalAlignment="Center"
-											   Fill="{ThemeResource MaterialDatePickerFlyoutPresenterSpacerFill}" />
+											   Fill="{ThemeResource CupertinoOpaqueSeparatorBrush}" />
 									<Rectangle x:Name="SecondPickerSpacing"
 											   Grid.Column="3"
-											   Width="{ThemeResource MaterialDatePickerSpacerThemeWidth}"
+											   Width="0"
 											   HorizontalAlignment="Center"
-											   Fill="{ThemeResource MaterialDatePickerFlyoutPresenterSpacerFill}" />
+											   Fill="{ThemeResource CupertinoOpaqueSeparatorBrush}" />
 								</Grid>
-								<Grid x:Name="AcceptDismissHostGrid"
-									  Height="{ThemeResource DatePickerFlyoutPresenterAcceptDismissHostGridHeight}"
-									  VerticalAlignment="Bottom"
-									  Background="{TemplateBinding Background}">
 
-									<Grid.ColumnDefinitions>
-										<ColumnDefinition Width="*" />
-										<ColumnDefinition Width="Auto" />
-										<ColumnDefinition Width="Auto" />
-									</Grid.ColumnDefinitions>
-									<Rectangle Height="{ThemeResource MaterialDatePickerSpacerThemeWidth}"
-											   VerticalAlignment="Top"
-											   Grid.ColumnSpan="3"
-											   Fill="{ThemeResource MaterialDatePickerFlyoutPresenterSpacerFill}" />
-
-
-									<Button x:Name="DismissButton"
-											x:Uid="DatePickerFlyoutDismissButton"
-											Grid.Column="1"
-											HorizontalAlignment="Right"
-											Content="CANCEL"
-											Style="{StaticResource MaterialTextButtonStyle}" />
-
-									<Button x:Name="AcceptButton"
-											x:Uid="DatePickerFlyoutAcceptButton"
-											Grid.Column="2"
-											HorizontalAlignment="Right"
-											Content="OK"
-											Style="{StaticResource MaterialTextButtonStyle}" />
-								</Grid>
 							</Grid>
 						</Border>
 					</toolkit:ElevatedView>
@@ -185,23 +199,21 @@
 		</Setter>
 	</not_win:Style>
 
-	<Style x:Key="MaterialDatePickerStyle"
+	<Style x:Key="CupertinoDatePickerStyle"
 		   TargetType="DatePicker">
 
 		<Setter Property="Background"
-				Value="{StaticResource TextBoxFilledBackgroundColorBrush}" />
+				Value="Transparent" />
 		<Setter Property="Foreground"
-				Value="{StaticResource MaterialPrimaryBrush}" />
+				Value="{StaticResource CupertinoLabelBrush}" />
 		<Setter Property="BorderBrush"
-				Value="{StaticResource MaterialPrimaryBrush}" />
+				Value="{StaticResource CupertinoDatePickerBorderBrush}" />
 		<Setter Property="HorizontalAlignment"
 				Value="Stretch" />
-		<Setter Property="Height"
-				Value="53" />
 		<Setter Property="CornerRadius"
-				Value="4,4,0,0" />
+				Value="{StaticResource CupertinoDatePickerCornerRadius}" />
 		<not_win:Setter Property="FlyoutPresenterStyle"
-						Value="{StaticResource MaterialDatePickerFlyoutPresenterStyle}" />
+						Value="{StaticResource CupertinoDatePickerFlyoutPresenterStyle}" />
 
 		<Setter Property="Template">
 			<Setter.Value>
@@ -209,56 +221,52 @@
 
 					<!-- Root Grid -->
 					<Grid x:Name="LayoutRoot">
+						<Grid.RowDefinitions>
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="*" />
+						</Grid.RowDefinitions>
+						<!-- Header -->
+						<TextBlock x:Name="HeaderTextBlock"
+								   Margin="0,8,10,0"
+								   HorizontalAlignment="Stretch"
+								   VerticalAlignment="Top"
+								   Foreground="{TemplateBinding Foreground}"
+								   Style="{StaticResource BodyTextBlockStyle}"
+								   Text="{TemplateBinding Header}"
+								   TextWrapping="Wrap" />
 						<!-- Flyout Button -->
 						<Button x:Name="FlyoutButton"
+								Grid.Row="1"
 								HorizontalAlignment="Stretch"
 								HorizontalContentAlignment="Stretch"
 								IsEnabled="{TemplateBinding IsEnabled}"
-								Style="{StaticResource DatePickerFlyoutButtonStyle}"
+								Style="{StaticResource CupertinoDatePickerFlyoutButtonStyle}"
 								UseSystemFocusVisuals="{TemplateBinding UseSystemFocusVisuals}">
 
-							<Grid Height="{TemplateBinding Height}"
+							<Grid x:Name="FlyoutButtonContentGrid"
+								  VerticalAlignment="Top"
 								  Background="{TemplateBinding Background}"
+								  BorderBrush="{TemplateBinding BorderBrush}"
+								  BorderThickness="1"
 								  CornerRadius="{TemplateBinding CornerRadius}">
 
-								<!-- Border -->
-								<Rectangle x:Name="BottomBorder"
-										   Height="2"
-										   VerticalAlignment="Bottom"
-										   Fill="{TemplateBinding BorderBrush}" />
+								<!-- DateText -->
+								<TextBlock x:Name="DateText"
+										   Margin="10,0,0,0"
+										   Style="{StaticResource BodyTextBlockStyle}"
+										   Text="{Binding Date, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource StringFormatConverter}, ConverterParameter=' {0:d}'}" />
 
-								<!-- Header -->
-								<TextBlock x:Name="HeaderTextBlock"
-										   Margin="10,8,10,0"
-										   HorizontalAlignment="Stretch"
-										   VerticalAlignment="Top"
-										   Foreground="{TemplateBinding Foreground}"
-										   Style="{StaticResource MaterialCaption}"
+								<!-- PlaceholderText -->
+								<TextBlock x:Name="PlaceholderText"
+										   Margin="10,0,0,0"
+										   Foreground="{StaticResource CupertinoPlaceholderTextBrush}"
+										   Style="{StaticResource BodyTextBlockStyle}"
 										   Text="{TemplateBinding Header}"
-										   TextWrapping="Wrap" />
+										   Visibility="Collapsed" />
 
-								<Grid x:Name="FlyoutButtonContentGrid"
-									  Height="24"
-									  Margin="6,24,10,0"
-									  VerticalAlignment="Top">
-
-									<!-- DateText -->
-									<TextBlock x:Name="DateText"
-											   Style="{StaticResource MaterialBody2}"
-											   Text="{Binding Date, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource StringFormatConverter}, ConverterParameter=' {0:d}'}" />
-
-									<!-- PlaceholderText -->
-									<TextBlock x:Name="PlaceholderText"
-											   Margin="4,0,0,0"
-											   Foreground="{StaticResource MaterialOnSurfaceLowBrush}"
-											   Style="{StaticResource MaterialBody2}"
-											   Text="{TemplateBinding Header}"
-											   Visibility="Collapsed" />
-
-									<!-- Removing this cause trouble with the DatePicker code -->
-									<TextBlock x:Name="DayTextBlock"
-											   Opacity="0" />
-								</Grid>
+								<!-- Removing this cause trouble with the DatePicker code -->
+								<TextBlock x:Name="DayTextBlock"
+										   Opacity="0" />
 							</Grid>
 						</Button>
 
@@ -271,8 +279,6 @@
 										<Setter Target="DateText.Foreground"
 												Value="{StaticResource MaterialOnSurfaceLowBrush}" />
 										<Setter Target="HeaderTextBlock.Foreground"
-												Value="{StaticResource MaterialOnSurfaceLowBrush}" />
-										<Setter Target="BottomBorder.Fill"
 												Value="{StaticResource MaterialOnSurfaceLowBrush}" />
 									</VisualState.Setters>
 								</VisualState>

--- a/src/library/Uno.Cupertino/Uno.Cupertino.csproj
+++ b/src/library/Uno.Cupertino/Uno.Cupertino.csproj
@@ -15,7 +15,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-    <PackageReference Include="Uno.UI" Version="3.6.0-dev.275" />
+    <PackageReference Include="Uno.UI" Version="3.6.0-dev.445" />
   </ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">
 		<PackageReference Include="Microsoft.UI.Xaml" Version="2.6.0-prerelease.210113001" />
@@ -28,6 +28,12 @@
   </ItemGroup>
 	<ItemGroup>
 		<UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
+	</ItemGroup>
+	<ItemGroup>
+	  <None Remove="Styles\Controls\DatePicker.xaml" />
+	</ItemGroup>
+	<ItemGroup>
+	  <UpToDateCheckInput Remove="Styles\Controls\DatePicker.xaml" />
 	</ItemGroup>
   <ItemGroup>
 		<Content Include="build\Uno.Cupertino.targets" Pack="true" PackagePath="build" />

--- a/src/library/Uno.Material/Uno.Material.csproj
+++ b/src/library/Uno.Material/Uno.Material.csproj
@@ -11,7 +11,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Uno.UI" Version="3.6.0-dev.275" />
+		<PackageReference Include="Uno.UI" Version="3.6.0-dev.445" />
 		
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">
@@ -21,7 +21,7 @@
 		</PackageReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'!='uap10.0.18362'">
-		<PackageReference Include="Uno.UI.Lottie" Version="3.6.0-dev.275" />
+		<PackageReference Include="Uno.UI.Lottie" Version="3.6.0-dev.445" />
 	</ItemGroup>
 	<ItemGroup>
 		<Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Droid/Uno.Themes.Samples.Droid.csproj
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Droid/Uno.Themes.Samples.Droid.csproj
@@ -90,12 +90,13 @@
     <PackageReference Include="Uno.ShowMeTheXAML.MSBuild">
       <Version>1.0.58</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="3.6.0-dev.275" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.6.0-dev.275" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI" Version="3.6.0-dev.445" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.6.0-dev.445" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.33" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.1.0" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.1.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/App.xaml.Navigation.cs
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/App.xaml.Navigation.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Uno.Extensions;
+using Uno.Themes.Samples.Content.Controls;
 using Uno.Themes.Samples.Content;
 using Uno.Themes.Samples.Content.Styles;
 using Uno.Themes.Samples.Entities;
@@ -84,7 +85,7 @@ namespace Uno.Themes.Samples
 			AddNavigationItems(nv);
 
 			// landing navigation
-			ShellNavigateTo<OverviewPage>(
+			ShellNavigateTo<DatePickerSamplePage>(
 #if WINDOWS_UWP
 				// note: on uwp, NavigationView.SelectedItem MUST be set on launch to avoid entering compact-mode
 				trySynchronizeCurrentItem: true

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/DatePickerSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/DatePickerSamplePage.xaml
@@ -1,47 +1,60 @@
 ﻿<Page x:Class="Uno.Themes.Samples.Content.Controls.DatePickerSamplePage"
-	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:local="using:Uno.Themes.Samples.Shared.Content"
-	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	  xmlns:sample="using:Uno.Themes.Samples"
-	  xmlns:android="http://uno.ui/android"
-	  xmlns:ios="http://uno.ui/ios"
-	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  xmlns:smtx="using:ShowMeTheXAML"
-	  mc:Ignorable="d android ios">
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:android="http://uno.ui/android"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:ios="http://uno.ui/ios"
+      xmlns:local="using:Uno.Themes.Samples.Shared.Content"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:sample="using:Uno.Themes.Samples"
+      xmlns:smtx="using:ShowMeTheXAML"
+      xmlns:xamarin="http://uno.ui/xamarin"
+      mc:Ignorable="d android ios xamarin">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<sample:SamplePageLayout>
 			<sample:SamplePageLayout.MaterialTemplate>
 				<DataTemplate>
 					<StackPanel>
+						<!--  Default  -->
+						<TextBlock Margin="12,16,12,4"
+						           Style="{StaticResource MaterialSubtitle2}"
+						           Text="Default" />
 
-						<!-- Default -->
-						<TextBlock Text="Default"
-								   Style="{StaticResource MaterialSubtitle2}"
-								   Margin="12,16,12,4" />
-
-						<!-- DatePicker -->
-						<smtx:XamlDisplay UniqueKey="DatePickerSamplePage_Default"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+						<!--  DatePicker  -->
+						<smtx:XamlDisplay Style="{StaticResource XamlDisplayBelowStyle}"
+						                  UniqueKey="DatePickerSamplePage_Material_Default">
 
 							<DatePicker x:Name="myDatePicker"
-										Header="Enter Date"
-										Style="{StaticResource MaterialDatePickerStyle}" />
+							            HorizontalAlignment="Left"
+							            xamarin:UseNativeStyle="False"
+							            Header="Enter Date"
+							            Style="{StaticResource MaterialDatePickerStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- Disbaled -->
-						<TextBlock Text="Disbaled"
-								   Style="{StaticResource MaterialSubtitle2}"
-								   Margin="12,8,12,4" />
+						<smtx:XamlDisplay Style="{StaticResource XamlDisplayBelowStyle}"
+						                  UniqueKey="DatePickerSamplePage_Fluent_Default">
 
-						<!-- DatePicker -->
-						<smtx:XamlDisplay UniqueKey="DatePickerSamplePage_Secondary"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<DatePicker x:Name="myDatePicker1"
+							            HorizontalAlignment="Left"
+							            xamarin:UseNativeStyle="False"
+							            Header="Enter Date" />
+						</smtx:XamlDisplay>
+						
+						<!--  Disbaled  -->
+						<TextBlock Margin="12,8,12,4"
+						           Style="{StaticResource MaterialSubtitle2}"
+						           Text="Disabled" />
 
-							<DatePicker Header="Enter Date"
-										Style="{StaticResource MaterialDatePickerStyle}"
-										IsEnabled="False" />
+						<!--  DatePicker  -->
+						<smtx:XamlDisplay Style="{StaticResource XamlDisplayBelowStyle}"
+						                  UniqueKey="DatePickerSamplePage_Material_Disabled">
+							
+							<DatePicker HorizontalAlignment="Left"
+							            xamarin:UseNativeStyle="False"
+							            Header="Enter Date"
+							            IsEnabled="False"
+							            Style="{StaticResource MaterialDatePickerStyle}" />
 						</smtx:XamlDisplay>
 					</StackPanel>
 				</DataTemplate>
@@ -49,6 +62,15 @@
 			<sample:SamplePageLayout.CupertinoTemplate>
 				<DataTemplate>
 					<StackPanel>
+						<smtx:XamlDisplay Style="{StaticResource XamlDisplayBelowStyle}"
+						                  UniqueKey="DatePickerSamplePage_Cupertino_Default">
+
+							<DatePicker x:Name="myDatePicker2"
+							            HorizontalAlignment="Left"
+							            xamarin:UseNativeStyle="False"
+							            Header="Enter Date"
+							            Style="{StaticResource CupertinoDatePickerStyle}" />
+						</smtx:XamlDisplay>
 					</StackPanel>
 				</DataTemplate>
 			</sample:SamplePageLayout.CupertinoTemplate>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/DatePickerSamplePage.xaml.cs
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/DatePickerSamplePage.xaml.cs
@@ -16,9 +16,7 @@ using Uno.Themes.Samples.Entities;
 
 namespace Uno.Themes.Samples.Content.Controls
 {
-#if !__WASM__ && !__MACOS__
 	[SamplePage(SampleCategory.Controls, "DatePicker", Description = "This control allows users to pick a date value.", DocumentationLink = "https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.datepicker")]
-#endif
 	public sealed partial class DatePickerSamplePage : Page
 	{
 		public DatePickerSamplePage()

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Entities/Sample.cs
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Entities/Sample.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Text;
 using Uno.Extensions;
 using Uno.Logging;
+using Windows.UI.Xaml.Data;
 
 namespace Uno.Themes.Samples.Entities
 {
+	[Bindable]
 	public class Sample
 	{
 		public Sample(SamplePageAttribute attribute, Type viewType)

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Skia.Gtk/Uno.Themes.Samples.Skia.Gtk.csproj
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Skia.Gtk/Uno.Themes.Samples.Skia.Gtk.csproj
@@ -25,8 +25,8 @@
 		</PackageReference>
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.0.58" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.0.58" />
-		<PackageReference Include="Uno.UI.Skia.Gtk" Version="3.6.0-dev.275" />
-		<PackageReference Include="Uno.UI.RemoteControl" Version="3.6.0-dev.275" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Skia.Gtk" Version="3.6.0-dev.445" />
+		<PackageReference Include="Uno.UI.RemoteControl" Version="3.6.0-dev.445" Condition="'$(Configuration)'=='Debug'" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.UWP/Uno.Themes.Samples.UWP.csproj
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.UWP/Uno.Themes.Samples.UWP.csproj
@@ -37,7 +37,7 @@
       <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>3.6.0-dev.275</Version>
+      <Version>3.6.0-dev.445</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Wasm/Uno.Themes.Samples.Wasm.csproj
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Wasm/Uno.Themes.Samples.Wasm.csproj
@@ -52,8 +52,8 @@
 		</PackageReference>
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.0.58" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.0.58" />
-		<PackageReference Include="Uno.UI.RemoteControl" Version="3.6.0-dev.275" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.WebAssembly" Version="3.6.0-dev.275" />
+		<PackageReference Include="Uno.UI.RemoteControl" Version="3.6.0-dev.445" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.WebAssembly" Version="3.6.0-dev.445" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="2.0.0-dev.167" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="2.0.0-dev.167" PrivateAssets="all" />
 	</ItemGroup>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.iOS/Uno.Themes.Samples.iOS.csproj
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.iOS/Uno.Themes.Samples.iOS.csproj
@@ -190,8 +190,8 @@
     <PackageReference Include="Uno.ShowMeTheXAML.MSBuild">
       <Version>1.0.58</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="3.6.0-dev.275" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.6.0-dev.275" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI" Version="3.6.0-dev.445" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.6.0-dev.445" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
   </ItemGroup>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.macOS/Uno.Themes.Samples.macOS.csproj
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.macOS/Uno.Themes.Samples.macOS.csproj
@@ -84,10 +84,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.6.0-dev.275" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.6.0-dev.445" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
-    <PackageReference Include="Uno.UI" Version="3.6.0-dev.275" />
+    <PackageReference Include="Uno.UI" Version="3.6.0-dev.445" />
     <PackageReference Include="Uno.ShowMeTheXAML.MSBuild">
       <Version>1.0.58</Version>
     </PackageReference>


### PR DESCRIPTION
closes #470
https://github.com/unoplatform/Uno.Gallery/issues/195

## PR Type

What kind of change does this PR introduce?
- Feature

## Description
Add style for DatePickerFlyoutPresenter

Material:
![image](https://user-images.githubusercontent.com/4793020/111332506-3cc14b00-8648-11eb-848d-780f692d381c.png)

Cupertino:
![image](https://user-images.githubusercontent.com/4793020/111332571-4cd92a80-8648-11eb-87c5-b82d766d2612.png)

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
