### PR TITLE
refactor!: Move everything under the Uno.Material namespace

### DIFF
--- a/src/library/Uno.Cupertino/Styles/Controls/Button.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/Button.xaml
@@ -1,20 +1,12 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:android="http://uno.ui/android"
-					xmlns:controls="using:Uno.Material.Controls"
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-					xmlns:ios="http://uno.ui/ios"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:wasm="http://uno.ui/wasm"
-					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					mc:Ignorable="d ios android wasm not_win">
+					mc:Ignorable="d">
 
 	<ResourceDictionary.MergedDictionaries>
-		<CupertinoColors xmlns="using:Uno.Cupertino"/>
-		<CupertinoFonts xmlns="using:Uno.Cupertino"/>
+		<CupertinoColors xmlns="using:Uno.Cupertino" />
+		<CupertinoFonts xmlns="using:Uno.Cupertino" />
 		<ResourceDictionary Source="../Application/AnimationConstants.xaml" />
 	</ResourceDictionary.MergedDictionaries>
 

--- a/src/library/Uno.Cupertino/Styles/Controls/HyperlinkButton.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/HyperlinkButton.xaml
@@ -2,13 +2,13 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:winui="using:Microsoft.UI.Xaml.Controls"
 					mc:Ignorable="d">
 
 	<ResourceDictionary.MergedDictionaries>
-		<CupertinoColors xmlns="using:Uno.Cupertino"/>
-		<CupertinoFonts xmlns="using:Uno.Cupertino"/>
+		<CupertinoColors xmlns="using:Uno.Cupertino" />
+		<CupertinoFonts xmlns="using:Uno.Cupertino" />
 	</ResourceDictionary.MergedDictionaries>
+
 	<FontFamily x:Key="CupertinoHyperlinkButtonFontFamily">SF Pro</FontFamily>
 	<x:String x:Key="MinusGlyphPathStyle">M0 1.67236H5.57812V0.327637H0V1.67236Z</x:String>
 

--- a/src/library/Uno.Cupertino/Styles/Controls/NumberBox.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/NumberBox.xaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:winui="using:Microsoft.UI.Xaml.Controls"
-					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+					xmlns:muxc="using:Microsoft.UI.Xaml.Controls">
 
 	<ResourceDictionary.MergedDictionaries>
 		<CupertinoColors xmlns="using:Uno.Cupertino"/>
@@ -28,7 +27,7 @@
 	<CornerRadius x:Key="CupertinoCornerRadius">8</CornerRadius>
 
 	<Style	x:Name="CupertinoNumberBoxStyle"
-			TargetType="winui:NumberBox">
+			TargetType="muxc:NumberBox">
 		<Setter Property="FontFamily"
 				Value="{StaticResource CupertinoFontFamily}" />
 		<Setter Property="Background"
@@ -43,7 +42,7 @@
 				Value="7" />
 		<Setter Property="Template">
 			<Setter.Value>
-				<ControlTemplate TargetType="winui:NumberBox">
+				<ControlTemplate TargetType="muxc:NumberBox">
 					<Grid>
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">

--- a/src/library/Uno.Cupertino/Styles/Controls/ProgressBar.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/ProgressBar.xaml
@@ -2,15 +2,15 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:winui="using:Microsoft.UI.Xaml.Controls"
+					xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 					mc:Ignorable="d">
 
 	<ResourceDictionary.MergedDictionaries>
-		<CupertinoColors xmlns="using:Uno.Cupertino"/>
+		<CupertinoColors xmlns="using:Uno.Cupertino" />
 	</ResourceDictionary.MergedDictionaries>
 
 	<Style x:Key="CupertinoProgressBarStyle"
-		   TargetType="winui:ProgressBar">
+		   TargetType="muxc:ProgressBar">
 		<Setter Property="Foreground"
 				Value="{StaticResource CupertinoBlueBrush}" />
 		<Setter Property="Background"

--- a/src/library/Uno.Cupertino/Styles/Controls/ProgressRing.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/ProgressRing.xaml
@@ -1,39 +1,39 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                    xmlns:lottie="using:Microsoft.Toolkit.Uwp.UI.Lottie"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:not_win="http://uno.ui/not_win"
-                    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:winui="using:Microsoft.UI.Xaml.Controls"
-                    mc:Ignorable="d not_win">
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+					xmlns:lottie="using:Microsoft.Toolkit.Uwp.UI.Lottie"
+					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+					xmlns:not_win="http://uno.ui/not_win"
+					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+					mc:Ignorable="d not_win">
 
 	<ResourceDictionary.MergedDictionaries>
-		<CupertinoColors xmlns="using:Uno.Cupertino"/>
+		<CupertinoColors xmlns="using:Uno.Cupertino" />
 		<win:ResourceDictionary>
 			<lottie:LottieVisualSource x:Key="CupertinoDeterminateAnimation"
-			                           UriSource="ms-appx:///Uno.Cupertino/Assets/CupertinoProgressRing.json" />
+									   UriSource="ms-appx:///Uno.Cupertino/Assets/CupertinoProgressRing.json" />
 			<lottie:LottieVisualSource x:Key="CupertinoIndeterminateAnimation"
-			                           UriSource="ms-appx:///Uno.Cupertino/Assets/CupertinoProgressRing.json" />
+									   UriSource="ms-appx:///Uno.Cupertino/Assets/CupertinoProgressRing.json" />
 		</win:ResourceDictionary>
 		<not_win:ResourceDictionary>
 			<lottie:LottieVisualSource x:Key="CupertinoDeterminateAnimation"
-			                           UriSource="embedded://Uno.Cupertino/Uno.Cupertino.Assets.CupertinoProgressRing.json" />
+									   UriSource="embedded://Uno.Cupertino/Uno.Cupertino.Assets.CupertinoProgressRing.json" />
 			<lottie:LottieVisualSource x:Key="CupertinoIndeterminateAnimation"
-			                           UriSource="embedded://Uno.Cupertino/Uno.Cupertino.Assets.CupertinoProgressRing.json" />
+									   UriSource="embedded://Uno.Cupertino/Uno.Cupertino.Assets.CupertinoProgressRing.json" />
 		</not_win:ResourceDictionary>
 	</ResourceDictionary.MergedDictionaries>
 
 
 
 	<Style x:Key="CupertinoProgressRingStyle"
-	       TargetType="winui:ProgressRing">
+		   TargetType="muxc:ProgressRing">
 		<Setter Property="DeterminateSource"
-		        Value="{StaticResource CupertinoDeterminateAnimation}" />
+				Value="{StaticResource CupertinoDeterminateAnimation}" />
 		<Setter Property="IndeterminateSource"
-		        Value="{StaticResource CupertinoIndeterminateAnimation}" />
+				Value="{StaticResource CupertinoIndeterminateAnimation}" />
 		<Setter Property="Foreground"
-		        Value="{StaticResource CupertinoPrimaryGrayBrush}" />
+				Value="{StaticResource CupertinoPrimaryGrayBrush}" />
 	</Style>
 
 </ResourceDictionary>

--- a/src/library/Uno.Cupertino/Uno.Cupertino.csproj
+++ b/src/library/Uno.Cupertino/Uno.Cupertino.csproj
@@ -64,14 +64,14 @@
 			</PropertyGroup>
 
 			<ItemGroup>
-				<PackageReference Include="Uno.UI" Version="4.0.0-dev.5676" />
+				<PackageReference Include="Uno.UI" Version="4.0.7" />
 			</ItemGroup>
 			<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">
 				<PackageReference Include="Microsoft.UI.Xaml" Version="2.6.0-prerelease.210113001" />
 				<PackageReference Include="Microsoft.Toolkit.Uwp.UI.Lottie" Version="6.1.0" />
 			</ItemGroup>
 			<ItemGroup Condition="'$(TargetFramework)'!='uap10.0.18362'">
-				<PackageReference Include="Uno.UI.Lottie" Version="4.0.0-dev.5676" />
+				<PackageReference Include="Uno.UI.Lottie" Version="4.0.7" />
 			</ItemGroup>
 
 			<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">

--- a/src/library/Uno.Material/Controls/Ripple.cs
+++ b/src/library/Uno.Material/Controls/Ripple.cs
@@ -19,7 +19,7 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 #endif
 
-namespace Uno.Material.Controls
+namespace Uno.Material
 {
 	/*
 	 * Starting implementation acknowledgement from project https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/2740f14a814896d42032ae0013b765a8a0ec04c3/MaterialDesignThemes.Uwp/Ripple.cs

--- a/src/library/Uno.Material/Converters/FirstCharacterConverter.cs
+++ b/src/library/Uno.Material/Converters/FirstCharacterConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 using Windows.UI.Xaml.Data;
 #endif
 
-namespace Uno.Material.Converters
+namespace Uno.Material
 {
 	public class FirstCharacterConverter : IValueConverter
 	{

--- a/src/library/Uno.Material/Converters/FromBoolToValueConverter.cs
+++ b/src/library/Uno.Material/Converters/FromBoolToValueConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 using Windows.UI.Xaml.Data;
 #endif
 
-namespace Uno.Material.Converters
+namespace Uno.Material
 {
 	public class FromBoolToValueConverter : IValueConverter
 	{

--- a/src/library/Uno.Material/Converters/FromEmptyStringOrNullObjectToValueConverter.cs
+++ b/src/library/Uno.Material/Converters/FromEmptyStringOrNullObjectToValueConverter.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
 #endif
 
-namespace Uno.Material.Converters
+namespace Uno.Material
 {
 	public class FromEmptyStringOrNullObjectToValueConverter : IValueConverter
 	{

--- a/src/library/Uno.Material/Converters/FromEmptyStringToValueConverter.cs
+++ b/src/library/Uno.Material/Converters/FromEmptyStringToValueConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 using Windows.UI.Xaml.Data;
 #endif
 
-namespace Uno.Material.Converters
+namespace Uno.Material
 {
 	public class FromEmptyStringToValueConverter : IValueConverter
 	{

--- a/src/library/Uno.Material/Converters/FromNullToValueConverter.cs
+++ b/src/library/Uno.Material/Converters/FromNullToValueConverter.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
 #endif
 
-namespace Uno.Material.Converters
+namespace Uno.Material
 {
 	public class FromNullToValueConverter : IValueConverter
 	{

--- a/src/library/Uno.Material/Converters/FromOpenToCustomValueConverter.cs
+++ b/src/library/Uno.Material/Converters/FromOpenToCustomValueConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 using Windows.UI.Xaml.Data;
 #endif
 
-namespace Uno.Material.Converters
+namespace Uno.Material
 {
 	public class FromOpenToCustomValueConverter : IValueConverter
 	{

--- a/src/library/Uno.Material/Converters/StringFormatConverter.cs
+++ b/src/library/Uno.Material/Converters/StringFormatConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 using Windows.UI.Xaml.Data;
 #endif
 
-namespace Uno.Material.Converters
+namespace Uno.Material
 {
 	public class StringFormatConverter : IValueConverter
 	{

--- a/src/library/Uno.Material/Converters/ToUpperConverter.cs
+++ b/src/library/Uno.Material/Converters/ToUpperConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 using Windows.UI.Xaml.Data;
 #endif
 
-namespace Uno.Material.Converters
+namespace Uno.Material
 {
 	public class ToUpperConverter : IValueConverter
 	{

--- a/src/library/Uno.Material/Extensions/ControlExtensions.cs
+++ b/src/library/Uno.Material/Extensions/ControlExtensions.cs
@@ -12,7 +12,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Controls;
 #endif
 
-namespace Uno.Material.Extensions
+namespace Uno.Material
 {
 	[Bindable]
 	public static class ControlExtensions

--- a/src/library/Uno.Material/Extensions/EnumerableExtensions.cs
+++ b/src/library/Uno.Material/Extensions/EnumerableExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Uno.Material.Extensions
+namespace Uno.Material
 {
 	internal static class EnumerableExtensions
 	{

--- a/src/library/Uno.Material/Extensions/StoryboardExtensions.cs
+++ b/src/library/Uno.Material/Extensions/StoryboardExtensions.cs
@@ -9,7 +9,7 @@ using Microsoft.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Media.Animation;
 #endif
 
-namespace Uno.Material.Extensions
+namespace Uno.Material
 {
 	internal static class StoryboardExtensions
 	{

--- a/src/library/Uno.Material/Helpers/ControlHelper.cs
+++ b/src/library/Uno.Material/Helpers/ControlHelper.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 #endif
 
-namespace Uno.Material.Helpers
+namespace Uno.Material
 {
 	internal static class ControlHelper
 	{

--- a/src/library/Uno.Material/LinkerConfig.xml
+++ b/src/library/Uno.Material/LinkerConfig.xml
@@ -1,6 +1,6 @@
 ﻿<linker>
 	<assembly fullname="Uno.Material">
 		<!-- required for attached properties to persist -->
-		<type fullname="Uno.Material.Extensions*" />
+		<type fullname="Uno.Material*" />
 	</assembly>
 </linker>

--- a/src/library/Uno.Material/Styles/Application/Converters.xaml
+++ b/src/library/Uno.Material/Styles/Application/Converters.xaml
@@ -1,49 +1,50 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:converters="using:Uno.Material.Converters">
+					xmlns:um="using:Uno.Material">
 
-	<converters:FromBoolToValueConverter x:Name="MaterialTrueToVisible"
-										 TrueValue="Visible"
-										 FalseValue="Collapsed"
-										 NullValue="Collapsed" />
+	<um:FromBoolToValueConverter x:Name="MaterialTrueToVisible"
+								 TrueValue="Visible"
+								 FalseValue="Collapsed"
+								 NullValue="Collapsed" />
 
-	<converters:FromBoolToValueConverter x:Name="MaterialTrueToCollapsed"
-										 TrueValue="Collapsed"
-										 FalseValue="Visible"
-										 NullValue="Visible" />
+	<um:FromBoolToValueConverter x:Name="MaterialTrueToCollapsed"
+								 TrueValue="Collapsed"
+								 FalseValue="Visible"
+								 NullValue="Visible" />
+
+	<um:FromEmptyStringToValueConverter x:Key="MaterialEmptyToFalse"
+										NotNullOrEmptyValue="True"
+										NullOrEmptyValue="False" />
+
+	<um:FromEmptyStringToValueConverter x:Key="MaterialEmptyToTrue"
+										NotNullOrEmptyValue="False"
+										NullOrEmptyValue="True" />
+
+	<um:FromEmptyStringToValueConverter x:Key="MaterialEmptyToVisible"
+										NotNullOrEmptyValue="Collapsed"
+										NullOrEmptyValue="Visible" />
+
+	<um:FromEmptyStringToValueConverter x:Key="MaterialEmptyToCollapsed"
+										NotNullOrEmptyValue="Visible"
+										NullOrEmptyValue="Collapsed" />
+
+	<um:FromNullToValueConverter x:Key="MaterialNullToCollapsedConverter"
+								 NotNullValue="Visible"
+								 NullValue="Collapsed" />
+
+	<um:FromNullToValueConverter x:Key="MaterialNullToVisibleConverter"
+								 NotNullValue="Visible"
+								 NullValue="Collapsed" />
+
+	<um:FromEmptyStringOrNullObjectToValueConverter x:Key="MaterialEmptyOrNullToVisible"
+													NotEmptyOrNullValue="Collapsed"
+													EmptyOrNullValue="Visible" />
+
+	<um:FromEmptyStringOrNullObjectToValueConverter x:Key="MaterialEmptyOrNullToCollapsed"
+													NotEmptyOrNullValue="Visible"
+													EmptyOrNullValue="Collapsed" />
+
+	<um:StringFormatConverter x:Key="StringFormatConverter" />
+	<um:FirstCharacterConverter x:Key="FirstCharacterConverter" />
 	
-	<converters:FromEmptyStringToValueConverter x:Key="MaterialEmptyToFalse"
-												NotNullOrEmptyValue="True"
-												NullOrEmptyValue="False" />
-
-	<converters:FromEmptyStringToValueConverter x:Key="MaterialEmptyToTrue"
-												NotNullOrEmptyValue="False"
-												NullOrEmptyValue="True" />
-
-	<converters:FromEmptyStringToValueConverter x:Key="MaterialEmptyToVisible"
-												NotNullOrEmptyValue="Collapsed"
-												NullOrEmptyValue="Visible" />
-
-	<converters:FromEmptyStringToValueConverter x:Key="MaterialEmptyToCollapsed"
-												NotNullOrEmptyValue="Visible"
-												NullOrEmptyValue="Collapsed" />
-
-	<converters:FromNullToValueConverter x:Key="MaterialNullToCollapsedConverter"
-										 NotNullValue="Visible"
-										 NullValue="Collapsed" />
-
-	<converters:FromNullToValueConverter x:Key="MaterialNullToVisibleConverter"
-										 NotNullValue="Visible"
-										 NullValue="Collapsed" />
-
-	<converters:FromEmptyStringOrNullObjectToValueConverter x:Key="MaterialEmptyOrNullToVisible"
-															NotEmptyOrNullValue="Collapsed"
-															EmptyOrNullValue="Visible" />
-
-	<converters:FromEmptyStringOrNullObjectToValueConverter x:Key="MaterialEmptyOrNullToCollapsed"
-															NotEmptyOrNullValue="Visible"
-															EmptyOrNullValue="Collapsed" />
-	
-	<converters:StringFormatConverter x:Key="StringFormatConverter"/>
-	<converters:FirstCharacterConverter x:Key="FirstCharacterConverter" />
 </ResourceDictionary>

--- a/src/library/Uno.Material/Styles/Controls/Button.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Button.xaml
@@ -3,16 +3,9 @@
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:controls="using:Uno.Material.Controls"
-					xmlns:converters="using:Uno.Material.Converters"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:ios="http://uno.ui/ios"
-					xmlns:android="http://uno.ui/android"
-					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:wasm="http://uno.ui/wasm"
+					xmlns:um="using:Uno.Material"
 					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:extensions="using:Uno.Material.Extensions"
-					mc:Ignorable="d ios android wasm not_win">
+					mc:Ignorable="d not_win">
 
 	<ResourceDictionary.MergedDictionaries>
 		<MaterialFonts xmlns="using:Uno.Material" />
@@ -20,7 +13,7 @@
 	</ResourceDictionary.MergedDictionaries>
 
 	<!-- Documented variables -->
-	<converters:ToUpperConverter x:Key="ToUpperConverter"/>
+	<um:ToUpperConverter x:Key="ToUpperConverter"/>
 	<Thickness x:Key="MaterialButtonPadding">16,8</Thickness>
 	<CornerRadius x:Key="MaterialButtonCornerRadius">4</CornerRadius>
 	<x:Double x:Key="MaterialButtonFontSize">14</x:Double>
@@ -145,7 +138,7 @@
 								Background="{TemplateBinding Foreground}"
 								Opacity="0" />
 
-						<controls:Ripple x:Name="ContentPresenter"
+						<um:Ripple x:Name="ContentPresenter"
 										 Feedback="{TemplateBinding Foreground}"
 										 FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
 										 BorderBrush="{TemplateBinding BorderBrush}"
@@ -155,7 +148,7 @@
 										 AutomationProperties.AccessibilityView="Raw"
 										 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
 										 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
-							<controls:Ripple.Content>
+							<um:Ripple.Content>
 								<Grid>
 									<Grid.ColumnDefinitions>
 										<ColumnDefinition Width="Auto" />
@@ -163,7 +156,7 @@
 									</Grid.ColumnDefinitions>
 
 									<ContentPresenter x:Name="IconPresenter"
-													  Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
+													  Content="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
 													  Margin="0,0,8,0"
 													  MaxHeight="34"
 													  MaxWidth="34"
@@ -171,7 +164,7 @@
 													  HorizontalAlignment="Stretch"
 													  VerticalAlignment="Stretch"
 													  VerticalContentAlignment="Center"
-													  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+													  Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 									<ContentPresenter Grid.Column="1"
 													  Content="{Binding Content, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource ToUpperConverter}}"
@@ -183,8 +176,8 @@
 													  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 													  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
 								</Grid>
-							</controls:Ripple.Content>
-						</controls:Ripple>
+							</um:Ripple.Content>
+						</um:Ripple>
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>
@@ -319,7 +312,7 @@
 								Background="{TemplateBinding Foreground}"
 								Opacity="0" />
 
-						<controls:Ripple x:Name="ContentPresenter"
+						<um:Ripple x:Name="ContentPresenter"
 										 Feedback="{TemplateBinding Foreground}"
 										 FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
 										 BorderBrush="{TemplateBinding BorderBrush}"
@@ -329,7 +322,7 @@
 										 AutomationProperties.AccessibilityView="Raw"
 										 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
 										 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
-							<controls:Ripple.Content>
+							<um:Ripple.Content>
 								<Grid>
 									<Grid.ColumnDefinitions>
 										<ColumnDefinition Width="Auto" />
@@ -337,7 +330,7 @@
 									</Grid.ColumnDefinitions>
 
 									<ContentPresenter x:Name="IconPresenter"
-													  Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
+													  Content="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
 													  Margin="0,0,8,0"
 													  MaxHeight="34"
 													  MaxWidth="34"
@@ -345,7 +338,7 @@
 													  HorizontalAlignment="Stretch"
 													  VerticalAlignment="Stretch"
 													  VerticalContentAlignment="Center"
-													  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+													  Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 									<ContentPresenter Grid.Column="1"
 													  Content="{Binding Content, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource ToUpperConverter}}"
@@ -357,8 +350,8 @@
 													  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 													  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
 								</Grid>
-							</controls:Ripple.Content>
-						</controls:Ripple>
+							</um:Ripple.Content>
+						</um:Ripple>
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>
@@ -484,7 +477,7 @@
 								Background="{TemplateBinding Foreground}"
 								Opacity="0" />
 
-						<controls:Ripple x:Name="ContentPresenter"
+						<um:Ripple x:Name="ContentPresenter"
 										 Feedback="{TemplateBinding Foreground}"
 										 FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
 										 BorderBrush="{TemplateBinding BorderBrush}"
@@ -494,7 +487,7 @@
 										 AutomationProperties.AccessibilityView="Raw"
 										 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
 										 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
-							<controls:Ripple.Content>
+							<um:Ripple.Content>
 								<Grid>
 									<Grid.ColumnDefinitions>
 										<ColumnDefinition Width="Auto" />
@@ -502,7 +495,7 @@
 									</Grid.ColumnDefinitions>
 
 									<ContentPresenter x:Name="IconPresenter"
-													  Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
+													  Content="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
 													  Margin="0,0,8,0"
 													  MaxHeight="34"
 													  MaxWidth="34"
@@ -510,7 +503,7 @@
 													  HorizontalAlignment="Stretch"
 													  VerticalAlignment="Stretch"
 													  VerticalContentAlignment="Center"
-													  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+													  Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 									<ContentPresenter Grid.Column="1"
 													  Content="{Binding Content, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource ToUpperConverter}}"
@@ -522,8 +515,8 @@
 													  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 													  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
 								</Grid>
-							</controls:Ripple.Content>
-						</controls:Ripple>
+							</um:Ripple.Content>
+						</um:Ripple>
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>

--- a/src/library/Uno.Material/Styles/Controls/CalendarDatePicker.xaml
+++ b/src/library/Uno.Material/Styles/Controls/CalendarDatePicker.xaml
@@ -1,19 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:converters="using:Uno.Material.Converters"
-					xmlns:android="http://uno.ui/android"
-					xmlns:ios="http://uno.ui/ios"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:wasm="http://uno.ui/wasm"
-					xmlns:uno="using:Uno.UI.Xaml.Controls"
-					mc:Ignorable="ios android wasm not_win">
+					mc:Ignorable="not_win">
 
 	<ResourceDictionary.MergedDictionaries>
-		<MaterialColors xmlns="using:Uno.Material"/>
+		<MaterialColors xmlns="using:Uno.Material" />
 		<ResourceDictionary Source="CalendarView.xaml" />
 	</ResourceDictionary.MergedDictionaries>
+	
 	<Style x:Key="DefaultMaterialCalendarDatePickerStyle"
 		   TargetType="CalendarDatePicker">
 		<Setter Property="Foreground"
@@ -35,7 +30,7 @@
 		<Setter Property="UseSystemFocusVisuals"
 				Value="{ThemeResource IsApplicationFocusVisualKindReveal}" />
 		<not_win:Setter Property="CornerRadius"
-				Value="{ThemeResource ControlCornerRadius}" />
+						Value="{ThemeResource ControlCornerRadius}" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="CalendarDatePicker">

--- a/src/library/Uno.Material/Styles/Controls/CalendarView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/CalendarView.xaml
@@ -1,22 +1,15 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:converters="using:Uno.Material.Converters"
-					xmlns:android="http://uno.ui/android"
-					xmlns:ios="http://uno.ui/ios"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:wasm="http://uno.ui/wasm"
-					xmlns:uno="using:Uno.UI.Xaml.Controls"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					mc:Ignorable="ios android wasm not_win">
+					mc:Ignorable="not_win">
 
 	<ResourceDictionary.MergedDictionaries>
 		<MaterialColors xmlns="using:Uno.Material" />
 		<MaterialFonts xmlns="using:Uno.Material" />
 	</ResourceDictionary.MergedDictionaries>
 
-	
 	<x:String x:Key="DownArrowPathData">M0,0L32,0 16,19.745z</x:String>
 
 	<Style x:Key="DefaultMaterialCalendarViewStyle"
@@ -313,7 +306,9 @@
 								<Border x:Name="BackgroundLayer"
 										Background="{TemplateBinding BorderBrush}">
 									<Border.RenderTransform>
-										<ScaleTransform x:Name="BackgroundTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
+										<ScaleTransform x:Name="BackgroundTransform"
+														CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}"
+														CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
 									</Border.RenderTransform>
 								</Border>
 								<Grid x:Name="MonthView">
@@ -322,7 +317,9 @@
 										<RowDefinition Height="*" />
 									</Grid.RowDefinitions>
 									<Grid.RenderTransform>
-										<ScaleTransform x:Name="MonthViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
+										<ScaleTransform x:Name="MonthViewTransform"
+														CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}"
+														CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
 									</Grid.RenderTransform>
 									<Grid x:Name="WeekDayNames"
 										  Background="{TemplateBinding Background}">
@@ -378,7 +375,9 @@
 											  UseLayoutRounding="False"
 											  Visibility="Collapsed">
 									<ScrollViewer.RenderTransform>
-										<ScaleTransform x:Name="YearViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
+										<ScaleTransform x:Name="YearViewTransform"
+														CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}"
+														CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
 									</ScrollViewer.RenderTransform>
 									<CalendarPanel x:Name="YearViewPanel" />
 								</ScrollViewer>
@@ -390,7 +389,9 @@
 											  UseLayoutRounding="False"
 											  Visibility="Collapsed">
 									<ScrollViewer.RenderTransform>
-										<ScaleTransform x:Name="DecadeViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
+										<ScaleTransform x:Name="DecadeViewTransform"
+														CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}"
+														CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
 									</ScrollViewer.RenderTransform>
 									<CalendarPanel x:Name="DecadeViewPanel" />
 								</ScrollViewer>

--- a/src/library/Uno.Material/Styles/Controls/ComboBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/ComboBox.xaml
@@ -1,35 +1,31 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:converters="using:Uno.Material.Converters"
-					xmlns:extensions="using:Uno.Material.Extensions"
-					xmlns:not_win="http://uno.ui/not_win"
+					xmlns:um="using:Uno.Material"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:uno="using:Uno.UI.Xaml.Controls"
-					xmlns:win="using:Uno.UI.Toolkit"
 					xmlns:xamarin="http://nventive.com/xamarin"
-					mc:Ignorable="not_win xamarin">
+					mc:Ignorable="xamarin">
 
 	<ResourceDictionary.MergedDictionaries>
 		<MaterialColors xmlns="using:Uno.Material" />
 	</ResourceDictionary.MergedDictionaries>
 
 	<!-- Converters -->
-	<converters:FromNullToValueConverter x:Key="NullToScaleConverter"
-										 NotNullValue="0.7"
-										 NullValue="1" />
+	<um:FromNullToValueConverter x:Key="NullToScaleConverter"
+								 NotNullValue="0.7"
+								 NullValue="1" />
 
-	<converters:FromNullToValueConverter x:Key="NullToPlaceholderTranslateYConverter"
-										 NotNullValue="-11"
-										 NullValue="0" />
+	<um:FromNullToValueConverter x:Key="NullToPlaceholderTranslateYConverter"
+								 NotNullValue="-11"
+								 NullValue="0" />
 
-	<converters:FromNullToValueConverter x:Key="NullToContentTranslateYConverter"
-										 NotNullValue="5"
-										 NullValue="0" />
+	<um:FromNullToValueConverter x:Key="NullToContentTranslateYConverter"
+								 NotNullValue="5"
+								 NullValue="0" />
 
-	<converters:FromNullToValueConverter x:Key="NullToPlaceholderThemeBrushConverter"
-										 NotNullValue="{StaticResource ComboBoxPlaceholderFocusedThemeBrush}"
-										 NullValue="{StaticResource ComboBoxPlaceholderForegroundThemeBrush}" />
+	<um:FromNullToValueConverter x:Key="NullToPlaceholderThemeBrushConverter"
+								 NotNullValue="{StaticResource ComboBoxPlaceholderFocusedThemeBrush}"
+								 NullValue="{StaticResource ComboBoxPlaceholderForegroundThemeBrush}" />
 
 	<!-- Brushes -->
 	<StaticResource x:Key="ComboBoxBackgroundColorBrush"
@@ -425,9 +421,9 @@
 										<CompositeTransform x:Key="ContentPresenter_CompositeTransformWithoutPlaceholder"
 															TranslateY="0" />
 
-										<converters:FromEmptyStringToValueConverter x:Key="EmptyToCompositeTransformConverter"
-																					NotNullOrEmptyValue="{StaticResource ContentPresenter_CompositeTransformWithPlaceholder}"
-																					NullOrEmptyValue="{StaticResource ContentPresenter_CompositeTransformWithoutPlaceholder}" />
+										<um:FromEmptyStringToValueConverter x:Key="EmptyToCompositeTransformConverter"
+																			NotNullOrEmptyValue="{StaticResource ContentPresenter_CompositeTransformWithPlaceholder}"
+																			NullOrEmptyValue="{StaticResource ContentPresenter_CompositeTransformWithoutPlaceholder}" />
 									</Grid.Resources>
 									<Grid.ColumnDefinitions>
 										<ColumnDefinition Width="Auto" />
@@ -436,14 +432,14 @@
 
 									<!-- IconPresenter -->
 									<ContentPresenter x:Name="IconPresenter"
-													  Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
+													  Content="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
 													  MaxHeight="34"
 													  MaxWidth="34"
 													  MinWidth="25"
 													  Margin="0,0,8,0"
 													  HorizontalAlignment="Center"
 													  VerticalAlignment="Center"
-													  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+													  Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 									<!-- ContentPresenter -->
 									<ContentPresenter x:Name="ContentPresenter"

--- a/src/library/Uno.Material/Styles/Controls/CommandBar.xaml
+++ b/src/library/Uno.Material/Styles/Controls/CommandBar.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:controls="using:Uno.Material.Controls"
+					xmlns:um="using:Uno.Material"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:android="http://nventive.com/android"
@@ -27,7 +27,7 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="AppBarButton">
-					<controls:Ripple Feedback="{TemplateBinding Foreground}"
+					<um:Ripple Feedback="{TemplateBinding Foreground}"
 									 FeedbackOpacity="{StaticResource MaterialPressedOpacity}">
 						<Viewbox x:Name="ContentViewbox"
 								 Height="{ThemeResource AppBarButtonContentHeight}"
@@ -39,7 +39,7 @@
 											  Content="{TemplateBinding Icon}"
 											  Foreground="{TemplateBinding Foreground}" />
 						</Viewbox>
-					</controls:Ripple>
+					</um:Ripple>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>

--- a/src/library/Uno.Material/Styles/Controls/FloatingActionButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/FloatingActionButton.xaml
@@ -2,19 +2,12 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:controls="using:Uno.Material.Controls"
+					xmlns:um="using:Uno.Material"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:ios="http://uno.ui/ios"
-					xmlns:android="http://uno.ui/android"
-					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:wasm="http://uno.ui/wasm"
-					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:extensions="using:Uno.Material.Extensions"
-					mc:Ignorable="d ios android wasm not_win">
+					mc:Ignorable="d">
 
 	<ResourceDictionary.MergedDictionaries>
-		<MaterialColors xmlns="using:Uno.Material"/>
+		<MaterialColors xmlns="using:Uno.Material" />
 		<MaterialFonts xmlns="using:Uno.Material" />
 	</ResourceDictionary.MergedDictionaries>
 
@@ -25,13 +18,13 @@
 		<ResourceDictionary x:Key="Light">
 			<Color x:Key="ButtonFabLowFabBackgroundColor">#9F9F9F</Color>
 		</ResourceDictionary>
-		
+
 		<!-- Dark Theme -->
 		<ResourceDictionary x:Key="Dark">
 			<Color x:Key="ButtonFabLowFabBackgroundColor">#606060</Color>
 		</ResourceDictionary>
 	</ResourceDictionary.ThemeDictionaries>
-			
+
 	<SolidColorBrush x:Key="ButtonFabFocusOverlayBackgroundColor"
 					 Color="Transparent" />
 	<SolidColorBrush x:Key="ButtonFabLowFabBackgroundColorBrush"
@@ -93,10 +86,10 @@
 											  CornerRadius="{TemplateBinding CornerRadius}"
 											  Background="Transparent">
 
-							<controls:Ripple x:Name="Ripple"
-											 CornerRadius="{TemplateBinding CornerRadius}"
-											 Feedback="{TemplateBinding Foreground}"
-											 FeedbackOpacity="{StaticResource MaterialPressedOpacity}">
+							<um:Ripple x:Name="Ripple"
+									   CornerRadius="{TemplateBinding CornerRadius}"
+									   Feedback="{TemplateBinding Foreground}"
+									   FeedbackOpacity="{StaticResource MaterialPressedOpacity}">
 
 								<Grid x:Name="Root"
 									  Background="{TemplateBinding Background}">
@@ -109,15 +102,15 @@
 												 Width="{StaticResource MaterialFabContentWidthOrHeight}"
 												 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 												 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-												 Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}">
-											<ContentPresenter Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
+												 Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}">
+											<ContentPresenter Content="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
 															  Foreground="{Binding Path=Foreground, RelativeSource={RelativeSource TemplatedParent}}" />
 										</Viewbox>
 
 										<!-- Icon/Content spacing -->
 										<Border Visibility="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyToCollapsed}, FallbackValue=Collapsed, TargetNullValue=Collapsed}">
 											<Border Width="{StaticResource MaterialFabIconTextPadding}"
-													Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+													Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 										</Border>
 
 										<!-- Content -->
@@ -134,7 +127,7 @@
 
 									<Border x:Name="FabFocusBorder" />
 								</Grid>
-							</controls:Ripple>
+							</um:Ripple>
 						</toolkit:ElevatedView>
 
 						<VisualStateManager.VisualStateGroups>
@@ -241,10 +234,10 @@
 											  CornerRadius="{TemplateBinding CornerRadius}"
 											  Background="Transparent">
 
-							<controls:Ripple x:Name="Ripple"
-											 CornerRadius="{TemplateBinding CornerRadius}"
-											 Feedback="{TemplateBinding Foreground}"
-											 FeedbackOpacity="{StaticResource MaterialPressedOpacity}">
+							<um:Ripple x:Name="Ripple"
+									   CornerRadius="{TemplateBinding CornerRadius}"
+									   Feedback="{TemplateBinding Foreground}"
+									   FeedbackOpacity="{StaticResource MaterialPressedOpacity}">
 
 								<Grid x:Name="Root"
 									  Background="{TemplateBinding Background}">
@@ -257,15 +250,15 @@
 												 Width="{StaticResource MaterialFabContentWidthOrHeight}"
 												 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 												 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-												 Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}">
-											<ContentPresenter Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
+												 Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}">
+											<ContentPresenter Content="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
 															  Foreground="{Binding Path=Foreground, RelativeSource={RelativeSource TemplatedParent}}" />
 										</Viewbox>
 
 										<!-- Icon/Content spacing -->
 										<Border Visibility="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyToCollapsed}, FallbackValue=Collapsed, TargetNullValue=Collapsed}">
 											<Border Width="{StaticResource MaterialFabIconTextPadding}"
-													Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+													Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 										</Border>
 
 										<!-- Content -->
@@ -282,7 +275,7 @@
 
 									<Border x:Name="FabFocusBorder" />
 								</Grid>
-							</controls:Ripple>
+							</um:Ripple>
 						</toolkit:ElevatedView>
 
 						<VisualStateManager.VisualStateGroups>
@@ -330,11 +323,11 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
-	
+
 	<Style x:Key="MaterialSecondaryFabStyle"
 		   BasedOn="{StaticResource MaterialFabStyle}"
 		   TargetType="Button">
-		
+
 		<Setter Property="Background"
 				Value="{StaticResource MaterialSecondaryBrush}" />
 		<Setter Property="Foreground"
@@ -344,7 +337,7 @@
 	<Style x:Key="MaterialPrimaryInvertedFabStyle"
 		   BasedOn="{StaticResource MaterialFabStyle}"
 		   TargetType="Button">
-		
+
 		<Setter Property="Background"
 				Value="{StaticResource MaterialOnPrimaryBrush}" />
 		<Setter Property="Foreground"

--- a/src/library/Uno.Material/Styles/Controls/Flyout.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Flyout.xaml
@@ -1,14 +1,11 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:winui="using:Microsoft.UI.Xaml.Controls"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:not_win="http://uno.ui/not_win"
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:android="http://uno.ui/android"
-					xmlns:wasm="http://uno.ui/wasm"
-					mc:Ignorable="not_win ios android wasm">
+					mc:Ignorable="not_win ios android">
 
 	<ResourceDictionary.MergedDictionaries>
 		<MaterialColors xmlns="using:Uno.Material" />

--- a/src/library/Uno.Material/Styles/Controls/HyperlinkButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/HyperlinkButton.xaml
@@ -2,7 +2,6 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:winui="using:Microsoft.UI.Xaml.Controls"
 					mc:Ignorable="d">
 
 	<ResourceDictionary.MergedDictionaries>

--- a/src/library/Uno.Material/Styles/Controls/InfoBar.xaml
+++ b/src/library/Uno.Material/Styles/Controls/InfoBar.xaml
@@ -1,13 +1,13 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:toolkit="using:Uno.UI.Toolkit"
-                    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:winui="using:Microsoft.UI.Xaml.Controls"
-                    mc:Ignorable="">
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+					mc:Ignorable="">
 
 	<ResourceDictionary.MergedDictionaries>
-		<MaterialColors xmlns="using:Uno.Material"/>
+		<MaterialColors xmlns="using:Uno.Material" />
 	</ResourceDictionary.MergedDictionaries>
 
 	<!--  Documented variables  -->
@@ -17,37 +17,37 @@
 	<x:String x:Key="CloseGlyphPathData">M1.442037,0L16.002031,14.585751 30.588022,0.025996563 32.001024,1.4409965 17.414783,16.001002 31.97503,30.587006 30.560022,32 15.999268,17.413969 1.4130009,31.973999 0,30.558998 14.586494,15.998742 0.027028472,1.4140019z</x:String>
 
 	<SolidColorBrush x:Key="InfoBarWarningSeverityBrush"
-	                 Color="{StaticResource InfoBarWarningSeverityColor}" />
+					 Color="{StaticResource InfoBarWarningSeverityColor}" />
 	<SolidColorBrush x:Key="InfoBarSuccessSeverityBrush"
-	                 Color="{StaticResource InfoBarSuccessSeverityColor}" />
+					 Color="{StaticResource InfoBarSuccessSeverityColor}" />
 
 	<!--  Style  -->
 	<Style x:Key="MaterialInfoBarStyle"
-	       TargetType="winui:InfoBar">
+		   TargetType="muxc:InfoBar">
 
 		<Setter Property="IsTabStop"
 				Value="False" />
 		<Setter Property="Background"
-		        Value="{StaticResource MaterialBackgroundBrush}" />
+				Value="{StaticResource MaterialBackgroundBrush}" />
 		<win:Setter Property="BorderBrush"
-		            Value="Black" />
+					Value="Black" />
 		<win:Setter Property="BorderThickness"
-		            Value="1" />
+					Value="1" />
 		<win:Setter Property="MinHeight"
-		            Value="120" />
+					Value="120" />
 		<win:Setter Property="Severity"
 					Value="Informational" />
 
 		<Setter Property="Template">
 			<Setter.Value>
-				<ControlTemplate TargetType="winui:InfoBar">
+				<ControlTemplate TargetType="muxc:InfoBar">
 
 					<toolkit:ElevatedView x:Name="Root"
-					                      HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-					                      VerticalAlignment="{TemplateBinding VerticalAlignment}"
-					                      Background="{TemplateBinding Background}"
-					                      CornerRadius="{TemplateBinding CornerRadius}"
-					                      Elevation="4">
+										  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+										  VerticalAlignment="{TemplateBinding VerticalAlignment}"
+										  Background="{TemplateBinding Background}"
+										  CornerRadius="{TemplateBinding CornerRadius}"
+										  Elevation="4">
 
 						<VisualStateManager.VisualStateGroups>
 
@@ -58,7 +58,7 @@
 								<VisualState x:Name="Error">
 									<VisualState.Setters>
 										<Setter Target="SeverityLevel.BorderBrush"
-										        Value="{StaticResource MaterialErrorBrush}" />
+												Value="{StaticResource MaterialErrorBrush}" />
 										<Setter Target="SeverityLevel.BorderThickness"
 												Value="0,0,0,4" />
 										<Setter Target="StandardIcon.Glyph"
@@ -69,7 +69,7 @@
 								<VisualState x:Name="Warning">
 									<VisualState.Setters>
 										<Setter Target="SeverityLevel.BorderBrush"
-										        Value="{StaticResource InfoBarWarningSeverityBrush}" />
+												Value="{StaticResource InfoBarWarningSeverityBrush}" />
 										<Setter Target="SeverityLevel.BorderThickness"
 												Value="0,0,0,4" />
 										<Setter Target="StandardIcon.Glyph"
@@ -80,7 +80,7 @@
 								<VisualState x:Name="Success">
 									<VisualState.Setters>
 										<Setter Target="SeverityLevel.BorderBrush"
-										        Value="{StaticResource InfoBarSuccessSeverityBrush}" />
+												Value="{StaticResource InfoBarSuccessSeverityBrush}" />
 										<Setter Target="SeverityLevel.BorderThickness"
 												Value="0,0,0,4" />
 										<Setter Target="StandardIcon.Glyph"
@@ -104,7 +104,7 @@
 										<Setter Target="UserIconBorder.Visibility"
 												Value="Visible" />
 										<Setter Target="StandardIcon.Visibility"
-										        Value="Collapsed" />
+												Value="Collapsed" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -121,7 +121,7 @@
 								<VisualState x:Name="InfoBarCollapsed">
 									<VisualState.Setters>
 										<Setter Target="ContentRoot.Visibility"
-										        Value="Collapsed" />
+												Value="Collapsed" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -131,18 +131,18 @@
 								<VisualState x:Name="ForegroundSet">
 									<VisualState.Setters>
 										<Setter Target="Title.Foreground"
-										        Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}" />
+												Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}" />
 										<Setter Target="Message.Foreground"
-										        Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}" />
+												Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 
 						<Grid x:Name="ContentRoot"
-						      Background="{TemplateBinding Background}"
-						      BorderBrush="{TemplateBinding BorderBrush}"
-						      BorderThickness="{TemplateBinding BorderThickness}"
+							  Background="{TemplateBinding Background}"
+							  BorderBrush="{TemplateBinding BorderBrush}"
+							  BorderThickness="{TemplateBinding BorderThickness}"
 							  CornerRadius="{TemplateBinding CornerRadius}">
 
 							<Grid x:Name="SeverityLevel"
@@ -186,7 +186,7 @@
 									<StackPanel VerticalAlignment="Center"
 												Margin="24,0,0,0"
 												Grid.Column="1">
-										
+
 										<!--  Title  -->
 										<TextBlock x:Name="Title"
 												   Style="{StaticResource MaterialSubtitle2}"
@@ -213,8 +213,8 @@
 								<ContentPresenter Grid.Row="1"
 												  VerticalAlignment="Bottom"
 												  HorizontalAlignment="Right"
-								                  Content="{TemplateBinding Content}"
-								                  ContentTemplate="{TemplateBinding ContentTemplate}" />
+												  Content="{TemplateBinding Content}"
+												  ContentTemplate="{TemplateBinding ContentTemplate}" />
 							</Grid>
 						</Grid>
 					</toolkit:ElevatedView>

--- a/src/library/Uno.Material/Styles/Controls/NavigationView/NavigationView_MUX.xaml
+++ b/src/library/Uno.Material/Styles/Controls/NavigationView/NavigationView_MUX.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:material="using:Uno.Material.Controls"
+					xmlns:um="using:Uno.Material"
 					xmlns:media="using:Microsoft.UI.Xaml.Media"
 					xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 					xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
@@ -1569,7 +1569,7 @@
 						<Border Margin="{TemplateBinding Padding}">
 							<!-- dont apply Margin on Ripple, as it will be applied twice (on the Ripple and on its template root) -->
 							<!-- material#446: skia:Opacity to workaround Ripple opacity issue -->
-							<material:Ripple Feedback="{StaticResource MaterialMUXNavigationViewRippleFeedback}"
+							<um:Ripple Feedback="{StaticResource MaterialMUXNavigationViewRippleFeedback}"
 											 skia:Opacity="0.12"
 											 CornerRadius="{TemplateBinding CornerRadius}" />
 						</Border>

--- a/src/library/Uno.Material/Styles/Controls/NavigationView/WUX/NavigationView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/NavigationView/WUX/NavigationView.xaml
@@ -1,21 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-				xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-				xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-				xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-				xmlns:toolkit="using:Uno.UI.Toolkit"
-				xmlns:ios="http://uno.ui/ios"
-				xmlns:android="http://uno.ui/android"
-				xmlns:wasm="http://uno.ui/wasm"
-				xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-				xmlns:not_win="http://uno.ui/not_win"
-				xmlns:xamarin="http://uno.ui/xamarin"
-				xmlns:converters="using:Uno.Material.Converters"
-				xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
-				mc:Ignorable="d ios android wasm not_win xamarin primitives">
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:android="http://uno.ui/android"
+					xmlns:xamarin="http://uno.ui/xamarin"
+					mc:Ignorable="d android xamarin">
 
 	<ResourceDictionary.MergedDictionaries>
-		<MaterialColors xmlns="using:Uno.Material"/>
+		<MaterialColors xmlns="using:Uno.Material" />
 		<ResourceDictionary Source="../WUX/NavigationView_SplitView.xaml" />
 		<ResourceDictionary Source="../WUX/NavigationView_PaneToggleButton.xaml" />
 		<ResourceDictionary Source="../WUX/NavigationViewItemSeparator.xaml" />

--- a/src/library/Uno.Material/Styles/Controls/NavigationView/WUX/NavigationViewItemSeparator.xaml
+++ b/src/library/Uno.Material/Styles/Controls/NavigationView/WUX/NavigationViewItemSeparator.xaml
@@ -2,19 +2,10 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:ios="http://uno.ui/ios"
-					xmlns:android="http://uno.ui/android"
-					xmlns:wasm="http://uno.ui/wasm"
-					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:xamarin="http://uno.ui/xamarin"
-					xmlns:converters="using:Uno.Material.Converters"
-					xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
-					mc:Ignorable="d ios android wasm not_win xamarin primitives">
+					mc:Ignorable="d">
 
 	<ResourceDictionary.MergedDictionaries>
-		<MaterialColors xmlns="using:Uno.Material"/>
+		<MaterialColors xmlns="using:Uno.Material" />
 	</ResourceDictionary.MergedDictionaries>
 
 	<Style TargetType="NavigationViewItemSeparator">

--- a/src/library/Uno.Material/Styles/Controls/NavigationView/WUX/NavigationView_PaneToggleButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/NavigationView/WUX/NavigationView_PaneToggleButton.xaml
@@ -2,24 +2,21 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:ios="http://uno.ui/ios"
 					xmlns:android="http://uno.ui/android"
-					xmlns:wasm="http://uno.ui/wasm"
-					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:xamarin="http://uno.ui/xamarin"
 					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:converters="using:Uno.Material.Converters"
-					xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
-					mc:Ignorable="d ios android wasm not_win xamarin primitives">
+					xmlns:um="using:Uno.Material"
+					mc:Ignorable="d android">
 
 	<ResourceDictionary.MergedDictionaries>
-		<MaterialColors xmlns="using:Uno.Material"/>
+		<MaterialColors xmlns="using:Uno.Material" />
 	</ResourceDictionary.MergedDictionaries>
 
 	<x:String x:Key="BackArrowPathData">M8,0 L9.4,1.4 L3.8,7 L16,7 L16,9 L3.8,9 L9.4,14.6 L8,16 L0,8 z</x:String>
 
+	<um:FromOpenToCustomValueConverter x:Name="OpenToPaneButtonStyle"
+									   ValueIfOpen="{StaticResource MaterialPaneBackArrowToggleButtonStyle}"
+									   ValueIfClosed="{StaticResource MaterialPaneToggleButtonStyle}" />
+	
 	<!-- PaneToggleButton Style-->
 	<Style x:Key="MaterialPaneToggleButtonStyle"
 		   TargetType="Button">
@@ -310,9 +307,5 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
-
-	<converters:FromOpenToCustomValueConverter x:Name="OpenToPaneButtonStyle"
-											   ValueIfOpen="{StaticResource MaterialPaneBackArrowToggleButtonStyle}"
-											   ValueIfClosed="{StaticResource MaterialPaneToggleButtonStyle}" />
-
+	
 </ResourceDictionary>

--- a/src/library/Uno.Material/Styles/Controls/PasswordBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/PasswordBox.xaml
@@ -1,18 +1,15 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:extensions="using:Uno.Material.Extensions"
+					xmlns:um="using:Uno.Material"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:xamarin="http://nventive.com/xamarin"
 					xmlns:ios="http://uno.ui/ios"
-					xmlns:android="http://uno.ui/android"
-					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:not_macos="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:macos="http://uno.ui/macos"
-					mc:Ignorable="xamarin ios android wasm macos">
+					mc:Ignorable="ios macos">
 
 	<ResourceDictionary.MergedDictionaries>
-		<MaterialColors xmlns="using:Uno.Material"/>
-		<MaterialFonts xmlns="using:Uno.Material"/>
+		<MaterialColors xmlns="using:Uno.Material" />
+		<MaterialFonts xmlns="using:Uno.Material" />
 		<ResourceDictionary Source="../Application/TextBoxVariables.xaml" />
 	</ResourceDictionary.MergedDictionaries>
 
@@ -171,14 +168,14 @@
 							</Grid.ColumnDefinitions>
 
 							<ContentPresenter x:Name="IconPresenter"
-											  Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
+											  Content="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
 											  MaxHeight="34"
 											  MaxWidth="34"
 											  MinWidth="25"
 											  Margin="0,0,8,0"
 											  HorizontalAlignment="Center"
 											  VerticalAlignment="Center"
-											  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+											  Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 							<ScrollViewer x:Name="ContentElement"
 										  Grid.Column="1"
@@ -364,14 +361,14 @@
 						</Grid.ColumnDefinitions>
 
 						<ContentPresenter x:Name="IconPresenter"
-										  Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
+										  Content="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
 										  MaxHeight="34"
 										  MaxWidth="34"
 										  MinWidth="25"
 										  Margin="0,0,8,0"
 										  HorizontalAlignment="Center"
 										  VerticalAlignment="Center"
-										  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+										  Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 						<ScrollViewer x:Name="ContentElement"
 									  Grid.Column="1"

--- a/src/library/Uno.Material/Styles/Controls/ProgressBar.xaml
+++ b/src/library/Uno.Material/Styles/Controls/ProgressBar.xaml
@@ -2,15 +2,15 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:winui="using:Microsoft.UI.Xaml.Controls"
+					xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 					mc:Ignorable="d">
 
 	<ResourceDictionary.MergedDictionaries>
-		<MaterialColors xmlns="using:Uno.Material"/>
+		<MaterialColors xmlns="using:Uno.Material" />
 	</ResourceDictionary.MergedDictionaries>
 
 	<Style x:Key="MaterialProgressBarStyle"
-		   TargetType="winui:ProgressBar">
+		   TargetType="muxc:ProgressBar">
 		<Setter Property="Foreground"
 				Value="{StaticResource MaterialPrimaryBrush}" />
 		<Setter Property="Background"
@@ -20,7 +20,7 @@
 	</Style>
 
 	<Style x:Key="MaterialSecondaryProgressBarStyle"
-		   TargetType="winui:ProgressBar">
+		   TargetType="muxc:ProgressBar">
 		<Setter Property="Foreground"
 				Value="{StaticResource MaterialSecondaryBrush}" />
 		<Setter Property="Background"

--- a/src/library/Uno.Material/Styles/Controls/ProgressRing.xaml
+++ b/src/library/Uno.Material/Styles/Controls/ProgressRing.xaml
@@ -1,53 +1,51 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                    xmlns:lottie="using:Microsoft.Toolkit.Uwp.UI.Lottie"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:not_win="http://uno.ui/not_win"
-                    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:winui="using:Microsoft.UI.Xaml.Controls"
-                    mc:Ignorable="d not_win">
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+					xmlns:lottie="using:Microsoft.Toolkit.Uwp.UI.Lottie"
+					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+					xmlns:not_win="http://uno.ui/not_win"
+					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+					mc:Ignorable="d not_win">
 
 	<ResourceDictionary.MergedDictionaries>
-		<MaterialColors xmlns="using:Uno.Material"/>
+		<MaterialColors xmlns="using:Uno.Material" />
 		<win:ResourceDictionary>
 			<lottie:LottieVisualSource x:Key="MaterialDeterminateAnimation"
-			                           UriSource="ms-appx:///Uno.Material/Assets/MaterialDeterminate.json" />
+									   UriSource="ms-appx:///Uno.Material/Assets/MaterialDeterminate.json" />
 			<lottie:LottieVisualSource x:Key="MaterialIndeterminateAnimation"
-			                           UriSource="ms-appx:///Uno.Material/Assets/MaterialIndeterminate.json" />
+									   UriSource="ms-appx:///Uno.Material/Assets/MaterialIndeterminate.json" />
 		</win:ResourceDictionary>
 		<not_win:ResourceDictionary>
 			<lottie:LottieVisualSource x:Key="MaterialDeterminateAnimation"
-			                           UriSource="embedded://Uno.Material/Uno.Material.Assets.MaterialDeterminate.json" />
+									   UriSource="embedded://Uno.Material/Uno.Material.Assets.MaterialDeterminate.json" />
 			<lottie:LottieVisualSource x:Key="MaterialIndeterminateAnimation"
-			                           UriSource="embedded://Uno.Material/Uno.Material.Assets.MaterialIndeterminate.json" />
+									   UriSource="embedded://Uno.Material/Uno.Material.Assets.MaterialIndeterminate.json" />
 		</not_win:ResourceDictionary>
 	</ResourceDictionary.MergedDictionaries>
 
-
-
 	<Style x:Key="MaterialProgressRingStyle"
-	       TargetType="winui:ProgressRing">
+		   TargetType="muxc:ProgressRing">
 		<Setter Property="DeterminateSource"
-		        Value="{StaticResource MaterialDeterminateAnimation}" />
+				Value="{StaticResource MaterialDeterminateAnimation}" />
 		<Setter Property="IndeterminateSource"
-		        Value="{StaticResource MaterialIndeterminateAnimation}" />
+				Value="{StaticResource MaterialIndeterminateAnimation}" />
 		<Setter Property="Foreground"
-		        Value="{StaticResource MaterialPrimaryBrush}" />
+				Value="{StaticResource MaterialPrimaryBrush}" />
 		<Setter Property="Background"
-		        Value="{StaticResource MaterialPrimaryLowBrush}" />
+				Value="{StaticResource MaterialPrimaryLowBrush}" />
 	</Style>
 
 	<Style x:Key="MaterialSecondaryProgressRingStyle"
-	       TargetType="winui:ProgressRing">
+		   TargetType="muxc:ProgressRing">
 		<Setter Property="DeterminateSource"
-		        Value="{StaticResource MaterialDeterminateAnimation}" />
+				Value="{StaticResource MaterialDeterminateAnimation}" />
 		<Setter Property="IndeterminateSource"
-		        Value="{StaticResource MaterialIndeterminateAnimation}" />
+				Value="{StaticResource MaterialIndeterminateAnimation}" />
 		<Setter Property="Foreground"
-		        Value="{StaticResource MaterialSecondaryBrush}" />
+				Value="{StaticResource MaterialSecondaryBrush}" />
 		<Setter Property="Background"
-		        Value="{StaticResource MaterialSecondaryLowBrush}" />
+				Value="{StaticResource MaterialSecondaryLowBrush}" />
 	</Style>
 
 </ResourceDictionary>

--- a/src/library/Uno.Material/Styles/Controls/RatingControl.xaml
+++ b/src/library/Uno.Material/Styles/Controls/RatingControl.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:local="using:Microsoft.UI.Xaml.Controls"
+					xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 					xmlns:not_win="http://uno.ui/not_win"
 					mc:Ignorable="not_win">
 
@@ -11,7 +11,7 @@
 	</ResourceDictionary.MergedDictionaries>
 
 	<Style x:Key="MaterialRatingControlStyle"
-		   TargetType="local:RatingControl">
+		   TargetType="muxc:RatingControl">
 		<Setter Property="Height" Value="32" />
 		<!--  9794813: retire these two properties as customisation points once all resource keys available  -->
 		<Setter Property="Foreground" Value="{ThemeResource MaterialPrimaryBrush}" />
@@ -20,7 +20,7 @@
 		<not_win:Setter Property="ItemInfo" Value="{ThemeResource MUX_RatingControlDefaultFontInfo}"/>
 		<Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="local:RatingControl">
+                <ControlTemplate TargetType="muxc:RatingControl">
                     <Grid x:Name="LayoutRoot">
 						<Grid.Resources>
 							<StaticResource x:Key="RatingControlSelectedForeground" ResourceKey="MaterialPrimaryBrush"/>
@@ -109,13 +109,13 @@
 	</Style>
 
 	<Style x:Key="MaterialSecondaryRatingControlStyle"
-		   TargetType="local:RatingControl"
+		   TargetType="muxc:RatingControl"
 		   BasedOn="{StaticResource MaterialRatingControlStyle}">
 		<Setter Property="Foreground"
 				Value="{ThemeResource MaterialSecondaryBrush}"/>
 		<Setter Property="Template">
 			<Setter.Value>
-				<ControlTemplate TargetType="local:RatingControl">
+				<ControlTemplate TargetType="muxc:RatingControl">
 					<Grid x:Name="LayoutRoot">
 						<Grid.Resources>
 							<StaticResource x:Key="RatingControlSelectedForeground" ResourceKey="MaterialSecondaryBrush"/>

--- a/src/library/Uno.Material/Styles/Controls/Ripple.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Ripple.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:controls="using:Uno.Material.Controls"
+					xmlns:um="using:Uno.Material"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:not_win="http://uno.ui/not_win"
 					mc:Ignorable="not_win">
@@ -10,10 +10,10 @@
 
 
 	<ResourceDictionary.MergedDictionaries>
-		<MaterialColors xmlns="using:Uno.Material"/>
+		<MaterialColors xmlns="using:Uno.Material" />
 	</ResourceDictionary.MergedDictionaries>
 	<!-- Known Issue - Wasm pressed state/ripple effect is only applied on first press -->
-	<Style TargetType="controls:Ripple">
+	<Style TargetType="um:Ripple">
 		<Setter Property="HorizontalAlignment"
 				Value="Stretch" />
 		<Setter Property="VerticalAlignment"
@@ -26,7 +26,7 @@
 				Value="False" />
 		<Setter Property="Template">
 			<Setter.Value>
-				<ControlTemplate TargetType="controls:Ripple">
+				<ControlTemplate TargetType="um:Ripple">
 					<Grid Background="Transparent"
 						  Margin="{TemplateBinding Margin}"
 						  CornerRadius="{TemplateBinding CornerRadius}">
@@ -65,7 +65,7 @@
 											</DoubleAnimation.EasingFunction>
 										</DoubleAnimation>
 										<win:DoubleAnimationUsingKeyFrames Storyboard.TargetName="ClickEllipse"
-																			Storyboard.TargetProperty="Opacity">
+																		   Storyboard.TargetProperty="Opacity">
 											<EasingDoubleKeyFrame KeyTime="0"
 																  Value="0">
 												<EasingDoubleKeyFrame.EasingFunction>
@@ -139,7 +139,9 @@
 									 Canvas.Top="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RippleY}"
 									 RenderTransformOrigin=".5,.5">
 								<Ellipse.RenderTransform>
-									<ScaleTransform x:Name="ScaleTransform" ScaleX="0" ScaleY="0" />
+									<ScaleTransform x:Name="ScaleTransform"
+													ScaleX="0"
+													ScaleY="0" />
 								</Ellipse.RenderTransform>
 							</Ellipse>
 						</Canvas>

--- a/src/library/Uno.Material/Styles/Controls/Slider.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Slider.xaml
@@ -1,14 +1,11 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:converters="using:Uno.Material.Converters"
-					xmlns:controls="using:Uno.Material.Controls"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:not_win="http://uno.ui/not_win"
 					mc:Ignorable="not_win">
 
 	<ResourceDictionary.MergedDictionaries>
-		<MaterialColors xmlns="using:Uno.Material"/>
+		<MaterialColors xmlns="using:Uno.Material" />
 	</ResourceDictionary.MergedDictionaries>
 
 	<SolidColorBrush x:Key="MaterialSliderTrackBrush"

--- a/src/library/Uno.Material/Styles/Controls/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/TextBox.xaml
@@ -4,8 +4,7 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_macos="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:macos="http://uno.ui/macos"
-					xmlns:extensions="using:Uno.Material.Extensions"
-					xmlns:converters="using:Uno.Material.Converters"
+					xmlns:um="using:Uno.Material"
 					mc:Ignorable="d macos">
 
 	<ResourceDictionary.MergedDictionaries>
@@ -15,9 +14,9 @@
 	</ResourceDictionary.MergedDictionaries>
 
 	<!-- Converters -->
-	<converters:FromEmptyStringToValueConverter x:Key="EmptyToCompositeTransformTranslateY"
-												NotNullOrEmptyValue="5"
-												NullOrEmptyValue="0" />
+	<um:FromEmptyStringToValueConverter x:Key="EmptyToCompositeTransformTranslateY"
+										NotNullOrEmptyValue="5"
+										NullOrEmptyValue="0" />
 
 	<!-- Path Data -->
 	<x:String x:Key="ClearGlyphPathData">M10.661012,7.5689991L7.5990001,10.650999 12.939089,15.997999 7.5990001,21.336999 10.661012,24.405 16.007082,19.065 21.369997,24.405 24.430058,21.336999 24.429081,21.336 19.088991,15.998999 24.429081,10.662001 21.345095,7.5819996 16.007082,12.919001z M15.997072,0C24.828983,0 31.994999,7.1770013 31.994999,15.999998 31.994999,24.826997 24.828007,31.999999 15.997072,31.999999 7.1569835,31.999999 1.5270052E-07,24.826997 0,15.999998 1.5270052E-07,7.1799997 7.1569835,0 15.997072,0z</x:String>
@@ -180,7 +179,7 @@
 							</Grid.ColumnDefinitions>
 
 							<ContentPresenter x:Name="IconPresenter"
-											  Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
+											  Content="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
 											  HorizontalAlignment="Center"
 											  Margin="0,0,8,0"
 											  MaxHeight="34"
@@ -188,7 +187,7 @@
 											  MinWidth="25"
 											  not_macos:VerticalAlignment="Top"
 											  macos:VerticalAlignment="Center"
-											  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+											  Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 
 							<ScrollViewer x:Name="ContentElement"
@@ -378,14 +377,14 @@
 						</Grid.ColumnDefinitions>
 
 						<ContentPresenter x:Name="IconPresenter"
-										  Content="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
+										  Content="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
 										  HorizontalAlignment="Center"
 										  MaxHeight="34"
 										  MaxWidth="34"
 										  MinWidth="25"
 										  Margin="0,0,8,0"
 										  VerticalAlignment="Bottom"
-										  Visibility="{Binding Path=(extensions:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+										  Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 						<ScrollViewer x:Name="ContentElement"
 									  Grid.Column="1"

--- a/src/library/Uno.Material/Styles/Controls/ToggleButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/ToggleButton.xaml
@@ -3,15 +3,9 @@
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:controls="using:Uno.Material.Controls"
-					xmlns:extensions="using:Uno.Material.Extensions"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:ios="http://uno.ui/ios"
-					xmlns:android="http://uno.ui/android"
+					xmlns:um="using:Uno.Material"
 					xmlns:xamarin="http://uno.ui/xamarin"
-					xmlns:wasm="http://uno.ui/wasm"
-					xmlns:not_win="http://uno.ui/not_win"
-					mc:Ignorable="d ios android wasm not_win xamarin">
+					mc:Ignorable="d xamarin">
 
 	<ResourceDictionary.MergedDictionaries>
 		<MaterialColors xmlns="using:Uno.Material" />
@@ -161,20 +155,20 @@
 								Opacity="0" />
 
 						<!-- Ripple effect -->
-						<controls:Ripple x:Name="ContentPresenter"
-										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
-										 BorderBrush="{TemplateBinding BorderBrush}"
-										 BorderThickness="{TemplateBinding BorderThickness}"
-										 Content="{TemplateBinding Content}"
-										 ContentTemplate="{TemplateBinding ContentTemplate}"
-										 ContentTransitions="{TemplateBinding ContentTransitions}"
-										 CornerRadius="{TemplateBinding CornerRadius}"
-										 FontFamily="{TemplateBinding FontFamily}"
-										 FontSize="{TemplateBinding FontSize}"
-										 Padding="{TemplateBinding Padding}"
-										 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-										 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-										 AutomationProperties.AccessibilityView="Raw" />
+						<um:Ripple x:Name="ContentPresenter"
+								   Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
+								   BorderBrush="{TemplateBinding BorderBrush}"
+								   BorderThickness="{TemplateBinding BorderThickness}"
+								   Content="{TemplateBinding Content}"
+								   ContentTemplate="{TemplateBinding ContentTemplate}"
+								   ContentTransitions="{TemplateBinding ContentTransitions}"
+								   CornerRadius="{TemplateBinding CornerRadius}"
+								   FontFamily="{TemplateBinding FontFamily}"
+								   FontSize="{TemplateBinding FontSize}"
+								   Padding="{TemplateBinding Padding}"
+								   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+								   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+								   AutomationProperties.AccessibilityView="Raw" />
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>
@@ -304,7 +298,7 @@
 						<!-- Alternate Content -->
 						<ContentPresenter x:Name="AlternateContentPresenter"
 										  AutomationProperties.AccessibilityView="Raw"
-										  Content="{Binding Path=(extensions:ControlExtensions.AlternateContent), RelativeSource={RelativeSource TemplatedParent}}"
+										  Content="{Binding Path=(um:ControlExtensions.AlternateContent), RelativeSource={RelativeSource TemplatedParent}}"
 										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
 										  Visibility="Collapsed" />

--- a/src/library/Uno.Material/Uno.Material.csproj
+++ b/src/library/Uno.Material/Uno.Material.csproj
@@ -74,14 +74,14 @@
 			</PropertyGroup>
 
 			<ItemGroup>
-				<PackageReference Include="Uno.UI" Version="4.0.0-dev.5676" />
+				<PackageReference Include="Uno.UI" Version="4.0.7" />
 			</ItemGroup>
 			<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">
 				<PackageReference Include="Microsoft.UI.Xaml" Version="2.6.0-prerelease.210113001" />
 				<PackageReference Include="Microsoft.Toolkit.Uwp.UI.Lottie" Version="6.1.0" />
 			</ItemGroup>
 			<ItemGroup Condition="'$(TargetFramework)'!='uap10.0.18362'">
-				<PackageReference Include="Uno.UI.Lottie" Version="4.0.0-dev.5676" />
+				<PackageReference Include="Uno.UI.Lottie" Version="4.0.7" />
 			</ItemGroup>
 
 

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Droid/Uno.Themes.Samples.Droid.csproj
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Droid/Uno.Themes.Samples.Droid.csproj
@@ -85,21 +85,21 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
-      <Version>1.0.58</Version>
+      <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML.MSBuild">
-      <Version>1.0.58</Version>
+      <Version>1.0.59</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="4.0.0-dev.5676" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.0-dev.5676" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.33" />
+    <PackageReference Include="Uno.UI" Version="4.0.7" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.7" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.35" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.1.0" />
     <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.1.0.2" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.0-dev.5676" />
-    <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.0-dev.7" />
-    <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.0-dev.7" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.7" />
+    <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
+    <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ButtonSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ButtonSamplePage.xaml
@@ -3,12 +3,10 @@
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:sample="using:Uno.Themes.Samples"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	  xmlns:android="http://uno.ui/android"
-	  xmlns:ios="http://uno.ui/ios"
-	  xmlns:extensions="using:Uno.Material.Extensions"
+	  xmlns:um="using:Uno.Material"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:smtx="using:ShowMeTheXAML"
-	  mc:Ignorable="d android ios">
+	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<sample:SamplePageLayout>
@@ -131,9 +129,9 @@
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<Button Content="CONTAINED"
 									Style="{StaticResource MaterialContainedButtonStyle}">
-								<extensions:ControlExtensions.Icon>
+								<um:ControlExtensions.Icon>
 									<FontIcon Glyph="&#xE946;" />
-								</extensions:ControlExtensions.Icon>
+								</um:ControlExtensions.Icon>
 							</Button>
 						</smtx:XamlDisplay>
 
@@ -142,9 +140,9 @@
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<Button Content="OUTLINED"
 									Style="{StaticResource MaterialOutlinedButtonStyle}">
-								<extensions:ControlExtensions.Icon>
+								<um:ControlExtensions.Icon>
 									<FontIcon Glyph="&#xE946;" />
-								</extensions:ControlExtensions.Icon>
+								</um:ControlExtensions.Icon>
 							</Button>
 						</smtx:XamlDisplay>
 
@@ -153,9 +151,9 @@
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<Button Content="TEXT"
 									Style="{StaticResource MaterialTextButtonStyle}">
-								<extensions:ControlExtensions.Icon>
+								<um:ControlExtensions.Icon>
 									<FontIcon Glyph="&#xE946;" />
-								</extensions:ControlExtensions.Icon>
+								</um:ControlExtensions.Icon>
 							</Button>
 						</smtx:XamlDisplay>
 
@@ -168,9 +166,9 @@
 									HorizontalAlignment="Stretch"
 									HorizontalContentAlignment="Center"
 									Style="{StaticResource MaterialContainedButtonStyle}">
-								<extensions:ControlExtensions.Icon>
+								<um:ControlExtensions.Icon>
 									<FontIcon Glyph="&#xE946;" />
-								</extensions:ControlExtensions.Icon>
+								</um:ControlExtensions.Icon>
 							</Button>
 						</smtx:XamlDisplay>
 
@@ -181,9 +179,9 @@
 									HorizontalAlignment="Stretch"
 									HorizontalContentAlignment="Center"
 									Style="{StaticResource MaterialOutlinedButtonStyle}">
-								<extensions:ControlExtensions.Icon>
+								<um:ControlExtensions.Icon>
 									<FontIcon Glyph="&#xE946;" />
-								</extensions:ControlExtensions.Icon>
+								</um:ControlExtensions.Icon>
 							</Button>
 						</smtx:XamlDisplay>
 
@@ -194,9 +192,9 @@
 									HorizontalAlignment="Stretch"
 									HorizontalContentAlignment="Center"
 									Style="{StaticResource MaterialTextButtonStyle}">
-								<extensions:ControlExtensions.Icon>
+								<um:ControlExtensions.Icon>
 									<FontIcon Glyph="&#xE946;" />
-								</extensions:ControlExtensions.Icon>
+								</um:ControlExtensions.Icon>
 							</Button>
 						</smtx:XamlDisplay>
 					</StackPanel>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/FabSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/FabSamplePage.xaml
@@ -1,18 +1,10 @@
 ﻿<Page x:Class="Uno.Themes.Samples.Content.Controls.FabSamplePage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	  xmlns:not_win="http://uno.ui/not_win"
-	  xmlns:ios="http://uno.ui/ios"
-	  xmlns:android="http://uno.ui/android"
-	  xmlns:wasm="http://uno.ui/wasm"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:smtx="using:ShowMeTheXAML"
-	  xmlns:extensions="using:Uno.Material.Extensions"
-	  xmlns:controls="using:Uno.Material.Controls"
-	  xmlns:sample="using:Uno.Themes.Samples"
-	  xmlns:toolkit="using:Uno.UI.Toolkit"
-	  mc:Ignorable="not_win android ios wasm">
+	  xmlns:um="using:Uno.Material"
+	  xmlns:sample="using:Uno.Themes.Samples">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<sample:SamplePageLayout>
@@ -35,9 +27,9 @@
 							<smtx:XamlDisplay UniqueKey="FabSamplePage_IconFab"
 											  Style="{StaticResource XamlDisplayBelowStyle}">
 								<Button Style="{StaticResource MaterialFabStyle}">
-									<extensions:ControlExtensions.Icon>
+									<um:ControlExtensions.Icon>
 										<SymbolIcon Symbol="Add" />
-									</extensions:ControlExtensions.Icon>
+									</um:ControlExtensions.Icon>
 								</Button>
 							</smtx:XamlDisplay>
 
@@ -46,9 +38,9 @@
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="16,10,16,0">
 								<Button Style="{StaticResource MaterialSecondaryFabStyle}">
-									<extensions:ControlExtensions.Icon>
+									<um:ControlExtensions.Icon>
 										<SymbolIcon Symbol="Add" />
-									</extensions:ControlExtensions.Icon>
+									</um:ControlExtensions.Icon>
 								</Button>
 							</smtx:XamlDisplay>
 						</StackPanel>
@@ -84,9 +76,9 @@
 											  Style="{StaticResource XamlDisplayBelowStyle}">
 								<Button Content="CREATE"
 										Style="{StaticResource MaterialFabStyle}">
-									<extensions:ControlExtensions.Icon>
+									<um:ControlExtensions.Icon>
 										<SymbolIcon Symbol="Add" />
-									</extensions:ControlExtensions.Icon>
+									</um:ControlExtensions.Icon>
 								</Button>
 							</smtx:XamlDisplay>
 
@@ -96,9 +88,9 @@
 											  Margin="16,10,16,0">
 								<Button Content="CREATE"
 										Style="{StaticResource MaterialSecondaryFabStyle}">
-									<extensions:ControlExtensions.Icon>
+									<um:ControlExtensions.Icon>
 										<SymbolIcon Symbol="Add" />
-									</extensions:ControlExtensions.Icon>
+									</um:ControlExtensions.Icon>
 								</Button>
 							</smtx:XamlDisplay>
 						</StackPanel>
@@ -113,9 +105,9 @@
 											  Style="{StaticResource XamlDisplayBelowStyle}">
 								<Button Content="CREATE"
 										Style="{StaticResource MaterialPrimaryInvertedFabStyle}">
-									<extensions:ControlExtensions.Icon>
+									<um:ControlExtensions.Icon>
 										<SymbolIcon Symbol="Add" />
-									</extensions:ControlExtensions.Icon>
+									</um:ControlExtensions.Icon>
 								</Button>
 							</smtx:XamlDisplay>
 
@@ -125,9 +117,9 @@
 											  Margin="16,10,16,0">
 								<Button Content="CREATE"
 										Style="{StaticResource MaterialSecondaryInvertedFabStyle}">
-									<extensions:ControlExtensions.Icon>
+									<um:ControlExtensions.Icon>
 										<SymbolIcon Symbol="Add" />
-									</extensions:ControlExtensions.Icon>
+									</um:ControlExtensions.Icon>
 								</Button>
 							</smtx:XamlDisplay>
 						</StackPanel>
@@ -143,9 +135,9 @@
 								<Button Content="CREATE"
 										Style="{StaticResource MaterialFabStyle}"
 										IsEnabled="False">
-									<extensions:ControlExtensions.Icon>
+									<um:ControlExtensions.Icon>
 										<SymbolIcon Symbol="Add" />
-									</extensions:ControlExtensions.Icon>
+									</um:ControlExtensions.Icon>
 								</Button>
 							</smtx:XamlDisplay>
 
@@ -156,9 +148,9 @@
 								<Button Content="CREATE"
 										Style="{StaticResource MaterialSecondaryFabStyle}"
 										IsEnabled="False">
-									<extensions:ControlExtensions.Icon>
+									<um:ControlExtensions.Icon>
 										<SymbolIcon Symbol="Add" />
-									</extensions:ControlExtensions.Icon>
+									</um:ControlExtensions.Icon>
 								</Button>
 							</smtx:XamlDisplay>
 						</StackPanel>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/FlyoutSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/FlyoutSamplePage.xaml
@@ -1,18 +1,11 @@
 ﻿<Page x:Class="Uno.Themes.Samples.Content.Controls.FlyoutSamplePage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	  xmlns:not_win="http://uno.ui/not_win"
-	  xmlns:ios="http://uno.ui/ios"
-	  xmlns:android="http://uno.ui/android"
-	  xmlns:wasm="http://uno.ui/wasm"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:smtx="using:ShowMeTheXAML"
-	  xmlns:extensions="using:Uno.Material.Extensions"
-	  xmlns:controls="using:Uno.Material.Controls"
+	  xmlns:um="using:Uno.Material"
 	  xmlns:sample="using:Uno.Themes.Samples"
-	  xmlns:toolkit="using:Uno.UI.Toolkit"
-	  mc:Ignorable="not_win android ios wasm">
+	  xmlns:toolkit="using:Uno.UI.Toolkit">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<sample:SamplePageLayout>
@@ -130,9 +123,9 @@
 													HorizontalAlignment="Stretch"
 													HorizontalContentAlignment="Left"
 													Style="{StaticResource MaterialTextButtonStyle}">
-												<extensions:ControlExtensions.Icon>
+												<um:ControlExtensions.Icon>
 													<SymbolIcon Symbol="Share" />
-												</extensions:ControlExtensions.Icon>
+												</um:ControlExtensions.Icon>
 											</Button>
 
 											<Button Grid.Row="1"
@@ -140,9 +133,9 @@
 													HorizontalAlignment="Stretch"
 													HorizontalContentAlignment="Left"
 													Style="{StaticResource MaterialTextButtonStyle}">
-												<extensions:ControlExtensions.Icon>
+												<um:ControlExtensions.Icon>
 													<SymbolIcon Symbol="Link" />
-												</extensions:ControlExtensions.Icon>
+												</um:ControlExtensions.Icon>
 											</Button>
 
 											<Button Grid.Row="2"
@@ -150,9 +143,9 @@
 													HorizontalAlignment="Stretch"
 													HorizontalContentAlignment="Left"
 													Style="{StaticResource MaterialTextButtonStyle}">
-												<extensions:ControlExtensions.Icon>
+												<um:ControlExtensions.Icon>
 													<SymbolIcon Symbol="Edit" />
-												</extensions:ControlExtensions.Icon>
+												</um:ControlExtensions.Icon>
 											</Button>
 
 											<Button Grid.Row="3"
@@ -160,9 +153,9 @@
 													HorizontalAlignment="Stretch"
 													HorizontalContentAlignment="Left"
 													Style="{StaticResource MaterialTextButtonStyle}">
-												<extensions:ControlExtensions.Icon>
+												<um:ControlExtensions.Icon>
 													<SymbolIcon Symbol="Delete" />
-												</extensions:ControlExtensions.Icon>
+												</um:ControlExtensions.Icon>
 											</Button>
 										</Grid>
 									</Flyout>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/InfoBarSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/InfoBarSamplePage.xaml
@@ -5,7 +5,7 @@
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:sample="using:Uno.Themes.Samples"
 	  xmlns:smtx="using:ShowMeTheXAML"
-	  xmlns:winui="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
@@ -16,34 +16,34 @@
 								Margin="0,20,0,0">
 						<smtx:XamlDisplay UniqueKey="Material_InfoBarSamplePage_Error_SingleButton"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<winui:InfoBar x:Name="firstInfo"
-										   Title="Title"
-										   IsOpen="True"
-										   Message="Essential app message for your users to be informed of, acknowledge, or take action on."
-										   IsIconVisible="True"
-										   Severity="Error"
-										   Style="{StaticResource MaterialInfoBarStyle}">
-								<winui:InfoBar.Content>
+							<muxc:InfoBar x:Name="firstInfo"
+										  Title="Title"
+										  IsOpen="True"
+										  Message="Essential app message for your users to be informed of, acknowledge, or take action on."
+										  IsIconVisible="True"
+										  Severity="Error"
+										  Style="{StaticResource MaterialInfoBarStyle}">
+								<muxc:InfoBar.Content>
 									<Button Style="{StaticResource MaterialTextButtonStyle}"
 											Content="DISMISS" />
-								</winui:InfoBar.Content>
-								<winui:InfoBar.IconSource>
-									<winui:BitmapIconSource UriSource="/Assets/MaterialIcon_Medium.png"
-															Foreground="{StaticResource MaterialPrimaryBrush}" />
-								</winui:InfoBar.IconSource>
-							</winui:InfoBar>
+								</muxc:InfoBar.Content>
+								<muxc:InfoBar.IconSource>
+									<muxc:BitmapIconSource UriSource="/Assets/MaterialIcon_Medium.png"
+														   Foreground="{StaticResource MaterialPrimaryBrush}" />
+								</muxc:InfoBar.IconSource>
+							</muxc:InfoBar>
 						</smtx:XamlDisplay>
 
 						<smtx:XamlDisplay UniqueKey="Material_InfoBarSamplePage_Warning_DoubleButton"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<winui:InfoBar x:Name="secondInfo"
-										   Title="Title"
-										   IsOpen="True"
-										   Message="Essential app message for your users to be informed of, acknowledge, or take action on."
-										   IsIconVisible="True"
-										   Severity="Warning"
-										   Style="{StaticResource MaterialInfoBarStyle}">
-								<winui:InfoBar.Content>
+							<muxc:InfoBar x:Name="secondInfo"
+										  Title="Title"
+										  IsOpen="True"
+										  Message="Essential app message for your users to be informed of, acknowledge, or take action on."
+										  IsIconVisible="True"
+										  Severity="Warning"
+										  Style="{StaticResource MaterialInfoBarStyle}">
+								<muxc:InfoBar.Content>
 									<StackPanel Orientation="Horizontal"
 												Spacing="8">
 										<Button Style="{StaticResource MaterialTextButtonStyle}"
@@ -51,49 +51,49 @@
 										<Button Style="{StaticResource MaterialTextButtonStyle}"
 												Content="ACTION" />
 									</StackPanel>
-								</winui:InfoBar.Content>
-								<winui:InfoBar.IconSource>
-									<winui:BitmapIconSource UriSource="/Assets/MaterialIcon_Medium.png"
-															Foreground="{StaticResource MaterialPrimaryBrush}" />
-								</winui:InfoBar.IconSource>
-							</winui:InfoBar>
+								</muxc:InfoBar.Content>
+								<muxc:InfoBar.IconSource>
+									<muxc:BitmapIconSource UriSource="/Assets/MaterialIcon_Medium.png"
+														   Foreground="{StaticResource MaterialPrimaryBrush}" />
+								</muxc:InfoBar.IconSource>
+							</muxc:InfoBar>
 						</smtx:XamlDisplay>
 
 						<smtx:XamlDisplay UniqueKey="Material_InfoBarSamplePage_Success_SingleButton"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<winui:InfoBar x:Name="thirdInfo"
-										   Title="Title"
-										   IsOpen="True"
-										   Message="Essential app message for your users to be informed of, acknowledge, or take action on."
-										   Severity="Success"
-										   IsIconVisible="False"
-										   Style="{StaticResource MaterialInfoBarStyle}">
-								<winui:InfoBar.Content>
+							<muxc:InfoBar x:Name="thirdInfo"
+										  Title="Title"
+										  IsOpen="True"
+										  Message="Essential app message for your users to be informed of, acknowledge, or take action on."
+										  Severity="Success"
+										  IsIconVisible="False"
+										  Style="{StaticResource MaterialInfoBarStyle}">
+								<muxc:InfoBar.Content>
 									<Button Style="{StaticResource MaterialTextButtonStyle}"
 											Content="DISMISS" />
-								</winui:InfoBar.Content>
-							</winui:InfoBar>
+								</muxc:InfoBar.Content>
+							</muxc:InfoBar>
 						</smtx:XamlDisplay>
 
 						<smtx:XamlDisplay UniqueKey="Material_InfoBarSamplePage_Information_SingleButton"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<winui:InfoBar x:Name="fourthInfo"
-										   Title="Title"
-										   IsOpen="True"
-										   Message="Single line essential app message."
-										   Severity="Informational"
-										   MinHeight="54"
-										   IsIconVisible="True"
-										   Style="{StaticResource MaterialInfoBarStyle}">
-								<winui:InfoBar.ActionButton>
+							<muxc:InfoBar x:Name="fourthInfo"
+										  Title="Title"
+										  IsOpen="True"
+										  Message="Single line essential app message."
+										  Severity="Informational"
+										  MinHeight="54"
+										  IsIconVisible="True"
+										  Style="{StaticResource MaterialInfoBarStyle}">
+								<muxc:InfoBar.ActionButton>
 									<Button Style="{StaticResource MaterialTextButtonStyle}"
 											Content="DISMISS" />
-								</winui:InfoBar.ActionButton>
-								<winui:InfoBar.IconSource>
-									<winui:BitmapIconSource UriSource="/Assets/MaterialIcon_Medium.png"
-															Foreground="{StaticResource MaterialPrimaryBrush}" />
-								</winui:InfoBar.IconSource>
-							</winui:InfoBar>
+								</muxc:InfoBar.ActionButton>
+								<muxc:InfoBar.IconSource>
+									<muxc:BitmapIconSource UriSource="/Assets/MaterialIcon_Medium.png"
+														   Foreground="{StaticResource MaterialPrimaryBrush}" />
+								</muxc:InfoBar.IconSource>
+							</muxc:InfoBar>
 						</smtx:XamlDisplay>
 					</StackPanel>
 				</DataTemplate>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/NumberBoxSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/NumberBoxSamplePage.xaml
@@ -1,11 +1,10 @@
 ﻿<Page x:Class="Uno.Themes.Samples.Content.Controls.NumberBoxSamplePage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:local="using:Uno.Themes.Samples.Shared.Content"
 	  xmlns:sample="using:Uno.Themes.Samples"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  xmlns:winui="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 	  xmlns:smtx="using:ShowMeTheXAML"
 	  mc:Ignorable="d">
 
@@ -19,45 +18,45 @@
 						<!-- NumberBox -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_NumberBoxSamplePage"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<winui:NumberBox Style="{StaticResource CupertinoNumberBoxStyle}"
-											 SmallChange="1"
-											 Value="0"
-											 PlaceholderText="Add"
-											 SpinButtonPlacementMode="Inline" />
+							<muxc:NumberBox Style="{StaticResource CupertinoNumberBoxStyle}"
+											SmallChange="1"
+											Value="0"
+											PlaceholderText="Add"
+											SpinButtonPlacementMode="Inline" />
 						</smtx:XamlDisplay>
 
 						<!-- Disabled NumberBox -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_NumberBoxSamplePage_Disabled"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<winui:NumberBox Style="{StaticResource CupertinoNumberBoxStyle}"
-											 SmallChange="1"
-											 Value="0"
-											 PlaceholderText="Add"
-											 IsEnabled="False"
-											 SpinButtonPlacementMode="Inline" />
+							<muxc:NumberBox Style="{StaticResource CupertinoNumberBoxStyle}"
+											SmallChange="1"
+											Value="0"
+											PlaceholderText="Add"
+											IsEnabled="False"
+											SpinButtonPlacementMode="Inline" />
 						</smtx:XamlDisplay>
-						
+
 						<!-- NumberBox with header -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_NumberBoxSamplePage_Header"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<winui:NumberBox Style="{StaticResource CupertinoNumberBoxStyle}"
-											 SmallChange="1"
-											 Value="0"
-											 Header="Value"
-											 PlaceholderText="Add"
-											 SpinButtonPlacementMode="Inline" />
+							<muxc:NumberBox Style="{StaticResource CupertinoNumberBoxStyle}"
+											SmallChange="1"
+											Value="0"
+											Header="Value"
+											PlaceholderText="Add"
+											SpinButtonPlacementMode="Inline" />
 						</smtx:XamlDisplay>
 
 						<!-- Disabled NumberBox -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_NumberBoxSamplePage_HeaderDisabled"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<winui:NumberBox Style="{StaticResource CupertinoNumberBoxStyle}"
-											 SmallChange="1"
-											 Value="0"
-											 Header="Value"
-											 PlaceholderText="Add"
-											 IsEnabled="False"
-											 SpinButtonPlacementMode="Inline" />
+							<muxc:NumberBox Style="{StaticResource CupertinoNumberBoxStyle}"
+											SmallChange="1"
+											Value="0"
+											Header="Value"
+											PlaceholderText="Add"
+											IsEnabled="False"
+											SpinButtonPlacementMode="Inline" />
 						</smtx:XamlDisplay>
 					</StackPanel>
 				</DataTemplate>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ProgressBarSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ProgressBarSamplePage.xaml
@@ -1,14 +1,12 @@
 ﻿<Page x:Class="Uno.Themes.Samples.Content.Controls.ProgressBarSamplePage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:android="http://uno.ui/android"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	  xmlns:ios="http://uno.ui/ios"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:smtx="using:ShowMeTheXAML"
-	  xmlns:winui="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 	  xmlns:sample="using:Uno.Themes.Samples"
-	  mc:Ignorable="d android ios">
+	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<sample:SamplePageLayout>
@@ -31,36 +29,36 @@
 						<TextBlock Text="Primary ProgressBar" />
 
 						<smtx:XamlDisplay UniqueKey="Material_ProgressBarSamplePage_Primary">
-							<winui:ProgressBar Style="{StaticResource MaterialProgressBarStyle}"
-											   Value="{Binding Value, ElementName=Material_ProgressSlider}"
-											   Minimum="0"
-											   Maximum="100" />
+							<muxc:ProgressBar Style="{StaticResource MaterialProgressBarStyle}"
+											  Value="{Binding Value, ElementName=Material_ProgressSlider}"
+											  Minimum="0"
+											  Maximum="100" />
 						</smtx:XamlDisplay>
 
 						<!-- Secondary ProgressBar Text -->
 						<TextBlock Text="Secondary ProgressBar" />
 
 						<smtx:XamlDisplay UniqueKey="Material_ProgressBarSamplePage_Secondary">
-							<winui:ProgressBar Style="{StaticResource MaterialSecondaryProgressBarStyle}"
-											   Value="{Binding Value, ElementName=Material_ProgressSlider}"
-											   Minimum="0"
-											   Maximum="100" />
+							<muxc:ProgressBar Style="{StaticResource MaterialSecondaryProgressBarStyle}"
+											  Value="{Binding Value, ElementName=Material_ProgressSlider}"
+											  Minimum="0"
+											  Maximum="100" />
 						</smtx:XamlDisplay>
 
 						<!-- Indeterminate Primary ProgressBar Text -->
 						<TextBlock Text="Indeterminate Primary ProgressBar" />
 
 						<smtx:XamlDisplay UniqueKey="Material_ProgressBarSamplePage_PrimaryIndeterminate">
-							<winui:ProgressBar Style="{StaticResource MaterialProgressBarStyle}"
-											   IsIndeterminate="True" />
+							<muxc:ProgressBar Style="{StaticResource MaterialProgressBarStyle}"
+											  IsIndeterminate="True" />
 						</smtx:XamlDisplay>
 
 						<!-- Indeterminate Secondary ProgressBar Text -->
 						<TextBlock Text="Indeterminate Secondary ProgressBar" />
 
 						<smtx:XamlDisplay UniqueKey="Material_ProgressBarSamplePage_SecondaryIndeterminate">
-							<winui:ProgressBar Style="{StaticResource MaterialSecondaryProgressBarStyle}"
-											   IsIndeterminate="True" />
+							<muxc:ProgressBar Style="{StaticResource MaterialSecondaryProgressBarStyle}"
+											  IsIndeterminate="True" />
 						</smtx:XamlDisplay>
 					</StackPanel>
 				</DataTemplate>
@@ -84,18 +82,18 @@
 						<TextBlock Text="Primary ProgressBar" />
 
 						<smtx:XamlDisplay UniqueKey="Cupertino_ProgressBarSamplePage_Primary">
-							<winui:ProgressBar Style="{StaticResource CupertinoProgressBarStyle}"
-											   Value="{Binding Value, ElementName=Cupertino_ProgressSlider}"
-											   Minimum="0"
-											   Maximum="100" />
+							<muxc:ProgressBar Style="{StaticResource CupertinoProgressBarStyle}"
+											  Value="{Binding Value, ElementName=Cupertino_ProgressSlider}"
+											  Minimum="0"
+											  Maximum="100" />
 						</smtx:XamlDisplay>
 
 						<!-- Indeterminate Primary ProgressBar Text -->
 						<TextBlock Text="Indeterminate Primary ProgressBar" />
 
 						<smtx:XamlDisplay UniqueKey="Cupertino_ProgressBarSamplePage_PrimaryIndeterminate">
-							<winui:ProgressBar Style="{StaticResource CupertinoProgressBarStyle}"
-											   IsIndeterminate="True" />
+							<muxc:ProgressBar Style="{StaticResource CupertinoProgressBarStyle}"
+											  IsIndeterminate="True" />
 						</smtx:XamlDisplay>
 					</StackPanel>
 				</DataTemplate>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ProgressRingSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ProgressRingSamplePage.xaml
@@ -1,14 +1,12 @@
 ﻿<Page x:Class="Uno.Themes.Samples.Content.Controls.ProgressRingSamplePage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:android="http://uno.ui/android"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	  xmlns:ios="http://uno.ui/ios"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:smtx="using:ShowMeTheXAML"
-	  xmlns:winui="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 	  xmlns:sample="using:Uno.Themes.Samples"
-	  mc:Ignorable="d android ios">
+	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<sample:SamplePageLayout>
@@ -31,36 +29,36 @@
 						<TextBlock Text="Primary ProgressRing" />
 
 						<smtx:XamlDisplay UniqueKey="ProgressRingSamplePage_Primary">
-							<winui:ProgressRing Style="{StaticResource MaterialProgressRingStyle}"
-												IsIndeterminate="False"
-												Value="{Binding Value, ElementName=progressSlider}"
-												Minimum="0"
-												Maximum="100" />
+							<muxc:ProgressRing Style="{StaticResource MaterialProgressRingStyle}"
+											   IsIndeterminate="False"
+											   Value="{Binding Value, ElementName=progressSlider}"
+											   Minimum="0"
+											   Maximum="100" />
 						</smtx:XamlDisplay>
 
 						<!-- Secondary ProgressRing Text -->
 						<TextBlock Text="Secondary ProgressRing" />
 
 						<smtx:XamlDisplay UniqueKey="ProgressRingSamplePage_Secondary">
-							<winui:ProgressRing Style="{StaticResource MaterialSecondaryProgressRingStyle}"
-												IsIndeterminate="False"
-												Value="{Binding Value, ElementName=progressSlider}"
-												Minimum="0"
-												Maximum="100" />
+							<muxc:ProgressRing Style="{StaticResource MaterialSecondaryProgressRingStyle}"
+											   IsIndeterminate="False"
+											   Value="{Binding Value, ElementName=progressSlider}"
+											   Minimum="0"
+											   Maximum="100" />
 						</smtx:XamlDisplay>
 
 						<!-- Indeterminate Primary ProgressRing Text -->
 						<TextBlock Text="Indeterminate Primary ProgressRing" />
 
 						<smtx:XamlDisplay UniqueKey="ProgressRingSamplePage_PrimaryIndeterminate">
-							<winui:ProgressRing Style="{StaticResource MaterialProgressRingStyle}" />
+							<muxc:ProgressRing Style="{StaticResource MaterialProgressRingStyle}" />
 						</smtx:XamlDisplay>
 
 						<!-- Indeterminate Secondary ProgressRing Text -->
 						<TextBlock Text="Indeterminate Secondary ProgressRing" />
 
 						<smtx:XamlDisplay UniqueKey="ProgressRingSamplePage_SecondaryIndeterminate">
-							<winui:ProgressRing Style="{StaticResource MaterialSecondaryProgressRingStyle}" />
+							<muxc:ProgressRing Style="{StaticResource MaterialSecondaryProgressRingStyle}" />
 						</smtx:XamlDisplay>
 					</StackPanel>
 				</DataTemplate>
@@ -84,18 +82,18 @@
 						<TextBlock Text="Primary ProgressRing" />
 
 						<smtx:XamlDisplay UniqueKey="ProgressRingSamplePage_Cupertino_Primary">
-							<winui:ProgressRing Style="{StaticResource CupertinoProgressRingStyle}"
-												IsIndeterminate="False"
-												Value="{Binding Value, ElementName=cupertinoProgressSlider}"
-												Minimum="0"
-												Maximum="100" />
+							<muxc:ProgressRing Style="{StaticResource CupertinoProgressRingStyle}"
+											   IsIndeterminate="False"
+											   Value="{Binding Value, ElementName=cupertinoProgressSlider}"
+											   Minimum="0"
+											   Maximum="100" />
 						</smtx:XamlDisplay>
 
 						<!-- Indeterminate Primary ProgressRing Text -->
 						<TextBlock Text="Indeterminate Primary ProgressRing" />
 
 						<smtx:XamlDisplay UniqueKey="ProgressRingSamplePage_Cupertino_PrimaryIndeterminate">
-							<winui:ProgressRing Style="{StaticResource CupertinoProgressRingStyle}" />
+							<muxc:ProgressRing Style="{StaticResource CupertinoProgressRingStyle}" />
 						</smtx:XamlDisplay>
 					</StackPanel>
 				</DataTemplate>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
@@ -1,15 +1,12 @@
 ﻿<Page x:Class="Uno.Themes.Samples.Content.Controls.TextBoxSamplePage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:local="using:Uno.Themes.Samples.Shared.Content"
 	  xmlns:sample="using:Uno.Themes.Samples"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	  xmlns:android="http://uno.ui/android"
-	  xmlns:ios="http://uno.ui/ios"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:smtx="using:ShowMeTheXAML"
-	  xmlns:extensions="using:Uno.Material.Extensions"
-	  mc:Ignorable="d android ios">
+	  xmlns:um="using:Uno.Material"
+	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<sample:SamplePageLayout>
@@ -75,9 +72,9 @@
 						<smtx:XamlDisplay UniqueKey="Material_TextBoxSamplePage_8"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox Style="{StaticResource MaterialFilledTextBoxStyle}">
-								<extensions:ControlExtensions.Icon>
+								<um:ControlExtensions.Icon>
 									<SymbolIcon Symbol="Favorite" />
-								</extensions:ControlExtensions.Icon>
+								</um:ControlExtensions.Icon>
 							</TextBox>
 						</smtx:XamlDisplay>
 
@@ -86,9 +83,9 @@
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox PlaceholderText="Filled with Icon"
 									 Style="{StaticResource MaterialOutlinedTextBoxStyle}">
-								<extensions:ControlExtensions.Icon>
+								<um:ControlExtensions.Icon>
 									<SymbolIcon Symbol="Favorite" />
-								</extensions:ControlExtensions.Icon>
+								</um:ControlExtensions.Icon>
 							</TextBox>
 						</smtx:XamlDisplay>
 					</StackPanel>
@@ -123,7 +120,7 @@
 									 PlaceholderText="Placeholder"
 									 IsEnabled="False" />
 						</smtx:XamlDisplay>
-						
+
 						<!-- Disabled -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_TextBoxSamplePage_Disabled"
 										  Style="{StaticResource XamlDisplayBelowStyle}">

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Extensions/ControlExtensionsSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Extensions/ControlExtensionsSamplePage.xaml
@@ -1,12 +1,11 @@
 ﻿<Page x:Class="Uno.Themes.Samples.Shared.Content.Extensions.ControlExtensionsSamplePage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:local="using:Uno.Themes.Samples.Shared.Content.Extensions"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:android="http://uno.ui/android"
 	  xmlns:ios="http://uno.ui/ios"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  xmlns:extensions="using:Uno.Material.Extensions"
+	  xmlns:um="using:Uno.Material"
 	  xmlns:smtx="using:ShowMeTheXAML"
 	  mc:Ignorable="d android ios">
 	<Page.Resources>
@@ -87,10 +86,10 @@
 								  Style="{StaticResource XamlDisplayBelowStyle}">
 					<TextBox PlaceholderText="Filled"
 							 Style="{StaticResource MaterialFilledTextBoxStyle}">
-						<extensions:ControlExtensions.Icon>
+						<um:ControlExtensions.Icon>
 							<SymbolIcon Symbol="SolidStar"
 										Foreground="{StaticResource MaterialPrimaryBrush}" />
-						</extensions:ControlExtensions.Icon>
+						</um:ControlExtensions.Icon>
 					</TextBox>
 				</smtx:XamlDisplay>
 
@@ -102,10 +101,10 @@
 					<ComboBox Style="{StaticResource MaterialComboBoxStyle}"
 							  PlaceholderText="Placeholder"
 							  ItemsSource="abcdefg">
-						<extensions:ControlExtensions.Icon>
+						<um:ControlExtensions.Icon>
 							<SymbolIcon Symbol="SolidStar"
 										Foreground="{StaticResource MaterialPrimaryBrush}" />
-						</extensions:ControlExtensions.Icon>
+						</um:ControlExtensions.Icon>
 					</ComboBox>
 				</smtx:XamlDisplay>
 
@@ -122,21 +121,21 @@
 				<smtx:XamlDisplay UniqueKey="ControlExtensionsSamplePage_ToggleButtonText"
 								  Style="{StaticResource XamlDisplayBelowStyle}">
 					<ToggleButton Content="On"
-								  extensions:ControlExtensions.AlternateContent="Off"
+								  um:ControlExtensions.AlternateContent="Off"
 								  Style="{StaticResource MaterialTextToggleButtonStyle}" />
 				</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="ControlExtensionsSamplePage_ToggleButtonIcon"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<ToggleButton Style="{StaticResource MaterialToggleButtonIconStyle}">
-								<ToggleButton.Content>
-									<PathIcon Data="{StaticResource Icon_more_horizontal}" />
-								</ToggleButton.Content>
-								<extensions:ControlExtensions.AlternateContent>
-									<PathIcon Data="{StaticResource Icon_more_vertical}" />
-								</extensions:ControlExtensions.AlternateContent>
-							</ToggleButton>
-						</smtx:XamlDisplay>
+				<smtx:XamlDisplay UniqueKey="ControlExtensionsSamplePage_ToggleButtonIcon"
+								  Style="{StaticResource XamlDisplayBelowStyle}">
+					<ToggleButton Style="{StaticResource MaterialToggleButtonIconStyle}">
+						<ToggleButton.Content>
+							<PathIcon Data="{StaticResource Icon_more_horizontal}" />
+						</ToggleButton.Content>
+						<um:ControlExtensions.AlternateContent>
+							<PathIcon Data="{StaticResource Icon_more_vertical}" />
+						</um:ControlExtensions.AlternateContent>
+					</ToggleButton>
+				</smtx:XamlDisplay>
 
 			</StackPanel>
 		</StackPanel>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/OverviewPage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/OverviewPage.xaml
@@ -2,12 +2,11 @@
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	  xmlns:extensions="using:Uno.Material.Extensions"
+	  xmlns:um="using:Uno.Material"
 	  xmlns:local="using:Uno.Themes.Samples.Content"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:sample="using:Uno.Themes.Samples"
 	  xmlns:samples="using:Uno.Themes.Samples.Content.Controls"
-	  xmlns:smtx="using:ShowMeTheXAML"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
 	  mc:Ignorable="d">
 
@@ -51,9 +50,9 @@
 							<TextBox AutomationProperties.AutomationId="MaterialFilledIconTextBox"
 									 PlaceholderText="Filled with icon"
 									 Style="{StaticResource MaterialFilledTextBoxStyle}">
-								<extensions:ControlExtensions.Icon>
+								<um:ControlExtensions.Icon>
 									<SymbolIcon Symbol="Favorite" />
-								</extensions:ControlExtensions.Icon>
+								</um:ControlExtensions.Icon>
 							</TextBox>
 
 							<TextBox AutomationProperties.AutomationId="MaterialOutlinedTextBox"
@@ -63,9 +62,9 @@
 							<TextBox AutomationProperties.AutomationId="MaterialOutlinedWithIconTextBox"
 									 PlaceholderText="Outlined with icon"
 									 Style="{StaticResource MaterialOutlinedTextBoxStyle}">
-								<extensions:ControlExtensions.Icon>
+								<um:ControlExtensions.Icon>
 									<SymbolIcon Symbol="Favorite" />
-								</extensions:ControlExtensions.Icon>
+								</um:ControlExtensions.Icon>
 							</TextBox>
 						</StackPanel>
 					</sample:OverviewSampleView>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Styles/SamplePageLayout.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Styles/SamplePageLayout.xaml
@@ -1,16 +1,6 @@
-﻿<ResourceDictionary
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:local="using:Uno.Themes.Samples"
-	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:xamarin="http://uno.ui/xamarin"
-	xmlns:ios="http://uno.ui/ios"
-	xmlns:android="http://uno.ui/android"
-	xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:material="using:Uno.Material.Controls"
-	xmlns:wasm="http://uno.ui/wasm"
-	mc:Ignorable="xamarin ios android wasm">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:local="using:Uno.Themes.Samples">
 
 	<Thickness x:Key="SampleContentPadding">0,0,0,0</Thickness>
 

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Skia.Gtk/Uno.Themes.Samples.Skia.Gtk.csproj
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Skia.Gtk/Uno.Themes.Samples.Skia.Gtk.csproj
@@ -23,13 +23,13 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.0.58" />
-		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.0.58" />
-		<PackageReference Include="Uno.UI.Skia.Gtk" Version="4.0.0-dev.5676" />
-		<PackageReference Include="Uno.UI.RemoteControl" Version="4.0.0-dev.5676" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.0-dev.5676" />
-		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.0-dev.7" />
-		<PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.0-dev.7" />
+		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.0.59" />
+		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.0.59" />
+		<PackageReference Include="Uno.UI.Skia.Gtk" Version="4.0.7" />
+		<PackageReference Include="Uno.UI.RemoteControl" Version="4.0.7" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.7" />
+		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
+		<PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.UWP/Uno.Themes.Samples.UWP.csproj
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.UWP/Uno.Themes.Samples.UWP.csproj
@@ -37,11 +37,11 @@
       <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>4.0.0-dev.5676</Version>
+      <Version>4.0.7</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.0-dev.5676" />
-    <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.0-dev.7" />
-    <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.0-dev.7" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.7" />
+    <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
+    <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
   </ItemGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Wasm/Uno.Themes.Samples.Wasm.csproj
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Wasm/Uno.Themes.Samples.Wasm.csproj
@@ -50,15 +50,15 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.0.58" />
-		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.0.58" />
-		<PackageReference Include="Uno.UI.RemoteControl" Version="4.0.0-dev.5676" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.WebAssembly" Version="4.0.0-dev.5676" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.0-dev.5676" />
-		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.0-dev.7" />
-		<PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.0-dev.7" />
-		<PackageReference Include="Uno.Wasm.Bootstrap" Version="2.1.0" />
-		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="2.1.0" PrivateAssets="all" />
+		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.0.59" />
+		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.0.59" />
+		<PackageReference Include="Uno.UI.RemoteControl" Version="4.0.7" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.WebAssembly" Version="4.0.7" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.7" />
+		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
+		<PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
+		<PackageReference Include="Uno.Wasm.Bootstrap" Version="3.1.2" />
+		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="3.1.2" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.1" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.iOS/Uno.Themes.Samples.iOS.csproj
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.iOS/Uno.Themes.Samples.iOS.csproj
@@ -185,18 +185,18 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
-      <Version>1.0.58</Version>
+      <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML.MSBuild">
-      <Version>1.0.58</Version>
+      <Version>1.0.59</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="4.0.0-dev.5676" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.0-dev.5676" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI" Version="4.0.7" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.7" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.0-dev.5676" />
-    <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.0-dev.7" />
-    <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.0-dev.7" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.7" />
+    <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
+    <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\library\Uno.Cupertino\Uno.Cupertino.csproj">

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.macOS/Uno.Themes.Samples.macOS.csproj
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.macOS/Uno.Themes.Samples.macOS.csproj
@@ -84,19 +84,19 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.0-dev.5676" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.7" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
-    <PackageReference Include="Uno.UI" Version="4.0.0-dev.5676" />
+    <PackageReference Include="Uno.UI" Version="4.0.7" />
     <PackageReference Include="Uno.ShowMeTheXAML.MSBuild">
-      <Version>1.0.58</Version>
+      <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
-      <Version>1.0.58</Version>
+      <Version>1.0.59</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.0-dev.5676" />
-    <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.0-dev.7" />
-    <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.0-dev.7" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.7" />
+    <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
+    <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
   </ItemGroup>
   <Import Project="..\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems" Label="Shared" Condition="Exists('..\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems')" />
   <ItemGroup>


### PR DESCRIPTION
BREAKING CHANGE: Everything (controls, extensions, converters,...) is now under `Uno.Material`

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## Description

Everything (controls, extensions, converters,...) is now under `Uno.Material`

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [X] Tested UWP
- [X] Tested iOS
- [X] Tested Android
- [X] Tested WASM
- [X] Tested MacOS
- [ ] Contains **No** breaking changes
  - [X] Breaking change commit message added
