### PR TITLE
feat: Add ControlExtensions.AlternateContent and MaterialToggleButtonIconStyle

### DIFF
--- a/src/library/Uno.Material/Extensions/ControlExtensions.cs
+++ b/src/library/Uno.Material/Extensions/ControlExtensions.cs
@@ -17,7 +17,7 @@ namespace Uno.Material.Extensions
 	[Bindable]
 	public static class ControlExtensions
 	{
-#region Property: Icon
+#region DependencyProperty: Icon
 
 		public static DependencyProperty IconProperty { get; } = DependencyProperty.RegisterAttached(
 			"Icon",
@@ -27,6 +27,19 @@ namespace Uno.Material.Extensions
 
 		public static IconElement GetIcon(Control obj) => (IconElement)obj.GetValue(IconProperty);
 		public static void SetIcon(Control obj, IconElement value) => obj.SetValue(IconProperty, value);
+
+#endregion
+
+#region DependencyProperty: AlternateContent
+
+		public static DependencyProperty AlternateContentProperty { get; } = DependencyProperty.RegisterAttached(
+			"AlternateContent",
+			typeof(object),
+			typeof(ControlExtensions),
+			new PropertyMetadata(default(object)));
+
+		public static object GetAlternateContent(Control obj) => (object)obj.GetValue(AlternateContentProperty);
+		public static void SetAlternateContent(Control obj, object value) => obj.SetValue(AlternateContentProperty, value);
 
 #endregion
 	}

--- a/src/library/Uno.Material/Styles/Controls/ToggleButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/ToggleButton.xaml
@@ -4,6 +4,7 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:controls="using:Uno.Material.Controls"
+					xmlns:extensions="using:Uno.Material.Extensions"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:android="http://uno.ui/android"
@@ -13,13 +14,17 @@
 					mc:Ignorable="d ios android wasm not_win xamarin">
 
 	<ResourceDictionary.MergedDictionaries>
-		<MaterialColors xmlns="using:Uno.Material"/>
+		<MaterialColors xmlns="using:Uno.Material" />
 		<MaterialFonts xmlns="using:Uno.Material" />
 	</ResourceDictionary.MergedDictionaries>
 
-	<!-- Text ToggleButton Variables -->
+
+	<!-- ToggleButton Brushes -->
 	<SolidColorBrush x:Key="ToggleButtonTextLabelBrush"
 					 Color="{ThemeResource MaterialPrimaryColor}" />
+
+	<StaticResource x:Key="ToggleButtonForegroundThemeBrush"
+					ResourceKey="MaterialOnSurfaceBrush" />
 
 	<!-- Other ToggleButton Variables -->
 	<CornerRadius x:Key="ToggleButtonBorderRadius">4</CornerRadius>
@@ -170,6 +175,139 @@
 										 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 										 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
 										 AutomationProperties.AccessibilityView="Raw" />
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style x:Key="MaterialToggleButtonIconStyle"
+		   TargetType="ToggleButton">
+		<Setter Property="Foreground"
+				Value="{StaticResource ToggleButtonForegroundThemeBrush}" />
+		<Setter Property="Background"
+				Value="Transparent" />
+		<Setter Property="BorderThickness"
+				Value="0" />
+		<Setter Property="MinHeight"
+				Value="40" />
+		<Setter Property="MinWidth"
+				Value="40" />
+		<Setter Property="UseSystemFocusVisuals"
+				Value="True" />
+		<Setter Property="HorizontalContentAlignment"
+				Value="Center" />
+		<Setter Property="VerticalContentAlignment"
+				Value="Center" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="ToggleButton">
+					<Grid x:Name="RootGrid"
+						  Background="{TemplateBinding Background}"
+						  BorderBrush="{TemplateBinding BorderBrush}"
+						  BorderThickness="{TemplateBinding BorderThickness}">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal" />
+								<VisualState x:Name="PointerOver">
+									<VisualState.Setters>
+										<Setter Target="ContentPresenter.Visibility"
+												Value="Visible" />
+										<Setter Target="AlternateContentPresenter.Visibility"
+												Value="Collapsed" />
+										<Setter Target="HoverOverlay.Opacity"
+												Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="Pressed">
+									<VisualState.Setters>
+										<Setter Target="ContentPresenter.Visibility"
+												Value="Visible" />
+										<Setter Target="AlternateContentPresenter.Visibility"
+												Value="Collapsed" />
+										<Setter Target="PressedOverlay.Opacity"
+												Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="ContentPresenter.Visibility"
+												Value="Visible" />
+										<Setter Target="AlternateContentPresenter.Visibility"
+												Value="Collapsed" />
+										<Setter Target="ContentPresenter.Foreground"
+												Value="{StaticResource MaterialOnSurfaceLowBrush}" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="Checked">
+									<VisualState.Setters>
+										<Setter Target="ContentPresenter.Visibility"
+												Value="Collapsed" />
+										<Setter Target="AlternateContentPresenter.Visibility"
+												Value="Visible" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="CheckedPointerOver">
+									<VisualState.Setters>
+										<Setter Target="ContentPresenter.Visibility"
+												Value="Collapsed" />
+										<Setter Target="AlternateContentPresenter.Visibility"
+												Value="Visible" />
+										<Setter Target="HoverOverlay.Opacity"
+												Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="CheckedPressed">
+									<VisualState.Setters>
+										<Setter Target="ContentPresenter.Visibility"
+												Value="Collapsed" />
+										<Setter Target="AlternateContentPresenter.Visibility"
+												Value="Visible" />
+										<Setter Target="PressedOverlay.Opacity"
+												Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="CheckedDisabled">
+									<VisualState.Setters>
+										<Setter Target="ContentPresenter.Visibility"
+												Value="Collapsed" />
+										<Setter Target="AlternateContentPresenter.Visibility"
+												Value="Visible" />
+										<Setter Target="AlternateContentPresenter.Foreground"
+												Value="{StaticResource MaterialOnSurfaceLowBrush}" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+
+						<!-- Ellipse for PointedOver State -->
+						<Ellipse x:Name="HoverOverlay"
+								 HorizontalAlignment="Stretch"
+								 VerticalAlignment="Stretch"
+								 Fill="{StaticResource MaterialPrimaryHoverBrush}"
+								 Opacity="0" />
+
+						<!-- Ellipse for Pressed State -->
+						<Ellipse x:Name="PressedOverlay"
+								 HorizontalAlignment="Stretch"
+								 VerticalAlignment="Stretch"
+								 Fill="{StaticResource MaterialPrimaryPressedBrush}"
+								 Opacity="0" />
+
+						<!-- Content -->
+						<ContentPresenter x:Name="ContentPresenter"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Content="{TemplateBinding Content}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+
+						<!-- Alternate Content -->
+						<ContentPresenter x:Name="AlternateContentPresenter"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Content="{Binding Path=(extensions:ControlExtensions.AlternateContent), RelativeSource={RelativeSource TemplatedParent}}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  Visibility="Collapsed" />
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Extensions/ControlExtensionsSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Extensions/ControlExtensionsSamplePage.xaml
@@ -9,6 +9,10 @@
 	  xmlns:extensions="using:Uno.Material.Extensions"
 	  xmlns:smtx="using:ShowMeTheXAML"
 	  mc:Ignorable="d android ios">
+	<Page.Resources>
+		<x:String x:Key="Icon_more_horizontal">M 2 0 C 0.8999999761581421 0 0 0.8999999761581421 0 2 C 0 3.100000023841858 0.8999999761581421 4 2 4 C 3.100000023841858 4 4 3.100000023841858 4 2 C 4 0.8999999761581421 3.100000023841858 0 2 0 Z M 14 0 C 12.899999976158142 0 12 0.8999999761581421 12 2 C 12 3.100000023841858 12.899999976158142 4 14 4 C 15.100000023841858 4 16 3.100000023841858 16 2 C 16 0.8999999761581421 15.100000023841858 0 14 0 Z M 8 0 C 6.899999976158142 0 6 0.8999999761581421 6 2 C 6 3.100000023841858 6.899999976158142 4 8 4 C 9.100000023841858 4 10 3.100000023841858 10 2 C 10 0.8999999761581421 9.100000023841858 0 8 0 Z</x:String>
+		<x:String x:Key="Icon_more_vertical">M 2 4 C 3.100000023841858 4 4 3.100000023841858 4 2 C 4 0.8999999761581421 3.100000023841858 0 2 0 C 0.8999999761581421 0 0 0.8999999761581421 0 2 C 0 3.100000023841858 0.8999999761581421 4 2 4 Z M 2 6 C 0.8999999761581421 6 0 6.899999976158142 0 8 C 0 9.100000023841858 0.8999999761581421 10 2 10 C 3.100000023841858 10 4 9.100000023841858 4 8 C 4 6.899999976158142 3.100000023841858 6 2 6 Z M 2 12 C 0.8999999761581421 12 0 12.899999976158142 0 14 C 0 15.100000023841858 0.8999999761581421 16 2 16 C 3.100000023841858 16 4 15.100000023841858 4 14 C 4 12.899999976158142 3.100000023841858 12 2 12 Z</x:String>
+	</Page.Resources>
 
 	<ScrollViewer VerticalScrollBarVisibility="Auto">
 		<StackPanel BorderBrush="{StaticResource MaterialOnSurfaceBrush}"
@@ -17,12 +21,13 @@
 					ios:Margin="12"
 					Padding="12">
 
-			<TextBlock Text="ControlExtensions.Icon"
-					   Style="{StaticResource MaterialHeadline5}" />
-			<StackPanel>
-				<TextBlock Style="{StaticResource MaterialBody1}">
-				This property support a variety of icon sources:
-				</TextBlock>
+			<StackPanel Spacing="16">
+
+				<TextBlock Text="ControlExtensions.Icon"
+						   Style="{StaticResource MaterialHeadline5}" />
+
+				<TextBlock Text="This property support a variety of icon sources:"
+						   Style="{StaticResource MaterialBody1}" />
 
 				<!-- BitmapIcon -->
 				<StackPanel Orientation="Horizontal">
@@ -70,40 +75,70 @@
 					</smtx:XamlDisplay>
 					<smtx:XamlPresenter ReferenceKey="TextBlockSamplePage_SymbolIcon" />
 				</StackPanel>
+
+				<TextBlock Text="Supported controls"
+						   Margin="0,16,0,0"
+						   Style="{StaticResource MaterialHeadline6}" />
+
+				<!-- TextBox -->
+				<TextBlock Text="TextBox"
+						   Style="{StaticResource MaterialSubtitle1}" />
+				<smtx:XamlDisplay UniqueKey="ControlExtensionsSamplePage_TextBox"
+								  Style="{StaticResource XamlDisplayBelowStyle}">
+					<TextBox PlaceholderText="Filled"
+							 Style="{StaticResource MaterialFilledTextBoxStyle}">
+						<extensions:ControlExtensions.Icon>
+							<SymbolIcon Symbol="SolidStar"
+										Foreground="{StaticResource MaterialPrimaryBrush}" />
+						</extensions:ControlExtensions.Icon>
+					</TextBox>
+				</smtx:XamlDisplay>
+
+				<!-- ComboBox -->
+				<TextBlock Text="ComboBox"
+						   Style="{StaticResource MaterialSubtitle1}" />
+				<smtx:XamlDisplay UniqueKey="ControlExtensionsSamplePage_ComboBox"
+								  Style="{StaticResource XamlDisplayBelowStyle}">
+					<ComboBox Style="{StaticResource MaterialComboBoxStyle}"
+							  PlaceholderText="Placeholder"
+							  ItemsSource="abcdefg">
+						<extensions:ControlExtensions.Icon>
+							<SymbolIcon Symbol="SolidStar"
+										Foreground="{StaticResource MaterialPrimaryBrush}" />
+						</extensions:ControlExtensions.Icon>
+					</ComboBox>
+				</smtx:XamlDisplay>
+
 			</StackPanel>
 
-			<TextBlock Text="Supported controls"
-					   Margin="0,16,0,0"
-					   Style="{StaticResource MaterialHeadline6}" />
+			<StackPanel Spacing="16">
 
-			<!-- TextBox -->
-			<TextBlock Text="TextBox"
-					   Style="{StaticResource MaterialSubtitle1}" />
-			<smtx:XamlDisplay UniqueKey="ControlExtensionsSamplePage_TextBox"
-							  Style="{StaticResource XamlDisplayBelowStyle}">
-				<TextBox PlaceholderText="Filled"
-						 Style="{StaticResource MaterialFilledTextBoxStyle}">
-					<extensions:ControlExtensions.Icon>
-						<SymbolIcon Symbol="SolidStar"
-									Foreground="{StaticResource MaterialPrimaryBrush}" />
-					</extensions:ControlExtensions.Icon>
-				</TextBox>
-			</smtx:XamlDisplay>
+				<TextBlock Text="ControlExtensions.AlternateContent"
+						   Style="{StaticResource MaterialHeadline5}" />
 
-			<!-- ComboBox -->
-			<TextBlock Text="ComboBox"
-					   Style="{StaticResource MaterialSubtitle1}" />
-			<smtx:XamlDisplay UniqueKey="ControlExtensionsSamplePage_ComboBox"
-							  Style="{StaticResource XamlDisplayBelowStyle}">
-				<ComboBox Style="{StaticResource MaterialComboBoxStyle}"
-						  PlaceholderText="Placeholder"
-						  ItemsSource="abcdefg">
-					<extensions:ControlExtensions.Icon>
-						<SymbolIcon Symbol="SolidStar"
-									Foreground="{StaticResource MaterialPrimaryBrush}" />
-					</extensions:ControlExtensions.Icon>
-				</ComboBox>
-			</smtx:XamlDisplay>
+				<TextBlock Text="This property can be used in order to have an alternate content for some controls:"
+						   Style="{StaticResource MaterialBody1}" />
+
+				<smtx:XamlDisplay UniqueKey="ControlExtensionsSamplePage_ToggleButtonText"
+								  Style="{StaticResource XamlDisplayBelowStyle}">
+					<ToggleButton Content="On"
+								  extensions:ControlExtensions.AlternateContent="Off"
+								  Style="{StaticResource MaterialTextToggleButtonStyle}" />
+				</smtx:XamlDisplay>
+
+						<smtx:XamlDisplay UniqueKey="ControlExtensionsSamplePage_ToggleButtonIcon"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<ToggleButton Style="{StaticResource MaterialToggleButtonIconStyle}">
+								<ToggleButton.Content>
+									<PathIcon Data="{StaticResource Icon_more_horizontal}" />
+								</ToggleButton.Content>
+								<extensions:ControlExtensions.AlternateContent>
+									<PathIcon Data="{StaticResource Icon_more_vertical}" />
+								</extensions:ControlExtensions.AlternateContent>
+							</ToggleButton>
+						</smtx:XamlDisplay>
+
+			</StackPanel>
 		</StackPanel>
 	</ScrollViewer>
 </Page>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Extensions/ControlExtensionsSamplePage.xaml.cs
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Extensions/ControlExtensionsSamplePage.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.Themes.Samples.Entities;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.UI.Xaml;
@@ -13,13 +14,9 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace Uno.Themes.Samples.Shared.Content.Extensions
 {
-	/// <summary>
-	/// An empty page that can be used on its own or navigated to within a Frame.
-	/// </summary>
+	[SamplePage(SampleCategory.Helpers, "ControlExtensions")]
 	public sealed partial class ControlExtensionsSamplePage : Page
 	{
 		public ControlExtensionsSamplePage()


### PR DESCRIPTION
GitHub Issue: https://github.com/unoplatform/uno.ui.toolkit/issues/81

## PR Type

What kind of change does this PR introduce?

- Feature


## Description

Add ControlExtensions.AlternateContent and MaterialToggleButtonIconStyle


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [X] Tested UWP
- [X] Tested iOS
- [X] Tested Android
- [X] Tested WASM
- [ ] Tested MacOS
- [X] Contains **No** breaking changes
