### PR TITLE
ci: Adjust for Uno 4.1 and Android 12

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,6 @@
 		<PackageIcon>uno-logo.png</PackageIcon>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageReleaseNotes Condition="exists('$(MSBuildThisFileDirectory)\changelog.md')">changelog.md</PackageReleaseNotes>
 	</PropertyGroup>
 	
 	<PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
@@ -27,7 +26,6 @@
 	<ItemGroup>
 		<None Include="$(MSBuildThisFileDirectory)build\uno-logo.png" Pack="true" Visible="false" PackagePath="\"/>
 		<None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="/" />
-		<None Include="$(MSBuildThisFileDirectory)build\changelog.md" Pack="true" PackagePath="/" Condition="exists('$(MSBuildThisFileDirectory)build\changelog.md')" />
 	</ItemGroup>
 	
 	<Choose>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,13 @@
+﻿<Project ToolsVersion="15.0">
+	<Target Name="_FillReleaseNotes"
+					AfterTargets="BeforeBuild"
+					Condition="'$(PackageReleaseNotesFile)'!=''">
+
+		<CreateProperty Value="$([System.IO.File]::ReadAllText($(PackageReleaseNotesFile)))">
+			<Output
+					TaskParameter="Value"
+					PropertyName="PackageReleaseNotes" />
+		</CreateProperty>
+
+	</Target>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,6 @@
 ﻿<Project ToolsVersion="15.0">
 	<Target Name="_FillReleaseNotes"
-					AfterTargets="BeforeBuild"
+					BeforeTargets="GenerateNuspec"
 					Condition="'$(PackageReleaseNotesFile)'!=''">
 
 		<CreateProperty Value="$([System.IO.File]::ReadAllText($(PackageReleaseNotesFile)))">

--- a/build/stage-build.yml
+++ b/build/stage-build.yml
@@ -44,7 +44,7 @@
     configuration: Release
     platform: $(ApplicationPlatform)
     maximumCpuCount: true
-    msbuildArguments: /ds /m /r /p:PackageVersion=$(SemVer) /p:ApplicationVersion=$(MajorMinorPatch) /p:RestoreConfigFile=$(Build.SourcesDirectory)\nuget.config /p:PackageReleaseNotesFile=build/CHANGELOG.md /bl:$(build.artifactstagingdirectory)/build-$(ApplicationPlatform).binlog
+    msbuildArguments: /ds /m /r /p:PackageVersion=$(SemVer) /p:ApplicationVersion=$(MajorMinorPatch) /p:RestoreConfigFile=$(Build.SourcesDirectory)\nuget.config /p:PackageReleaseNotesFile=$(Build.SourcesDirectory)/build/CHANGELOG.md /bl:$(build.artifactstagingdirectory)/build-$(ApplicationPlatform).binlog
 
 - task: PublishBuildArtifacts@1
   condition: always()

--- a/build/stage-build.yml
+++ b/build/stage-build.yml
@@ -44,7 +44,7 @@
     configuration: Release
     platform: $(ApplicationPlatform)
     maximumCpuCount: true
-    msbuildArguments: /ds /m /r /p:PackageVersion=$(SemVer) /p:ApplicationVersion=$(MajorMinorPatch) /p:RestoreConfigFile=$(Build.SourcesDirectory)\nuget.config /bl:$(build.artifactstagingdirectory)/build-$(ApplicationPlatform).binlog
+    msbuildArguments: /ds /m /r /p:PackageVersion=$(SemVer) /p:ApplicationVersion=$(MajorMinorPatch) /p:RestoreConfigFile=$(Build.SourcesDirectory)\nuget.config /p:PackageReleaseNotesFile=build/CHANGELOG.md /bl:$(build.artifactstagingdirectory)/build-$(ApplicationPlatform).binlog
 
 - task: PublishBuildArtifacts@1
   condition: always()

--- a/src/library/Uno.Cupertino/Uno.Cupertino.csproj
+++ b/src/library/Uno.Cupertino/Uno.Cupertino.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/3.0.23">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;xamarinios10;xamarinmac20;MonoAndroid10.0;monoandroid11.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;xamarinios10;xamarinmac20;monoandroid11.0</TargetFrameworks>
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>portable</DebugType>

--- a/src/library/Uno.Material/Uno.Material.csproj
+++ b/src/library/Uno.Material/Uno.Material.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/3.0.23">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;xamarinios10;monoandroid10.0;monoandroid11.0;xamarinmac20</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;xamarinios10;monoandroid11.0;xamarinmac20</TargetFrameworks>
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>portable</DebugType>


### PR DESCRIPTION
Removes MonoAndroid 10.0 which is not available anymore with the Play Store.