### PR TITLE
fix: Auto-Capitalize Material Button Content

### DIFF
--- a/src/library/Uno.Material/Converters/ToUpperConverter.cs
+++ b/src/library/Uno.Material/Converters/ToUpperConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+#if WinUI
+using Microsoft.UI.Xaml.Data;
+#else
+using Windows.UI.Xaml.Data;
+#endif
+
+namespace Uno.Material.Converters
+{
+	public class ToUpperConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, string language)
+		{
+			return value is string text ? text.ToUpperInvariant() : value;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, string language)
+		{
+			return null;
+		}
+	}
+}

--- a/src/library/Uno.Material/Styles/Controls/Button.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Button.xaml
@@ -4,6 +4,7 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:controls="using:Uno.Material.Controls"
+					xmlns:converters="using:Uno.Material.Converters"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:android="http://uno.ui/android"
@@ -19,6 +20,7 @@
 	</ResourceDictionary.MergedDictionaries>
 
 	<!-- Documented variables -->
+	<converters:ToUpperConverter x:Key="ToUpperConverter"/>
 	<Thickness x:Key="MaterialButtonPadding">16,8</Thickness>
 	<CornerRadius x:Key="MaterialButtonCornerRadius">4</CornerRadius>
 	<x:Double x:Key="MaterialButtonFontSize">14</x:Double>
@@ -170,7 +172,7 @@
 													  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 									<ContentPresenter Grid.Column="1"
-													  Content="{TemplateBinding Content}"
+													  Content="{Binding Content, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource ToUpperConverter}}"
 													  ContentTemplate="{TemplateBinding ContentTemplate}"
 													  ContentTransitions="{TemplateBinding ContentTransitions}"
 													  FontFamily="{TemplateBinding FontFamily}"
@@ -342,7 +344,7 @@
 													  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 									<ContentPresenter Grid.Column="1"
-													  Content="{TemplateBinding Content}"
+													  Content="{Binding Content, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource ToUpperConverter}}"
 													  ContentTemplate="{TemplateBinding ContentTemplate}"
 													  ContentTransitions="{TemplateBinding ContentTransitions}"
 													  FontFamily="{TemplateBinding FontFamily}"
@@ -505,7 +507,7 @@
 													  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 									<ContentPresenter Grid.Column="1"
-													  Content="{TemplateBinding Content}"
+													  Content="{Binding Content, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource ToUpperConverter}}"
 													  ContentTemplate="{TemplateBinding ContentTemplate}"
 													  ContentTransitions="{TemplateBinding ContentTransitions}"
 													  FontFamily="{TemplateBinding FontFamily}"

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ButtonSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ButtonSamplePage.xaml
@@ -20,14 +20,14 @@
 						<!-- Button Contained -->
 						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_Contained"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<Button Content="CONTAINED"
+							<Button Content="Contained"
 									Style="{StaticResource MaterialContainedButtonStyle}" />
 						</smtx:XamlDisplay>
 
 						<!-- Button Contained Disabled -->
 						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_ContainedDisabled"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<Button Content="CONTAINED DISABLED"
+							<Button Content="Contained Disabled"
 									IsEnabled="False"
 									Style="{StaticResource MaterialContainedButtonStyle}" />
 						</smtx:XamlDisplay>
@@ -35,14 +35,14 @@
 						<!-- Button Outlined -->
 						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_Outline"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<Button Content="OUTLINED"
+							<Button Content="Outlined"
 									Style="{StaticResource MaterialOutlinedButtonStyle}" />
 						</smtx:XamlDisplay>
 
 						<!-- Button Outlined Disabled -->
 						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_OutlineDisabled"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<Button Content="OUTLINED DISABLED"
+							<Button Content="Outlined Disabled"
 									IsEnabled="False"
 									Style="{StaticResource MaterialOutlinedButtonStyle}" />
 						</smtx:XamlDisplay>
@@ -50,7 +50,7 @@
 						<!-- Button Text -->
 						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_Text"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<Button Content="TEXT"
+							<Button Content="Test"
 									Style="{StaticResource MaterialTextButtonStyle}" />
 						</smtx:XamlDisplay>
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## Description

Material styled Buttons will have their Content capitalized by default

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
