### PR TITLE
fix: vertically center icon in material buttons

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/Button.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Button.xaml
@@ -155,15 +155,16 @@
 										<ColumnDefinition Width="Auto" />
 										<ColumnDefinition Width="*" />
 									</Grid.ColumnDefinitions>
-									
+
 									<ContentPresenter x:Name="IconPresenter"
 													  Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
-													  HorizontalAlignment="Stretch"
 													  Margin="0,0,8,0"
 													  MaxHeight="34"
 													  MaxWidth="34"
 													  MinWidth="25"
+													  HorizontalAlignment="Stretch"
 													  VerticalAlignment="Stretch"
+													  VerticalContentAlignment="Center"
 													  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 									<ContentPresenter Grid.Column="1"
@@ -327,12 +328,13 @@
 
 									<ContentPresenter x:Name="IconPresenter"
 													  Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
-													  HorizontalAlignment="Stretch"
 													  Margin="0,0,8,0"
 													  MaxHeight="34"
 													  MaxWidth="34"
 													  MinWidth="25"
+													  HorizontalAlignment="Stretch"
 													  VerticalAlignment="Stretch"
+													  VerticalContentAlignment="Center"
 													  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 									<ContentPresenter Grid.Column="1"
@@ -487,12 +489,13 @@
 
 									<ContentPresenter x:Name="IconPresenter"
 													  Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
-													  HorizontalAlignment="Stretch"
 													  Margin="0,0,8,0"
 													  MaxHeight="34"
 													  MaxWidth="34"
 													  MinWidth="25"
+													  HorizontalAlignment="Stretch"
 													  VerticalAlignment="Stretch"
+													  VerticalContentAlignment="Center"
 													  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 									<ContentPresenter Grid.Column="1"


### PR DESCRIPTION
﻿GitHub Issue: fixes #607

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
- Feature

## Description

Adds a `VerticalContentAlignment="Center"` to the `ContentPresenter` of icons in Material buttons.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [x] Tested MacOS
- [x] Contains **No** breaking changes
