### PR TITLE
fix: Allow programmatically deselecting selected navigation bar item

### DIFF
--- a/src/library/Uno.Material/Controls/BottomNavigationBar.cs
+++ b/src/library/Uno.Material/Controls/BottomNavigationBar.cs
@@ -116,6 +116,10 @@ namespace Uno.Material.Controls
 			{
 				item.IsChecked = true;
 			}
+			else if (e.NewValue == null && e.OldValue is BottomNavigationBarItem oldItem)
+			{
+				oldItem.IsChecked = false;
+			}
 		}
 
 		private void BottomNavigationBarItem_Checked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
﻿GitHub Issue: https://stackoverflow.com/questions/67248286/uno-platform-bottomnavbar-uncheck-selected-item

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

It is currently not possible to deselect all items in `BottomNavigationBar`


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [ ] Tested iOS
- [x] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)