### PR TITLE
refactor: color overriding for ToggleSwitch

### DIFF
--- a/src/library/Uno.Material/Styles/Application/ColorPalette.xaml
+++ b/src/library/Uno.Material/Styles/Application/ColorPalette.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
 	<!--
@@ -40,10 +40,6 @@
 			<Color x:Key="MaterialBottomNavBackgroundColor">#5B4CF5</Color>
 			<Color x:Key="MaterialBottomNavForegroundColor">#FFFFFF</Color>
 
-			<!-- Toggle Switch -->
-			<Color x:Key="MaterialToggleSwitchButtonColor">#5B4CF5</Color>
-			<Color x:Key="MaterialToggleSwitchBackgroundColor">#B6A8FB</Color>
-			
 			<!-- Slider -->
 			<Color x:Key="MaterialSliderTrackColor">#999999</Color>
 			
@@ -83,10 +79,6 @@
 			<!-- Bottom Bar Navigation -->
 			<Color x:Key="MaterialBottomNavBackgroundColor">#292929</Color>
 			<Color x:Key="MaterialBottomNavForegroundColor">#B6A8FB</Color>
-
-			<!-- Toggle Switch -->
-			<Color x:Key="MaterialToggleSwitchButtonColor">#5B4CF5</Color>
-			<Color x:Key="MaterialToggleSwitchBackgroundColor">#B6A8FB</Color>
 
 			<!-- Slider -->
 			<Color x:Key="MaterialSliderTrackColor">#717171</Color>

--- a/src/library/Uno.Material/Styles/Controls/ToggleSwitch.xaml
+++ b/src/library/Uno.Material/Styles/Controls/ToggleSwitch.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:ios="http:///umbrella/ui/ios"
@@ -24,9 +24,9 @@
 
 	<!-- Toggle On -->
 	<SolidColorBrush x:Key="MaterialToggleSwitchOnButtonBrush"
-					 Color="{ThemeResource MaterialToggleSwitchButtonColor}" />
+					 Color="{ThemeResource MaterialPrimaryColor}" />
 	<SolidColorBrush x:Key="MaterialToggleSwitchOnBackgroundBrush"
-					 Color="{ThemeResource MaterialToggleSwitchBackgroundColor}" />
+					 Color="{ThemeResource MaterialPrimaryVariantLightColor}" />
 
 	<!-- Toggle Off -->
 	<StaticResource x:Key="MaterialToggleSwitchOffButtonBrush"
@@ -246,6 +246,11 @@
 											<DiscreteObjectKeyFrame KeyTime="0"
 																	Value="Collapsed" />
 										</ObjectAnimationUsingKeyFrames>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="SwitchKnobOffShadow"
+																	   Storyboard.TargetProperty="Visibility">
+											<DiscreteObjectKeyFrame KeyTime="0"
+																	Value="Visible" />
+										</ObjectAnimationUsingKeyFrames>
 									</Storyboard>
 								</VisualState>
 
@@ -261,6 +266,11 @@
 																	   Storyboard.TargetProperty="Visibility">
 											<DiscreteObjectKeyFrame KeyTime="0"
 																	Value="Visible" />
+										</ObjectAnimationUsingKeyFrames>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="SwitchKnobOffShadow"
+																	   Storyboard.TargetProperty="Visibility">
+											<DiscreteObjectKeyFrame KeyTime="0"
+																	Value="Collapsed" />
 										</ObjectAnimationUsingKeyFrames>
 
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HighlightBorder"


### PR DESCRIPTION
﻿GitHub Issue: unoplatform/nventive-private#320

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Refactoring (no functional changes, no api changes)

## Description
You are no longer required to redefine the follow resource in color override:
- `MaterialToggleSwitchButtonColor`
- `MaterialToggleSwitchBackgroundColor`

They will now be based on the material colors.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [ ] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS (not affected)
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information
ninja fix: mouse-over indicator not displaying primary/secondary color

## Internal Issue (If applicable):
unoplatform/nventive-private#320
