### PR TITLE
feat: use templated parent border brush on combo box's elevated view

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/ComboBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/ComboBox.xaml
@@ -216,6 +216,8 @@
 				Value="{ThemeResource ComboBoxForegroundThemeBrush}" />
 		<Setter Property="Background"
 				Value="{ThemeResource ComboBoxBackgroundColorBrush}" />
+		<Setter Property="BorderBrush"
+				Value="{StaticResource ComboBoxBorderBrush}" />
 		<Setter Property="BorderThickness"
 				Value="1" />
 		<Setter Property="Padding"
@@ -382,7 +384,7 @@
 											  HorizontalAlignment="Stretch"
 											  CornerRadius="{StaticResource MaterialComboBoxCornerRadius}"
 											  Elevation="8"
-											  BorderBrush="{StaticResource ComboBoxBorderBrush}"
+											  BorderBrush="{TemplateBinding BorderBrush}"
 											  BorderThickness="{TemplateBinding BorderThickness}">
 
 							<Grid x:Name="ComboBoxContent"


### PR DESCRIPTION
﻿GitHub Issue: closes #701

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

Instead of forcing the default combo box border brush onto the elevated view, we instead set it as default and let the templated parent set its own border brush.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [x] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
