### PR TITLE
fix(ComboBox): Use proper CupertinoFootnote style name

### DIFF
--- a/src/library/Uno.Cupertino/Styles/Controls/ComboBox.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/ComboBox.xaml
@@ -322,7 +322,7 @@
 										   Grid.Column="1"
 										   Visibility="{Binding SelectedItem, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource NullToVisible}, TargetNullValue=Collapsed, FallbackValue=Collapsed}"
 										   Text="{TemplateBinding PlaceholderText}"
-										   Style="{ThemeResource FootnoteTextBlockStyle}"
+										   Style="{ThemeResource CupertinoFootnote}"
 										   Foreground="{ThemeResource CupertinoTertiaryGrayBrush}"
 										   VerticalAlignment="Center"
 										   TextWrapping="NoWrap"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## Description

Apps using the Cupertino ComboBox Style on UWP would crash since we are referencing the old name for the Cupertino Footnote TextBlock Style

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)