### PR TITLE
fix: Don't override default SplitView style when not explicitly requested

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/NavigationView/WUX/NavigationView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/NavigationView/WUX/NavigationView.xaml
@@ -328,6 +328,7 @@
 							</StackPanel>
 
 							<SplitView x:Name="RootSplitView"
+									   xamarin:Style="{StaticResource DrawerSplitViewStyle}"
 									   Background="{TemplateBinding Background}"
 									   CompactPaneLength="{TemplateBinding CompactPaneLength}"
 									   DisplayMode="Inline"

--- a/src/library/Uno.Material/Styles/Controls/NavigationView/WUX/NavigationView_SplitView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/NavigationView/WUX/NavigationView_SplitView.xaml
@@ -12,11 +12,11 @@
 					xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
 					mc:Ignorable="d ios android wasm not_win xamarin primitives">
 
-	<SolidColorBrush x:Key="SplitViewDismissBackgroundBrush"
+	<SolidColorBrush x:Key="DrawerSplitViewDismissBackgroundBrush"
 					 Color="Black"
 					 Opacity="0.5" />
 
-	<ios:Style x:Key="DefaultSplitViewStyle"
+	<ios:Style x:Key="DrawerSplitViewStyle"
 			   TargetType="SplitView">
 		<Setter Property="HorizontalContentAlignment"
 				Value="Stretch" />
@@ -585,7 +585,7 @@
 											VerticalAlignment="Stretch">
 								<Button.Template>
 									<ControlTemplate>
-										<Border Background="{StaticResource SplitViewDismissBackgroundBrush}" />
+										<Border Background="{StaticResource DrawerSplitViewDismissBackgroundBrush}" />
 									</ControlTemplate>
 								</Button.Template>
 							</xamarin:Button>
@@ -615,7 +615,7 @@
 		</Setter>
 	</ios:Style>
 
-	<android:Style x:Key="DefaultSplitViewStyle"
+	<android:Style x:Key="DrawerSplitViewStyle"
 				   TargetType="SplitView">
 		<Setter Property="OpenPaneLength"
 				Value="{StaticResource NativeDefaultSplitViewOpenPaneLength}" />
@@ -634,8 +634,5 @@
 			</Setter.Value>
 		</Setter>
 	</android:Style>
-
-	<xamarin:Style TargetType="SplitView"
-				   BasedOn="{StaticResource DefaultSplitViewStyle}" />
 
 </ResourceDictionary>


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

The WUX `NavigationView` styles overrides the default `SplitView` style on Android and iOS, which then applies this "drawer-based" split view even to MUX `NavigationView` which is then broken (as `Compact` pane mode is enabled there).

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [x] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
