### PR TITLE
fix: Allow ChipGroup initial section when ItemsSource is set after SelectedItem

### DIFF
--- a/src/library/Uno.Material/Controls/Chips/ChipGroup.cs
+++ b/src/library/Uno.Material/Controls/Chips/ChipGroup.cs
@@ -25,9 +25,9 @@ namespace Uno.Material.Controls
 		public event ChipItemRemovingEventHandler ItemRemoving;
 		public event ChipItemEventHandler ItemRemoved;
 
+		private bool _isLoaded = false;
 		private bool _isSynchronizingSelection = false;
 		private bool _isUpdatingSelection = false;
-		private bool _needsToSynchronizeInitialSelection = false;
 
 		public ChipGroup()
 		{
@@ -43,6 +43,7 @@ namespace Uno.Material.Controls
 
 		private void OnLoaded(object sender, RoutedEventArgs e)
 		{
+			_isLoaded = true;
 			SynchronizeInitialSelection();
 			EnforceSelectionMode();
 			ApplyThumbnailTemplate();
@@ -102,11 +103,13 @@ namespace Uno.Material.Controls
 		{
 			base.OnItemsChanged(e);
 
+			SynchronizeInitialSelection();
 			EnforceSelectionMode();
 		}
 
 		protected void OnItemsSourceChanged()
 		{
+			SynchronizeInitialSelection();
 			EnforceSelectionMode();
 		}
 
@@ -114,9 +117,8 @@ namespace Uno.Material.Controls
 		{
 			if (_isSynchronizingSelection || _isUpdatingSelection) return;
 
-			if (!_needsToSynchronizeInitialSelection && ItemsPanelRoot == null && e.NewValue != null)
+			if (!IsReady && e.NewValue != null)
 			{
-				_needsToSynchronizeInitialSelection = true;
 				return;
 			}
 
@@ -135,9 +137,8 @@ namespace Uno.Material.Controls
 		{
 			if (_isSynchronizingSelection || _isUpdatingSelection) return;
 
-			if (!_needsToSynchronizeInitialSelection && ItemsPanelRoot == null && e.NewValue != null)
+			if (!IsReady && e.NewValue != null)
 			{
-				_needsToSynchronizeInitialSelection = true;
 				return;
 			}
 
@@ -262,22 +263,25 @@ namespace Uno.Material.Controls
 
 		private void SynchronizeInitialSelection()
 		{
-			if (_needsToSynchronizeInitialSelection && SelectedItem != null)
+			if (!IsReady)
+			{
+				return;
+			}
+
+			if (SelectedItem != null)
 			{
 				OnSelectedItemChanged(null);
 			}
 
-			if (_needsToSynchronizeInitialSelection && SelectedItems != null)
+			if (SelectedItems != null)
 			{
 				OnSelectedItemsChanged(null);
 			}
-
-			_needsToSynchronizeInitialSelection = false;
 		}
 
 		private void EnforceSelectionMode()
 		{
-			if (ItemsPanelRoot == null) return;
+			if (!IsReady) return;
 
 			if (SelectionMode == ChipSelectionMode.None)
 			{
@@ -320,7 +324,7 @@ namespace Uno.Material.Controls
 
 		private void UpdateSelection(Chip[] newlySelectedContainers, bool forceClearOthersSelection = false)
 		{
-			if (ItemsPanelRoot == null) return;
+			if (!IsReady) return;
 			if (_isSynchronizingSelection) return;
 
 			try
@@ -376,6 +380,10 @@ namespace Uno.Material.Controls
 				_isSynchronizingSelection = false;
 			}
 		}
+
+		private bool IsReady => _isLoaded && HasItems;
+
+		private bool HasItems => GetItems().Any();
 
 		/// <summary>
 		/// Get the items.


### PR DESCRIPTION
﻿GitHub Issue: https://github.com/unoplatform/Uno.Themes/issues/626

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

- Allow ChipGroup initial section when ItemsSource is set after SelectedItem.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
