### PR TITLE
fix: ChipGroup initial selection being lost

### DIFF
--- a/src/library/Uno.Material/Controls/Chips/ChipGroup.cs
+++ b/src/library/Uno.Material/Controls/Chips/ChipGroup.cs
@@ -185,6 +185,7 @@ namespace Uno.Material.Controls
 					container.ThumbnailTemplate = ThumbnailTemplate;
 				}
 
+				container.IsChecked = IsItemSelected(item);
 				container.CanRemove = CanRemove;
 
 				container.IsCheckedChanged += OnItemIsCheckedChanged;
@@ -194,6 +195,12 @@ namespace Uno.Material.Controls
 				container.Removing += OnItemRemoving;
 				container.Removed += OnItemRemoved;
 			}
+		}
+
+		private bool IsItemSelected(object item)
+		{
+			// It's important to use Equals and not == because of boxing.
+			return Equals(item, SelectedItem) || (SelectedItems?.Contains(item) ?? false);
 		}
 
 		protected override void ClearContainerForItemOverride(DependencyObject element, object item)
@@ -381,9 +388,11 @@ namespace Uno.Material.Controls
 			}
 		}
 
-		private bool IsReady => _isLoaded && HasItems;
+		private bool IsReady => _isLoaded && HasItems && HasContainers;
 
 		private bool HasItems => GetItems().Any();
+
+		private bool HasContainers => GetItemContainers().Any();
 
 		/// <summary>
 		/// Get the items.


### PR DESCRIPTION
﻿GitHub Issue: https://github.com/unoplatform/nventive-private/issues/290

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->

- Set proper initial `IsChecked` value on chips (when available).
- Avoid discarding initial selection when `ChipGroup` is not ready.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

This fix mainly affects the UWP behavior, in a case where all the ItemsSource and selection bindings would apply before any `Chip` container were created.

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

https://dev.azure.com/nventive/TradeZero/_workitems/edit/230007