### PR TITLE
feat: Leading icon for material buttons

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/Button.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Button.xaml
@@ -10,6 +10,7 @@
 					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:not_win="http://uno.ui/not_win"
+					xmlns:extensions="using:Uno.Material.Extensions"
 					mc:Ignorable="d ios android wasm not_win">
 
 	<ResourceDictionary.MergedDictionaries>
@@ -30,7 +31,7 @@
 	<StaticResource x:Key="MaterialTextButtonLowBrush"
 					ResourceKey="MaterialOnSurfaceMediumBrush" />
 
-	<!-- Styles -->
+	<!-- Button Styles -->
 	<Style x:Key="MaterialContainedButtonStyle"
 		   TargetType="Button">
 
@@ -145,17 +146,38 @@
 										 FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
 										 BorderBrush="{TemplateBinding BorderBrush}"
 										 BorderThickness="{TemplateBinding BorderThickness}"
-										 Content="{TemplateBinding Content}"
-										 ContentTemplate="{TemplateBinding ContentTemplate}"
-										 ContentTransitions="{TemplateBinding ContentTransitions}"
 										 CornerRadius="{TemplateBinding CornerRadius}"
-										 FontFamily="{TemplateBinding FontFamily}"
-										 FontSize="{TemplateBinding FontSize}"
-										 FontWeight="{TemplateBinding FontWeight}"
 										 Padding="{TemplateBinding Padding}"
-										 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-										 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-										 AutomationProperties.AccessibilityView="Raw" />
+										 AutomationProperties.AccessibilityView="Raw" >
+							<controls:Ripple.Content>
+								<Grid>
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="*" />
+									</Grid.ColumnDefinitions>
+									
+									<ContentPresenter x:Name="IconPresenter"
+													  Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
+													  HorizontalAlignment="Stretch"
+													  Margin="0,0,8,0"
+													  MaxHeight="34"
+													  MaxWidth="34"
+													  MinWidth="25"
+													  VerticalAlignment="Stretch"
+													  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+
+									<ContentPresenter Grid.Column="1"
+													  Content="{TemplateBinding Content}"
+													  ContentTemplate="{TemplateBinding ContentTemplate}"
+													  ContentTransitions="{TemplateBinding ContentTransitions}"
+													  FontFamily="{TemplateBinding FontFamily}"
+													  FontSize="{TemplateBinding FontSize}"
+													  FontWeight="{TemplateBinding FontWeight}"
+													  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+													  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+								</Grid>
+							</controls:Ripple.Content>
+						</controls:Ripple>
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>
@@ -293,17 +315,38 @@
 										 FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
 										 BorderBrush="{TemplateBinding BorderBrush}"
 										 BorderThickness="{TemplateBinding BorderThickness}"
-										 Content="{TemplateBinding Content}"
-										 ContentTemplate="{TemplateBinding ContentTemplate}"
-										 ContentTransitions="{TemplateBinding ContentTransitions}"
-										 CornerRadius="{StaticResource MaterialButtonCornerRadius}"
-										 FontFamily="{TemplateBinding FontFamily}"
-										 FontSize="{TemplateBinding FontSize}"
-										 FontWeight="{TemplateBinding FontWeight}"
+										 CornerRadius="{TemplateBinding CornerRadius}"
 										 Padding="{TemplateBinding Padding}"
-										 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-										 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-										 AutomationProperties.AccessibilityView="Raw" />
+										 AutomationProperties.AccessibilityView="Raw" >
+							<controls:Ripple.Content>
+								<Grid>
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="*" />
+									</Grid.ColumnDefinitions>
+
+									<ContentPresenter x:Name="IconPresenter"
+													  Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
+													  HorizontalAlignment="Stretch"
+													  Margin="0,0,8,0"
+													  MaxHeight="34"
+													  MaxWidth="34"
+													  MinWidth="25"
+													  VerticalAlignment="Stretch"
+													  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+
+									<ContentPresenter Grid.Column="1"
+													  Content="{TemplateBinding Content}"
+													  ContentTemplate="{TemplateBinding ContentTemplate}"
+													  ContentTransitions="{TemplateBinding ContentTransitions}"
+													  FontFamily="{TemplateBinding FontFamily}"
+													  FontSize="{TemplateBinding FontSize}"
+													  FontWeight="{TemplateBinding FontWeight}"
+													  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+													  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+								</Grid>
+							</controls:Ripple.Content>
+						</controls:Ripple>
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>
@@ -432,17 +475,38 @@
 										 FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
 										 BorderBrush="{TemplateBinding BorderBrush}"
 										 BorderThickness="{TemplateBinding BorderThickness}"
-										 Content="{TemplateBinding Content}"
-										 ContentTemplate="{TemplateBinding ContentTemplate}"
-										 ContentTransitions="{TemplateBinding ContentTransitions}"
-										 CornerRadius="{StaticResource MaterialButtonCornerRadius}"
-										 FontFamily="{TemplateBinding FontFamily}"
-										 FontSize="{TemplateBinding FontSize}"
-										 FontWeight="{TemplateBinding FontWeight}"
+										 CornerRadius="{TemplateBinding CornerRadius}"
 										 Padding="{TemplateBinding Padding}"
-										 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-										 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-										 AutomationProperties.AccessibilityView="Raw" />
+										 AutomationProperties.AccessibilityView="Raw" >
+							<controls:Ripple.Content>
+								<Grid>
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="*" />
+									</Grid.ColumnDefinitions>
+
+									<ContentPresenter x:Name="IconPresenter"
+													  Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
+													  HorizontalAlignment="Stretch"
+													  Margin="0,0,8,0"
+													  MaxHeight="34"
+													  MaxWidth="34"
+													  MinWidth="25"
+													  VerticalAlignment="Stretch"
+													  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+
+									<ContentPresenter Grid.Column="1"
+													  Content="{TemplateBinding Content}"
+													  ContentTemplate="{TemplateBinding ContentTemplate}"
+													  ContentTransitions="{TemplateBinding ContentTransitions}"
+													  FontFamily="{TemplateBinding FontFamily}"
+													  FontSize="{TemplateBinding FontSize}"
+													  FontWeight="{TemplateBinding FontWeight}"
+													  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+													  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+								</Grid>
+							</controls:Ripple.Content>
+						</controls:Ripple>
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ButtonSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ButtonSamplePage.xaml
@@ -5,6 +5,7 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:android="http://uno.ui/android"
 	  xmlns:ios="http://uno.ui/ios"
+	  xmlns:extensions="using:Uno.Material.Extensions"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:smtx="using:ShowMeTheXAML"
 	  mc:Ignorable="d android ios">
@@ -52,6 +53,37 @@
 							<Button Content="TEXT DISABLED"
 									IsEnabled="False"
 									Style="{StaticResource MaterialTextButtonStyle}" />
+						</smtx:XamlDisplay>
+
+						<TextBlock FontSize="14" Margin="0,8,0,0" Text="Material Buttons can specify a leading icon through an attached property"/>
+						<!-- Icon Button Contained -->
+						<smtx:XamlDisplay UniqueKey="Material_IconButtonSamplePage_Contained">
+							<Button Content="CONTAINED"
+									Style="{StaticResource MaterialContainedButtonStyle}">
+								<extensions:ControlExtensions.Icon>
+									<FontIcon Glyph="&#xE946;"/>
+								</extensions:ControlExtensions.Icon>
+							</Button>
+						</smtx:XamlDisplay>
+
+						<!-- Icon Button Outlined -->
+						<smtx:XamlDisplay UniqueKey="Material_IconButtonSamplePage_Outline">
+							<Button Content="OUTLINED"
+									Style="{StaticResource MaterialOutlinedButtonStyle}">
+								<extensions:ControlExtensions.Icon>
+									<FontIcon Glyph="&#xE946;"/>
+								</extensions:ControlExtensions.Icon>
+							</Button>
+						</smtx:XamlDisplay>
+
+						<!-- Icon Button Text -->
+						<smtx:XamlDisplay UniqueKey="Material_IconButtonSamplePage_Text">
+							<Button Content="TEXT"
+									Style="{StaticResource MaterialTextButtonStyle}" >
+								<extensions:ControlExtensions.Icon>
+									<FontIcon Glyph="&#xE946;"/>
+								</extensions:ControlExtensions.Icon>
+							</Button>
 						</smtx:XamlDisplay>
 					</StackPanel>
 				</DataTemplate>


### PR DESCRIPTION
﻿GitHub Issue: https://github.com/unoplatform/Uno.Themes/issues/580
Closes #580 

## PR Type

What kind of change does this PR introduce?
- Feature

<!-- Please uncomment one or more that apply to this PR -->

## Description
Adds support for a leading `Icon` property on Material-themed Button with ControlExtensions.
<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information
This PR contains the updated approach based on latest information from Jerome and @MatFillion 
<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
N/A