### PR TITLE
fix(Button): Add missing MaterialButtonIconStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ For example, if you would like change the `CornerRadius` of all the `Buttons` us
 
 | **Controls** | **StyleNames**                                                                        |
 |----------|-------------------------------------------------------------------------------------------|
-| Button   | MaterialContainedButtonStyle <br> MaterialOutlinedButtonStyle <br> MaterialTextButtonStyle <br> MaterialContainedSecondaryButtonStyle <br> MaterialOutlinedSecondaryButtonStyle<br> MaterialTextSecondaryButtonStyle |
+| Button   | MaterialContainedButtonStyle <br> MaterialOutlinedButtonStyle <br> MaterialTextButtonStyle <br> MaterialButtonIconStyle <br> MaterialContainedSecondaryButtonStyle <br> MaterialOutlinedSecondaryButtonStyle<br> MaterialTextSecondaryButtonStyle |
 | CheckBox         | MaterialCheckBoxStyle <br> MaterialSecondaryCheckBoxStyle                         |
 | ComboBox         | MaterialComboBoxStyle                                                             |
 | CommandBar       | MaterialCommandBarStyle                                                           |
@@ -204,7 +204,7 @@ For example, if you would like change the `CornerRadius` of all the `Buttons` us
 | RadioButton      | MaterialRadioButtonStyle <br> MaterialSecondaryRadioButtonStyle                   |
 | TextBlock        | MaterialHeadline1 <br> MaterialHeadline2 <br> MaterialHeadline3 <br> MaterialHeadline4 <br> MaterialHeadline5 <br> MaterialHeadline6 <br> MaterialSubtitle1 <br> MaterialSubtitle2 <br> MaterialBody1 <br> MaterialBody2 <br> MaterialButtonText <br> MaterialCaption <br> MaterialOverline                                 |
 | TextBox          | MaterialFilledTextBoxStyle <br> MaterialOutlinedTextBoxStyle                      |
-| ToggleButton     | MaterialTextToggleButtonStyle                                                     |
+| ToggleButton     | MaterialTextToggleButtonStyle <br> MaterialToggleButtonIconStyle                  |
 | ToggleSwitch     | MaterialToggleSwitchStyle                                                         |
 
 ## Controls Setup (Specialized)

--- a/src/library/Uno.Material/Styles/Controls/Button.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Button.xaml
@@ -13,7 +13,7 @@
 	</ResourceDictionary.MergedDictionaries>
 
 	<!-- Documented variables -->
-	<um:ToUpperConverter x:Key="ToUpperConverter"/>
+	<um:ToUpperConverter x:Key="ToUpperConverter" />
 	<Thickness x:Key="MaterialButtonPadding">16,8</Thickness>
 	<CornerRadius x:Key="MaterialButtonCornerRadius">4</CornerRadius>
 	<x:Double x:Key="MaterialButtonFontSize">14</x:Double>
@@ -143,15 +143,15 @@
 								Opacity="0" />
 
 						<um:Ripple x:Name="ContentPresenter"
-										 Feedback="{TemplateBinding Foreground}"
-										 FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
-										 BorderBrush="{TemplateBinding BorderBrush}"
-										 BorderThickness="{TemplateBinding BorderThickness}"
-										 CornerRadius="{TemplateBinding CornerRadius}"
-										 Padding="{TemplateBinding Padding}"
-										 AutomationProperties.AccessibilityView="Raw"
-										 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-										 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
+								   Feedback="{TemplateBinding Foreground}"
+								   FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
+								   BorderBrush="{TemplateBinding BorderBrush}"
+								   BorderThickness="{TemplateBinding BorderThickness}"
+								   CornerRadius="{TemplateBinding CornerRadius}"
+								   Padding="{TemplateBinding Padding}"
+								   AutomationProperties.AccessibilityView="Raw"
+								   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+								   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
 							<um:Ripple.Content>
 								<Grid>
 									<Grid.ColumnDefinitions>
@@ -321,15 +321,15 @@
 								Opacity="0" />
 
 						<um:Ripple x:Name="ContentPresenter"
-										 Feedback="{TemplateBinding Foreground}"
-										 FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
-										 BorderBrush="{TemplateBinding BorderBrush}"
-										 BorderThickness="{TemplateBinding BorderThickness}"
-										 CornerRadius="{TemplateBinding CornerRadius}"
-										 Padding="{TemplateBinding Padding}"
-										 AutomationProperties.AccessibilityView="Raw"
-										 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-										 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
+								   Feedback="{TemplateBinding Foreground}"
+								   FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
+								   BorderBrush="{TemplateBinding BorderBrush}"
+								   BorderThickness="{TemplateBinding BorderThickness}"
+								   CornerRadius="{TemplateBinding CornerRadius}"
+								   Padding="{TemplateBinding Padding}"
+								   AutomationProperties.AccessibilityView="Raw"
+								   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+								   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
 							<um:Ripple.Content>
 								<Grid>
 									<Grid.ColumnDefinitions>
@@ -491,15 +491,15 @@
 								Opacity="0" />
 
 						<um:Ripple x:Name="ContentPresenter"
-										 Feedback="{TemplateBinding Foreground}"
-										 FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
-										 BorderBrush="{TemplateBinding BorderBrush}"
-										 BorderThickness="{TemplateBinding BorderThickness}"
-										 CornerRadius="{TemplateBinding CornerRadius}"
-										 Padding="{TemplateBinding Padding}"
-										 AutomationProperties.AccessibilityView="Raw"
-										 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-										 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
+								   Feedback="{TemplateBinding Foreground}"
+								   FeedbackOpacity="{StaticResource MaterialPressedOpacity}"
+								   BorderBrush="{TemplateBinding BorderBrush}"
+								   BorderThickness="{TemplateBinding BorderThickness}"
+								   CornerRadius="{TemplateBinding CornerRadius}"
+								   Padding="{TemplateBinding Padding}"
+								   AutomationProperties.AccessibilityView="Raw"
+								   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+								   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
 							<um:Ripple.Content>
 								<Grid>
 									<Grid.ColumnDefinitions>
@@ -541,6 +541,96 @@
 		   BasedOn="{StaticResource MaterialTextButtonStyle}">
 		<Setter Property="Foreground"
 				Value="{StaticResource MaterialSecondaryBrush}" />
+	</Style>
+
+	<Style x:Key="MaterialButtonIconStyle"
+		   TargetType="Button">
+		<Setter Property="Foreground"
+				Value="{StaticResource MaterialOnSurfaceBrush}" />
+		<Setter Property="Background"
+				Value="Transparent" />
+		<Setter Property="BorderThickness"
+				Value="0" />
+		<Setter Property="MinHeight"
+				Value="40" />
+		<Setter Property="MinWidth"
+				Value="40" />
+		<Setter Property="UseSystemFocusVisuals"
+				Value="True" />
+		<Setter Property="HorizontalContentAlignment"
+				Value="Center" />
+		<Setter Property="VerticalContentAlignment"
+				Value="Center" />
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="Button">
+					<Grid x:Name="RootGrid"
+						  Background="{TemplateBinding Background}"
+						  BorderBrush="{TemplateBinding BorderBrush}"
+						  BorderThickness="{TemplateBinding BorderThickness}">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal" />
+								<VisualState x:Name="PointerOver">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity"
+												Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="Pressed">
+									<VisualState.Setters>
+										<Setter Target="PressedOverlay.Opacity"
+												Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="Focused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="ContentPresenter.Foreground"
+												Value="{StaticResource MaterialOnSurfaceLowBrush}" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+
+						<!-- Ellipse for PointedOver State -->
+						<Ellipse x:Name="HoverOverlay"
+								 HorizontalAlignment="Stretch"
+								 VerticalAlignment="Stretch"
+								 Fill="{StaticResource MaterialPrimaryHoverBrush}"
+								 Opacity="0" />
+
+						<!-- Ellipse for Pressed State -->
+						<Ellipse x:Name="PressedOverlay"
+								 HorizontalAlignment="Stretch"
+								 VerticalAlignment="Stretch"
+								 Fill="{StaticResource MaterialPrimaryPressedBrush}"
+								 Opacity="0" />
+
+						<!-- Ellipse for Focused State -->
+						<Ellipse x:Name="FocusedOverlay"
+								 HorizontalAlignment="Stretch"
+								 VerticalAlignment="Stretch"
+								 Fill="{StaticResource MaterialPrimaryFocusedBrush}"
+								 Opacity="0" />
+
+						<!-- Content -->
+						<ContentPresenter x:Name="ContentPresenter"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Content="{TemplateBinding Content}"
+										  ContentTemplate="{TemplateBinding ContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
 	</Style>
 
 	<Style x:Key="SeeStyleFlyoutButtonStyle"

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ButtonSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ButtonSamplePage.xaml
@@ -48,7 +48,7 @@
 						<!-- Button Text -->
 						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_Text"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<Button Content="Test"
+							<Button Content="Text"
 									Style="{StaticResource MaterialTextButtonStyle}" />
 						</smtx:XamlDisplay>
 
@@ -58,6 +58,16 @@
 							<Button Content="TEXT DISABLED"
 									IsEnabled="False"
 									Style="{StaticResource MaterialTextButtonStyle}" />
+						</smtx:XamlDisplay>
+
+						<!-- Button Icon  -->
+						<smtx:XamlDisplay UniqueKey="Material_ButtonSamplePage_Icon"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<Button Style="{StaticResource MaterialButtonIconStyle}">
+								<Button.Content>
+									<SymbolIcon Symbol="Favorite" />
+								</Button.Content>
+							</Button>
 						</smtx:XamlDisplay>
 
 						<!-- STRETCHED BUTTONS -->

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/OverviewPage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/OverviewPage.xaml
@@ -36,6 +36,13 @@
 							<Button AutomationProperties.AutomationId="MaterialTextButton"
 									Content="TEXT"
 									Style="{StaticResource MaterialTextButtonStyle}" />
+
+							<Button AutomationProperties.AutomationId="MaterialButtonIcon"
+									Style="{StaticResource MaterialButtonIconStyle}">
+								<Button.Content>
+									<SymbolIcon Symbol="Favorite" />
+								</Button.Content>
+							</Button>
 						</StackPanel>
 					</sample:OverviewSampleView>
 


### PR DESCRIPTION
﻿GitHub Issue: https://github.com/unoplatform/uno.toolkit.ui/issues/166

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Add missing MaterialButtonIconStyle for Uno.Material


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [X] Tested UWP
- [X] Tested iOS
- [X] Tested Android
- [X] Tested WASM
- [ ] Tested MacOS
- [X] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
