### PR TITLE
fix(ripple): animation speed

### DIFF
--- a/src/library/Uno.Material/Controls/Ripple.cs
+++ b/src/library/Uno.Material/Controls/Ripple.cs
@@ -153,12 +153,12 @@ namespace Uno.Material.Controls
 			RippleX = point.Position.X - RippleSize / 2;
 			RippleY = point.Position.Y - RippleSize / 2;
 
-			VisualStateManager.GoToState(this, "Normal", true);
+			VisualStateManager.GoToState(this, "Normal", false);
 			VisualStateManager.GoToState(this, "Pressed", true);
 		}
 
 		public static readonly DependencyProperty RippleSizeMultiplierProperty = DependencyProperty.Register(
-			"RippleSizeMultiplier", typeof(double), typeof(Ripple), new PropertyMetadata(8.0));
+			"RippleSizeMultiplier", typeof(double), typeof(Ripple), new PropertyMetadata(2 * Math.Sqrt(2)));
 
 		public double RippleSizeMultiplier
 		{

--- a/src/library/Uno.Material/Styles/Controls/Ripple.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Ripple.xaml
@@ -50,20 +50,18 @@
 														 Storyboard.TargetProperty="ScaleX"
 														 Duration="0:0:0.225"
 														 From="0"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RippleSizeMultiplier}"
-														 FillBehavior="Stop">
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RippleSizeMultiplier}">
 											<DoubleAnimation.EasingFunction>
-												<CubicEase EasingMode="EaseInOut" />
+												<CubicEase EasingMode="EaseIn" />
 											</DoubleAnimation.EasingFunction>
 										</DoubleAnimation>
 										<DoubleAnimation Storyboard.TargetName="ScaleTransform"
 														 Storyboard.TargetProperty="ScaleY"
 														 Duration="0:0:0.225"
 														 From="0"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RippleSizeMultiplier}"
-														 FillBehavior="Stop">
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RippleSizeMultiplier}">
 											<DoubleAnimation.EasingFunction>
-												<CubicEase EasingMode="EaseInOut" />
+												<CubicEase EasingMode="EaseIn" />
 											</DoubleAnimation.EasingFunction>
 										</DoubleAnimation>
 										<win:DoubleAnimationUsingKeyFrames Storyboard.TargetName="ClickEllipse"
@@ -83,31 +81,34 @@
 											<EasingDoubleKeyFrame KeyTime="0:0:0.6"
 																  Value="1">
 												<EasingDoubleKeyFrame.EasingFunction>
-													<CubicEase EasingMode="EaseIn" />
+													<CubicEase EasingMode="EaseOut" />
 												</EasingDoubleKeyFrame.EasingFunction>
 											</EasingDoubleKeyFrame>
 											<EasingDoubleKeyFrame KeyTime="0:0:1"
 																  Value="0">
 												<EasingDoubleKeyFrame.EasingFunction>
-													<CubicEase EasingMode="EaseIn" />
+													<CubicEase EasingMode="EaseOut" />
 												</EasingDoubleKeyFrame.EasingFunction>
 											</EasingDoubleKeyFrame>
 										</win:DoubleAnimationUsingKeyFrames>
 										<not_win:DoubleAnimation Storyboard.TargetName="ClickEllipse"
-														 Storyboard.TargetProperty="Opacity"
-														 Duration="0:0:0.075"
-														 From="0"
-														 To="1">
+																 Storyboard.TargetProperty="Opacity"
+																 Duration="0:0:0.075"
+																 From="0"
+																 To="1">
 											<DoubleAnimation.EasingFunction>
 												<CubicEase EasingMode="EaseIn" />
 											</DoubleAnimation.EasingFunction>
 										</not_win:DoubleAnimation>
 										<not_win:DoubleAnimation Storyboard.TargetName="ClickEllipse"
-														 Storyboard.TargetProperty="Opacity"
-														 Duration="0:0:0.4"
-														 BeginTime="0:0:0.6"
-														 From="1"
-														 To="0">
+																 Storyboard.TargetProperty="Opacity"
+																 Duration="0:0:0.4"
+																 BeginTime="0:0:0.6"
+																 From="1"
+																 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseOut" />
+											</DoubleAnimation.EasingFunction>
 										</not_win:DoubleAnimation>
 									</Storyboard>
 								</VisualState>


### PR DESCRIPTION
﻿GitHub Issue: closes #627

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Fix an issue where the rippling animation of Ripple control were too fast to be observed.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information
RippleSizeMultiplier is reduced to 2 from 8, as it also is a multiplier for how fast the ripple is travelling if we only consider the visible area, not whats outside. The ScaleXY animation is using an `EaseIn` function, so that the bulk of it will happen in the 2nd half of the duration. The FillBehavior has been reverted back to the default `HoldEnd`, so the ellipse stays expanded for the full duration of the entire animation (225+150ms), instead of immediately reverting to scale-0 when the expansion ends (at 225ms).