### PR TITLE
chore(Android): Remove workarounds not needed anymore and enabling again Fast Deployment

### DIFF
--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Droid/Uno.Themes.Samples.Droid.csproj
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Droid/Uno.Themes.Samples.Droid.csproj
@@ -14,8 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
-    <!-- AndroidUseAapt2 is disabled until https://github.com/unoplatform/uno/issues/1382 is resolved -->
-    <AndroidUseAapt2>false</AndroidUseAapt2>
+    <AndroidUseAapt2>true</AndroidUseAapt2>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
@@ -38,7 +37,6 @@
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
     <BundleAssemblies>false</BundleAssemblies>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
-    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>
@@ -215,6 +213,4 @@
   <ItemGroup />
   <Import Project="..\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems" Label="Shared" Condition="Exists('..\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <!-- This will force the generation of the APK when not building inside visual studio -->
-  <Target Name="GenerateBuild" DependsOnTargets="SignAndroidPackage" AfterTargets="Build" Condition="'$(BuildingInsideVisualStudio)'==''" />
 </Project>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Android project file changes

## Description

- Remove workarounds not needed anymore as their related issues are now fixed:
  - Enable again AndroidUseAapt2 as https://github.com/unoplatform/uno/issues/1382 is now resolved
  - Remove the target that will force the generation of the APK as it's not needed anymore and as it causes issues to deploy on Android with latest VS 2022 Prev 17.1.0 Preview 1.0 and 1.1
- Enabling again Fast Deployment by default for Debug as when disabled this cause issues to deploy on Android with latest VS 2022 Prev 17.1.0 Preview 1.0 and 1.1 
(Related issues : https://github.com/xamarin/xamarin-android/issues/6480 / https://developercommunity.visualstudio.com/t/cannot-debug-on-android/1590528)

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [X] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [X] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

