### PR TITLE
Fix TextBox Disabled colors

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/TextBox.xaml
@@ -98,8 +98,13 @@
 
 								<VisualState x:Name="Disabled">
 									<VisualState.Setters>
-										<Setter Target="ContentElement.Foreground"
+										<Setter Target="NormalBorder.Fill"
 												Value="{StaticResource MaterialOnSurfaceLowBrush}" />
+										<Setter Target="ContentElement.Foreground"
+												Value="{StaticResource MaterialOnSurfaceBrush}" />
+										<!-- In this case the opacity is not applied to the brush -->
+										<Setter Target="ContentElement.Opacity"
+												Value="{StaticResource MaterialLowOpacity}" />
 										<Setter Target="PlaceholderElement.Foreground"
 												Value="{StaticResource MaterialOnSurfaceLowBrush}" />
 									</VisualState.Setters>
@@ -296,8 +301,13 @@
 
 								<VisualState x:Name="Disabled">
 									<VisualState.Setters>
-										<Setter Target="ContentElement.Foreground"
+										<Setter Target="Root.BorderBrush"
 												Value="{StaticResource MaterialOnSurfaceLowBrush}" />
+										<Setter Target="ContentElement.Foreground"
+												Value="{StaticResource MaterialOnSurfaceBrush}" />
+										<!-- In this case the opacity is not applied to the brush -->
+										<Setter Target="ContentElement.Opacity"
+												Value="{StaticResource MaterialLowOpacity}" />
 										<Setter Target="PlaceholderElement.Foreground"
 												Value="{StaticResource MaterialOnSurfaceLowBrush}" />
 									</VisualState.Setters>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
@@ -30,10 +30,11 @@
 									 Style="{StaticResource MaterialFilledTextBoxStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- TexBox Filled Disabled -->
+						<!-- TexBox Filled Disabled with PlaceholderText -->
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_3"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<TextBox PlaceholderText="Filled Disabled"
+							<TextBox PlaceholderText="Placeholder"
+									 Text="Filled Disabled"
 									 Style="{StaticResource MaterialFilledTextBoxStyle}"
 									 IsEnabled="False" />
 						</smtx:XamlDisplay>
@@ -51,10 +52,11 @@
 									 Style="{StaticResource MaterialOutlinedTextBoxStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- TexBox Outlined Disabled -->
+						<!-- TexBox Outlined Disabled with PlaceholderText -->
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_6"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<TextBox PlaceholderText="Outlined Disabled"
+							<TextBox PlaceholderText="Placeholder"
+									 Text="Outlined Disabled"
 									 Style="{StaticResource MaterialOutlinedTextBoxStyle}"
 									 IsEnabled="False" />
 						</smtx:XamlDisplay>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
@@ -17,20 +17,20 @@
 				<DataTemplate>
 					<StackPanel>
 
-						<!-- TexBox Filled -->
+						<!-- TextBox Filled -->
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_1"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox Style="{StaticResource MaterialFilledTextBoxStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- TexBox Filled With PlaceholderText -->
+						<!-- TextBox Filled With PlaceholderText -->
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_2"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox PlaceholderText="Filled"
 									 Style="{StaticResource MaterialFilledTextBoxStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- TexBox Filled Disabled with PlaceholderText -->
+						<!-- TextBox Filled Disabled with PlaceholderText -->
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_3"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox PlaceholderText="Placeholder"
@@ -39,20 +39,20 @@
 									 IsEnabled="False" />
 						</smtx:XamlDisplay>
 
-						<!-- TexBox Outlined -->
+						<!-- TextBox Outlined -->
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_4"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox Style="{StaticResource MaterialOutlinedTextBoxStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- TexBox Outlined with PlaceholderText -->
+						<!-- TextBox Outlined with PlaceholderText -->
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_5"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox PlaceholderText="Outlined"
 									 Style="{StaticResource MaterialOutlinedTextBoxStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- TexBox Outlined Disabled with PlaceholderText -->
+						<!-- TextBox Outlined Disabled with PlaceholderText -->
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_6"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox PlaceholderText="Placeholder"
@@ -71,7 +71,7 @@
 									 AcceptsReturn="True" />
 						</smtx:XamlDisplay>
 
-						<!-- TexBox Filled Icon -->
+						<!-- TextBox Filled Icon -->
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_8"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox Style="{StaticResource MaterialFilledTextBoxStyle}">
@@ -81,7 +81,7 @@
 							</TextBox>
 						</smtx:XamlDisplay>
 
-						<!-- TexBox Outlined Icon with PlaceholderText -->
+						<!-- TextBox Outlined Icon with PlaceholderText -->
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_9"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox PlaceholderText="Filled with Icon"


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->
Changed opacity of disabled MaterialFilledTextBoxStyle and MaterialOutlinedTextBoxStyle to match Material Design.
Added placeholders to disabled sample in order to see the full disabled version.
For some reason the brush's opacity isn't translated to the ScrollViewer's opacity so I changed it directly.
Screenshots:
![image](https://user-images.githubusercontent.com/46804643/134574637-d3879e97-3996-4dbb-9b22-70c53f650d26.png)
![image](https://user-images.githubusercontent.com/46804643/134574732-5e439dfb-1bb6-4b8f-9a6a-11b161928001.png)
![image](https://user-images.githubusercontent.com/46804643/134574808-91476850-23e9-4c7a-bfb7-905350d4eef6.png)


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [X] Tested UWP
- [x] Tested iOS
- [X] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [X] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
