### PR TITLE
fix(Button): [Material] Stretched ContentAlignment does not work for all the styles

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/Button.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Button.xaml
@@ -14,7 +14,7 @@
 					mc:Ignorable="d ios android wasm not_win">
 
 	<ResourceDictionary.MergedDictionaries>
-		<MaterialColors xmlns="using:Uno.Material"/>
+		<MaterialColors xmlns="using:Uno.Material" />
 	</ResourceDictionary.MergedDictionaries>
 
 	<!-- Documented variables -->
@@ -148,7 +148,9 @@
 										 BorderThickness="{TemplateBinding BorderThickness}"
 										 CornerRadius="{TemplateBinding CornerRadius}"
 										 Padding="{TemplateBinding Padding}"
-										 AutomationProperties.AccessibilityView="Raw" >
+										 AutomationProperties.AccessibilityView="Raw"
+										 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
 							<controls:Ripple.Content>
 								<Grid>
 									<Grid.ColumnDefinitions>
@@ -318,7 +320,9 @@
 										 BorderThickness="{TemplateBinding BorderThickness}"
 										 CornerRadius="{TemplateBinding CornerRadius}"
 										 Padding="{TemplateBinding Padding}"
-										 AutomationProperties.AccessibilityView="Raw" >
+										 AutomationProperties.AccessibilityView="Raw"
+										 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
 							<controls:Ripple.Content>
 								<Grid>
 									<Grid.ColumnDefinitions>
@@ -479,7 +483,9 @@
 										 BorderThickness="{TemplateBinding BorderThickness}"
 										 CornerRadius="{TemplateBinding CornerRadius}"
 										 Padding="{TemplateBinding Padding}"
-										 AutomationProperties.AccessibilityView="Raw" >
+										 AutomationProperties.AccessibilityView="Raw"
+										 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
 							<controls:Ripple.Content>
 								<Grid>
 									<Grid.ColumnDefinitions>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ButtonSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ButtonSamplePage.xaml
@@ -15,79 +15,194 @@
 			<sample:SamplePageLayout.MaterialTemplate>
 				<DataTemplate>
 					<StackPanel>
+						<!-- BUTTONS -->
 
 						<!-- Button Contained -->
-						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_Contained">
+						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_Contained"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<Button Content="CONTAINED"
 									Style="{StaticResource MaterialContainedButtonStyle}" />
 						</smtx:XamlDisplay>
 
 						<!-- Button Contained Disabled -->
-						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_ContainedDisabled">
+						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_ContainedDisabled"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<Button Content="CONTAINED DISABLED"
 									IsEnabled="False"
 									Style="{StaticResource MaterialContainedButtonStyle}" />
 						</smtx:XamlDisplay>
 
 						<!-- Button Outlined -->
-						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_Outline">
+						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_Outline"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<Button Content="OUTLINED"
 									Style="{StaticResource MaterialOutlinedButtonStyle}" />
 						</smtx:XamlDisplay>
 
 						<!-- Button Outlined Disabled -->
-						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_OutlineDisabled">
+						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_OutlineDisabled"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<Button Content="OUTLINED DISABLED"
 									IsEnabled="False"
 									Style="{StaticResource MaterialOutlinedButtonStyle}" />
 						</smtx:XamlDisplay>
 
 						<!-- Button Text -->
-						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_Text">
+						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_Text"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<Button Content="TEXT"
 									Style="{StaticResource MaterialTextButtonStyle}" />
 						</smtx:XamlDisplay>
 
 						<!-- Button Text Disabled -->
-						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_TextDisabled">
+						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_TextDisabled"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<Button Content="TEXT DISABLED"
 									IsEnabled="False"
 									Style="{StaticResource MaterialTextButtonStyle}" />
 						</smtx:XamlDisplay>
 
-						<TextBlock FontSize="14" Margin="0,8,0,0" Text="Material Buttons can specify a leading icon through an attached property"/>
+						<!-- STRETCHED BUTTONS -->
+
+						<!-- Stretched Button Contained -->
+						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_ContainedStretched"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<Button Content="CONTAINED"
+									HorizontalAlignment="Stretch"
+									HorizontalContentAlignment="Center"
+									Style="{StaticResource MaterialContainedButtonStyle}" />
+						</smtx:XamlDisplay>
+
+						<!-- Stretched Button Contained Disabled -->
+						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_ContainedDisabledStretched"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<Button Content="CONTAINED DISABLED"
+									IsEnabled="False"
+									HorizontalAlignment="Stretch"
+									HorizontalContentAlignment="Center"
+									Style="{StaticResource MaterialContainedButtonStyle}" />
+						</smtx:XamlDisplay>
+
+						<!-- Stretched Button Outlined -->
+						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_OutlineStretched"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<Button Content="OUTLINED"
+									HorizontalAlignment="Stretch"
+									HorizontalContentAlignment="Center"
+									Style="{StaticResource MaterialOutlinedButtonStyle}" />
+						</smtx:XamlDisplay>
+
+						<!-- Stretched Button Outlined Disabled -->
+						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_OutlineDisabledStretched"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<Button Content="OUTLINED DISABLED"
+									IsEnabled="False"
+									HorizontalAlignment="Stretch"
+									HorizontalContentAlignment="Center"
+									Style="{StaticResource MaterialOutlinedButtonStyle}" />
+						</smtx:XamlDisplay>
+
+						<!-- Stretched Button Text -->
+						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_TextStretched"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<Button Content="TEXT"
+									HorizontalAlignment="Stretch"
+									HorizontalContentAlignment="Center"
+									Style="{StaticResource MaterialTextButtonStyle}" />
+						</smtx:XamlDisplay>
+
+						<!-- Stretched Button Text Disabled -->
+						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_TextDisabledStretched"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<Button Content="TEXT DISABLED"
+									IsEnabled="False"
+									HorizontalAlignment="Stretch"
+									HorizontalContentAlignment="Center"
+									Style="{StaticResource MaterialTextButtonStyle}" />
+						</smtx:XamlDisplay>
+
+						<!-- BUTTONS WITH ICON -->
+						<TextBlock FontSize="14"
+								   Margin="0,8,0,0"
+								   Text="Material Buttons can specify a leading icon through an attached property" />
+
 						<!-- Icon Button Contained -->
-						<smtx:XamlDisplay UniqueKey="Material_IconButtonSamplePage_Contained">
+						<smtx:XamlDisplay UniqueKey="Material_IconButtonSamplePage_Contained"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<Button Content="CONTAINED"
 									Style="{StaticResource MaterialContainedButtonStyle}">
 								<extensions:ControlExtensions.Icon>
-									<FontIcon Glyph="&#xE946;"/>
+									<FontIcon Glyph="&#xE946;" />
 								</extensions:ControlExtensions.Icon>
 							</Button>
 						</smtx:XamlDisplay>
 
 						<!-- Icon Button Outlined -->
-						<smtx:XamlDisplay UniqueKey="Material_IconButtonSamplePage_Outline">
+						<smtx:XamlDisplay UniqueKey="Material_IconButtonSamplePage_Outline"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<Button Content="OUTLINED"
 									Style="{StaticResource MaterialOutlinedButtonStyle}">
 								<extensions:ControlExtensions.Icon>
-									<FontIcon Glyph="&#xE946;"/>
+									<FontIcon Glyph="&#xE946;" />
 								</extensions:ControlExtensions.Icon>
 							</Button>
 						</smtx:XamlDisplay>
 
 						<!-- Icon Button Text -->
-						<smtx:XamlDisplay UniqueKey="Material_IconButtonSamplePage_Text">
+						<smtx:XamlDisplay UniqueKey="Material_IconButtonSamplePage_Text"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<Button Content="TEXT"
-									Style="{StaticResource MaterialTextButtonStyle}" >
+									Style="{StaticResource MaterialTextButtonStyle}">
 								<extensions:ControlExtensions.Icon>
-									<FontIcon Glyph="&#xE946;"/>
+									<FontIcon Glyph="&#xE946;" />
+								</extensions:ControlExtensions.Icon>
+							</Button>
+						</smtx:XamlDisplay>
+
+						<!-- STRETCHED BUTTONS WITH ICON -->
+
+						<!-- Stretched Icon Button Contained -->
+						<smtx:XamlDisplay UniqueKey="Material_IconButtonSamplePage_ContainedStretched"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<Button Content="CONTAINED"
+									HorizontalAlignment="Stretch"
+									HorizontalContentAlignment="Center"
+									Style="{StaticResource MaterialContainedButtonStyle}">
+								<extensions:ControlExtensions.Icon>
+									<FontIcon Glyph="&#xE946;" />
+								</extensions:ControlExtensions.Icon>
+							</Button>
+						</smtx:XamlDisplay>
+
+						<!-- Stretched Icon Button Outlined -->
+						<smtx:XamlDisplay UniqueKey="Material_IconButtonSamplePage_OutlineStretched"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<Button Content="OUTLINED"
+									HorizontalAlignment="Stretch"
+									HorizontalContentAlignment="Center"
+									Style="{StaticResource MaterialOutlinedButtonStyle}">
+								<extensions:ControlExtensions.Icon>
+									<FontIcon Glyph="&#xE946;" />
+								</extensions:ControlExtensions.Icon>
+							</Button>
+						</smtx:XamlDisplay>
+
+						<!-- Stretched Icon Button Text -->
+						<smtx:XamlDisplay UniqueKey="Material_IconButtonSamplePage_TextStretched"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<Button Content="TEXT"
+									HorizontalAlignment="Stretch"
+									HorizontalContentAlignment="Center"
+									Style="{StaticResource MaterialTextButtonStyle}">
+								<extensions:ControlExtensions.Icon>
+									<FontIcon Glyph="&#xE946;" />
 								</extensions:ControlExtensions.Icon>
 							</Button>
 						</smtx:XamlDisplay>
 					</StackPanel>
 				</DataTemplate>
 			</sample:SamplePageLayout.MaterialTemplate>
+
 			<sample:SamplePageLayout.CupertinoTemplate>
 				<DataTemplate>
 					<StackPanel>


### PR DESCRIPTION
﻿GitHub Issue: #619 

## PR Type

What kind of change does this PR introduce?

- Bugfix


## Description

Fixed Stretched ContentAlignment for all the Material Button Styles

![image](https://user-images.githubusercontent.com/16295702/128571605-47ca09c0-0359-424a-b5e8-d7f2e0f7d4dd.png)
![image](https://user-images.githubusercontent.com/16295702/128571742-9882b42e-a26c-4438-b1a4-1c8446d99f2a.png)

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [X] Tested UWP
- [X] Tested iOS
- [X] Tested Android
- [X] Tested WASM
- [ ] Tested MacOS
- [X] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

