### PR TITLE
Don't build Skia.GTK/macOS heads for Android config

### DIFF
--- a/Uno.Themes.sln
+++ b/Uno.Themes.sln
@@ -217,7 +217,6 @@ Global
 		{2C13056C-D56D-4302-A983-14AF3FFA565C}.Release|UWP_x64.ActiveCfg = Release|iPhoneSimulator
 		{2C13056C-D56D-4302-A983-14AF3FFA565C}.Release|WASM.ActiveCfg = Release|iPhoneSimulator
 		{E5A33630-47C0-4E0B-8D0A-9D50CCC3498B}.Debug|Android.ActiveCfg = Debug|iPhoneSimulator
-		{E5A33630-47C0-4E0B-8D0A-9D50CCC3498B}.Debug|Android.Build.0 = Debug|iPhoneSimulator
 		{E5A33630-47C0-4E0B-8D0A-9D50CCC3498B}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
 		{E5A33630-47C0-4E0B-8D0A-9D50CCC3498B}.Debug|Any CPU.Build.0 = Debug|iPhoneSimulator
 		{E5A33630-47C0-4E0B-8D0A-9D50CCC3498B}.Debug|iPhone.ActiveCfg = Debug|iPhoneSimulator
@@ -248,7 +247,6 @@ Global
 		{E5A33630-47C0-4E0B-8D0A-9D50CCC3498B}.Release|WASM.ActiveCfg = Release|iPhoneSimulator
 		{E5A33630-47C0-4E0B-8D0A-9D50CCC3498B}.Release|WASM.Build.0 = Release|iPhoneSimulator
 		{290980EF-0A64-43A5-AEB4-E022D82BBF8B}.Debug|Android.ActiveCfg = Debug|Any CPU
-		{290980EF-0A64-43A5-AEB4-E022D82BBF8B}.Debug|Android.Build.0 = Debug|Any CPU
 		{290980EF-0A64-43A5-AEB4-E022D82BBF8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{290980EF-0A64-43A5-AEB4-E022D82BBF8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{290980EF-0A64-43A5-AEB4-E022D82BBF8B}.Debug|iPhone.ActiveCfg = Debug|Any CPU
@@ -266,7 +264,6 @@ Global
 		{290980EF-0A64-43A5-AEB4-E022D82BBF8B}.Debug|WASM.ActiveCfg = Debug|Any CPU
 		{290980EF-0A64-43A5-AEB4-E022D82BBF8B}.Debug|WASM.Build.0 = Debug|Any CPU
 		{290980EF-0A64-43A5-AEB4-E022D82BBF8B}.Release|Android.ActiveCfg = Release|Any CPU
-		{290980EF-0A64-43A5-AEB4-E022D82BBF8B}.Release|Android.Build.0 = Release|Any CPU
 		{290980EF-0A64-43A5-AEB4-E022D82BBF8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{290980EF-0A64-43A5-AEB4-E022D82BBF8B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{290980EF-0A64-43A5-AEB4-E022D82BBF8B}.Release|iPhone.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes


## Description

Themes SampleApp `Debug|Android` and `Release|Android` build configs should not build Skia.Gtk or macOS heads

