### PR TITLE
fix: Fix ChipGroup not properly selecting when ItemsSource contains enums

### DIFF
--- a/src/library/Uno.Material/Controls/Chips/ChipGroup.cs
+++ b/src/library/Uno.Material/Controls/Chips/ChipGroup.cs
@@ -391,6 +391,18 @@ namespace Uno.Material.Controls
 		{
 			if (item == null) return null;
 
+			// For some obscure reason, ContainerFromItem returns null when item is an enum.
+			// Note however that it works fine for other value types such as int.
+			// Because of this, we retrieve the container using the index instead.
+			if (item is Enum)
+			{
+				var index = GetItems().IndexOf(item);
+				if (index != -1)
+				{
+					return ContainerFromIndex(index) as Chip;
+				}
+			}
+
 			return
 				item as Chip ??
 				ContainerFromItem(item) as Chip;

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ChipSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ChipSamplePage.xaml
@@ -398,6 +398,39 @@
 								</chips:ChipGroup>
 							</ScrollViewer>
 						</smtx:XamlDisplay>
+
+						<TextBlock Text="Single Selection with Enum"
+								   Style="{StaticResource MaterialSubtitle1}" />
+						<TextBlock Style="{StaticResource MaterialSubtitle2}">
+							<Run Text="{Binding ElementName=SingleEnumSelectionChipGroup, Path=SelectedItem, Mode=TwoWay, Converter={StaticResource SingleSelectionToValueConverter}}" /><Run Text="{Binding ElementName=SingleEnumSelectionChipGroup, Path=SelectedItem, Mode=TwoWay}" />
+						</TextBlock>
+
+						<smtx:XamlDisplay UniqueKey="ChipSamplePage_ChipGroup_SingleEnumSelection_WithSelectedItem"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+
+							<ScrollViewer HorizontalScrollMode="Auto"
+										  HorizontalScrollBarVisibility="Auto"
+										  VerticalScrollMode="Disabled"
+										  VerticalScrollBarVisibility="Hidden">
+
+								<chips:ChipGroup x:Name="SingleEnumSelectionChipGroup"
+												 ItemsSource="{Binding Data.TestEnumArray}"
+												 SelectedItem="{Binding Data.TestEnumItem}"
+												 Style="{StaticResource MaterialChipGroupStyle}"
+												 ItemContainerStyle="{StaticResource MaterialPrimaryChipStyle}"
+												 SelectionMode="Single"
+												 Margin="8,0,8,8">
+
+									<chips:ChipGroup.ItemTemplate>
+										<DataTemplate>
+											<TextBlock Style="{StaticResource MaterialBody1}"
+													   Text="{Binding}" />
+										</DataTemplate>
+									</chips:ChipGroup.ItemTemplate>
+								</chips:ChipGroup>
+							</ScrollViewer>
+						</smtx:XamlDisplay>
+
 						<TextBlock Text="Multiple selection"
 								   Style="{StaticResource MaterialSubtitle1}" />
 						<StackPanel Orientation="Horizontal">

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Entities/Data/TestCollections.cs
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Entities/Data/TestCollections.cs
@@ -14,6 +14,8 @@ namespace Uno.Themes.Samples.Entities.Data
 		public static IEnumerable<SelectableData> TestArray { get; } = CreateItems();
 		public static IEnumerable<SelectableData> TestSelectedItems { get; } = TestArray.Take(3).ToArray();
 		public static SelectableData TestItem { get; } = TestArray.First();
+		public static IEnumerable<DayOfWeek> TestEnumArray { get; } = new DayOfWeek[] { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday, DayOfWeek.Saturday, DayOfWeek.Sunday };
+		public static DayOfWeek TestEnumItem { get; } = DayOfWeek.Monday;
 
 		private static IEnumerable<SelectableData> CreateItems()
 		{


### PR DESCRIPTION
﻿GitHub Issue: https://github.com/unoplatform/Uno.Themes/issues/624

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->

- Fixed ChipGroup not properly selecting when ItemsSource contains enums.
- Added sample:
  ![image](https://user-images.githubusercontent.com/39710855/133295110-ce05860f-07f1-45c5-b178-293a37b83d99.png)


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
