### PR TITLE
fix(ComboBox): Correct the vertical content alignment of TexBox without a PlaceholderText using Material styles

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/TextBox.xaml
@@ -5,13 +5,20 @@
 					xmlns:not_macos="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:macos="http://uno.ui/macos"
 					xmlns:extensions="using:Uno.Material.Extensions"
+					xmlns:converters="using:Uno.Material.Converters"
 					mc:Ignorable="d macos">
 
 	<ResourceDictionary.MergedDictionaries>
-		<MaterialColors xmlns="using:Uno.Material"/>
+		<MaterialColors xmlns="using:Uno.Material" />
 		<ResourceDictionary Source="../Application/TextBoxVariables.xaml" />
 	</ResourceDictionary.MergedDictionaries>
 
+	<!-- Converters -->
+	<converters:FromEmptyStringToValueConverter x:Key="EmptyToCompositeTransformTranslateY"
+												NotNullOrEmptyValue="5"
+												NullOrEmptyValue="0" />
+
+	<!-- Path Data -->
 	<x:String x:Key="ClearGlyphPathData">M10.661012,7.5689991L7.5990001,10.650999 12.939089,15.997999 7.5990001,21.336999 10.661012,24.405 16.007082,19.065 21.369997,24.405 24.430058,21.336999 24.429081,21.336 19.088991,15.998999 24.429081,10.662001 21.345095,7.5819996 16.007082,12.919001z M15.997072,0C24.828983,0 31.994999,7.1770013 31.994999,15.999998 31.994999,24.826997 24.828007,31.999999 15.997072,31.999999 7.1569835,31.999999 1.5270052E-07,24.826997 0,15.999998 1.5270052E-07,7.1799997 7.1569835,0 15.997072,0z</x:String>
 
 	<Style x:Name="DeleteButtonStyle"
@@ -97,7 +104,7 @@
 												Value="{StaticResource MaterialOnSurfaceLowBrush}" />
 									</VisualState.Setters>
 								</VisualState>
-								
+
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
 										<Setter Target="PlaceholderElement.Foreground"
@@ -129,11 +136,12 @@
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
 														 To="-11" />
+										<!-- ContentElement TranslateY value changing depending if there is a PlaceholderText or not -->
 										<DoubleAnimation Storyboard.TargetName="ContentElement_CompositeTransform"
 														 Storyboard.TargetProperty="TranslateY"
 														 Duration="{StaticResource MaterialAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="5" />
+														 To="{Binding PlaceholderText, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<DoubleAnimation Storyboard.TargetName="PlaceholderElement_CompositeTransform"
 														 Storyboard.TargetProperty="ScaleX"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
@@ -294,7 +302,7 @@
 												Value="{StaticResource MaterialOnSurfaceLowBrush}" />
 									</VisualState.Setters>
 								</VisualState>
-								
+
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
 										<Setter Target="Root.BorderBrush"
@@ -321,11 +329,12 @@
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
 														 To="-11" />
+										<!-- ContentElement TranslateY value changing depending if there is a PlaceholderText or not -->
 										<DoubleAnimation Storyboard.TargetName="ContentElement_CompositeTransform"
 														 Storyboard.TargetProperty="TranslateY"
 														 Duration="{StaticResource MaterialAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="5" />
+														 To="{Binding PlaceholderText, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<DoubleAnimation Storyboard.TargetName="PlaceholderElement_CompositeTransform"
 														 Storyboard.TargetProperty="ScaleX"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
@@ -17,47 +17,50 @@
 				<DataTemplate>
 					<StackPanel>
 
-						<!-- Default -->
+						<!-- TexBox Filled -->
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_1"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<TextBox PlaceholderText="Filled"
-									 Style="{StaticResource MaterialFilledTextBoxStyle}" />
+							<TextBox Style="{StaticResource MaterialFilledTextBoxStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- TexBox With Header -->
+						<!-- TexBox Filled With PlaceholderText -->
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_2"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox PlaceholderText="Filled"
-									 Header="Header"
 									 Style="{StaticResource MaterialFilledTextBoxStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- TexBox Disabled -->
+						<!-- TexBox Filled Disabled -->
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_3"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<TextBox PlaceholderText="Disabled"
+							<TextBox PlaceholderText="Filled Disabled"
 									 Style="{StaticResource MaterialFilledTextBoxStyle}"
 									 IsEnabled="False" />
 						</smtx:XamlDisplay>
 
-						<!-- TexBox Outline -->
+						<!-- TexBox Outlined -->
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_4"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Style="{StaticResource MaterialOutlinedTextBoxStyle}" />
+						</smtx:XamlDisplay>
+
+						<!-- TexBox Outlined with PlaceholderText -->
+						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_5"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox PlaceholderText="Outlined"
-									 Header="Header"
 									 Style="{StaticResource MaterialOutlinedTextBoxStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- TexBox Outline Disabled -->
-						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_5"
+						<!-- TexBox Outlined Disabled -->
+						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_6"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox PlaceholderText="Outlined Disabled"
 									 Style="{StaticResource MaterialOutlinedTextBoxStyle}"
 									 IsEnabled="False" />
 						</smtx:XamlDisplay>
 
-						<!-- TextBox MultiLine -->
-						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_6"
+						<!-- TextBox Filled MultiLine -->
+						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_7"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox Text="Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper commodo primis ornare himenaeos, inceptos tellus accumsan praesent laoreet. Pharetra semper ullamcorper neque mollis vestibulum luctus gravida facilisi rhoncus, rutrum massa bibendum vitae imperdiet quisque fames dignissim, varius curae erat risus platea orci quis scelerisque. Auctor erat vestibulum enim sodales sapien nam litora rhoncus condimentum praesent, platea dui odio eros integer id gravida turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo habitant."
 									 PlaceholderText="MultiLine Filled"
@@ -66,11 +69,21 @@
 									 AcceptsReturn="True" />
 						</smtx:XamlDisplay>
 
-						<!-- TexBox Icon -->
-						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_7"
+						<!-- TexBox Filled Icon -->
+						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_8"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Style="{StaticResource MaterialFilledTextBoxStyle}">
+								<extensions:ControlExtensions.Icon>
+									<SymbolIcon Symbol="Favorite" />
+								</extensions:ControlExtensions.Icon>
+							</TextBox>
+						</smtx:XamlDisplay>
+
+						<!-- TexBox Outlined Icon with PlaceholderText -->
+						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_9"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox PlaceholderText="Filled with Icon"
-									 Style="{StaticResource MaterialFilledTextBoxStyle}">
+									 Style="{StaticResource MaterialOutlinedTextBoxStyle}">
 								<extensions:ControlExtensions.Icon>
 									<SymbolIcon Symbol="Favorite" />
 								</extensions:ControlExtensions.Icon>


### PR DESCRIPTION
﻿GitHub Issue: #601 

## PR Type

What kind of change does this PR introduce?

- Bugfix


## Description

Correct the vertical content alignment of TexBox without a PlaceholderText using Material styles

- **BEFORE:**
![image](https://user-images.githubusercontent.com/16295702/127529385-87b10a20-5b8e-4231-ac62-273dd005a286.png)

- **AFTER:**
![image](https://user-images.githubusercontent.com/16295702/127531628-92322d93-087f-4e93-80af-d1703f904656.png)


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [X] Tested UWP
- [X] Tested iOS
- [X] Tested Android
- [X] Tested WASM
- [ ] Tested MacOS
- [X] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

