### PR TITLE
fix: Made TextBox uniform with PasswordBox.

### DIFF
--- a/src/library/Uno.Cupertino/Generated/mergedpages.xaml
+++ b/src/library/Uno.Cupertino/Generated/mergedpages.xaml
@@ -81,11 +81,7 @@
                     <Setter Target="FocusedOverlay.Opacity" Value="{StaticResource CupertinoFocusedOpacity}" />
                   </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="PointerFocused">
-                  <VisualState.Setters>
-                    <Setter Target="FocusedOverlay.Opacity" Value="{StaticResource CupertinoFocusedOpacity}" />
-                  </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="PointerFocused" />
                 <VisualState x:Name="Unfocused">
                   <VisualState.Setters>
                     <Setter Target="FocusedOverlay.Opacity" Value="0" />
@@ -149,11 +145,7 @@
                     <Setter Target="FocusedOverlay.Opacity" Value="{StaticResource CupertinoFocusedOpacity}" />
                   </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="PointerFocused">
-                  <VisualState.Setters>
-                    <Setter Target="FocusedOverlay.Opacity" Value="{StaticResource CupertinoFocusedOpacity}" />
-                  </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="PointerFocused" />
                 <VisualState x:Name="Unfocused">
                   <VisualState.Setters>
                     <Setter Target="FocusedOverlay.Opacity" Value="0" />
@@ -839,11 +831,7 @@
                     <Setter Target="FocusRing.Opacity" Value="{StaticResource CupertinoFocusedOpacity}" />
                   </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="PointerFocused">
-                  <VisualState.Setters>
-                    <Setter Target="FocusRing.Opacity" Value="{StaticResource CupertinoFocusedOpacity}" />
-                  </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="PointerFocused" />
                 <VisualState x:Name="Unfocused" />
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
@@ -1555,11 +1543,7 @@
                     <Setter Target="FocusRing.Opacity" Value="{StaticResource CupertinoFocusedOpacity}" />
                   </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="PointerFocused">
-                  <VisualState.Setters>
-                    <Setter Target="FocusRing.Opacity" Value="{StaticResource CupertinoFocusedOpacity}" />
-                  </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="PointerFocused" />
                 <VisualState x:Name="Unfocused" />
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>

--- a/src/library/Uno.Material/Generated/mergedpages.xaml
+++ b/src/library/Uno.Material/Generated/mergedpages.xaml
@@ -283,11 +283,7 @@
                     <Setter Target="FocusedOverlay.Opacity" Value="{StaticResource MaterialFocusedOpacity}" />
                   </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="PointerFocused">
-                  <VisualState.Setters>
-                    <Setter Target="FocusedOverlay.Opacity" Value="{StaticResource MaterialFocusedOpacity}" />
-                  </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="PointerFocused" />
                 <VisualState x:Name="Unfocused">
                   <VisualState.Setters>
                     <Setter Target="FocusedOverlay.Opacity" Value="0" />
@@ -376,11 +372,7 @@
                     <Setter Target="FocusedOverlay.Opacity" Value="{StaticResource MaterialFocusedOpacity}" />
                   </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="PointerFocused">
-                  <VisualState.Setters>
-                    <Setter Target="FocusedOverlay.Opacity" Value="{StaticResource MaterialFocusedOpacity}" />
-                  </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="PointerFocused" />
                 <VisualState x:Name="Unfocused">
                   <VisualState.Setters>
                     <Setter Target="FocusedOverlay.Opacity" Value="0" />
@@ -471,11 +463,7 @@
                     <Setter Target="FocusedOverlay.Opacity" Value="{StaticResource MaterialFocusedOpacity}" />
                   </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="Unfocused">
-                  <VisualState.Setters>
-                    <Setter Target="FocusedOverlay.Opacity" Value="0" />
-                  </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="Unfocused" />
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
             <Border x:Name="CommonStatesOverlay" Background="{TemplateBinding Foreground}" Opacity="0" />
@@ -1350,11 +1338,7 @@
                     <Setter Target="FocusRing.Opacity" Value="{StaticResource MaterialFocusedOpacity}" />
                   </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="PointerFocused">
-                  <VisualState.Setters>
-                    <Setter Target="FocusRing.Opacity" Value="{StaticResource MaterialFocusedOpacity}" />
-                  </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="PointerFocused" />
                 <VisualState x:Name="Unfocused" />
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
@@ -1943,11 +1927,7 @@
                     <Setter Target="FabFocusBorder.Background" Value="{StaticResource MaterialOnSurfaceFocusedBrush}" />
                   </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="PointerFocused">
-                  <VisualState.Setters>
-                    <Setter Target="FabFocusBorder.Background" Value="{StaticResource MaterialOnSurfaceFocusedBrush}" />
-                  </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="PointerFocused" />
                 <VisualState x:Name="Unfocused" />
               </VisualStateGroup>
               <VisualStateGroup>
@@ -2029,11 +2009,7 @@
                     <Setter Target="FabFocusBorder.Background" Value="{StaticResource MaterialOnSurfaceFocusedBrush}" />
                   </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="PointerFocused">
-                  <VisualState.Setters>
-                    <Setter Target="FabFocusBorder.Background" Value="{StaticResource MaterialOnSurfaceFocusedBrush}" />
-                  </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="PointerFocused" />
                 <VisualState x:Name="Unfocused" />
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
@@ -3411,7 +3387,9 @@
                     <Setter Target="RootGrid.Background" Value="{ThemeResource MaterialMUXTopNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPointerOver}" />
-                    <contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)" Value="PointerOver" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)"
+																 Value="PointerOver" />-->
                   </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="Pressed">
@@ -3419,7 +3397,9 @@
                     <Setter Target="RootGrid.Background" Value="{ThemeResource MaterialMUXTopNavigationViewItemBackgroundPressed}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundPressed}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPressed}" />
-                    <contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)" Value="Pressed" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)"
+																 Value="Pressed" />-->
                   </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="Disabled">
@@ -3460,7 +3440,9 @@
                     <Setter Target="RootGrid.Background" Value="{ThemeResource MaterialMUXTopNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPointerOver}" />
-                    <contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)" Value="PointerOver" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)"
+																 Value="PointerOver" />-->
                   </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="Pressed">
@@ -3468,7 +3450,9 @@
                     <Setter Target="RootGrid.Background" Value="{ThemeResource MaterialMUXTopNavigationViewItemBackgroundPressed}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundPressed}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPressed}" />
-                    <contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)" Value="Pressed" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)"
+																 Value="Pressed" />-->
                   </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="Disabled">
@@ -3701,7 +3685,9 @@
                 <VisualState x:Name="Normal" />
                 <VisualState x:Name="PointerOver">
                   <VisualState.Setters>
-                    <contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="PointerOver" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
+																 Value="PointerOver" />-->
                     <Setter Target="BackgroundBorder.Background" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="RevealBorder.BorderBrush" Value="{ThemeResource MaterialMUXNavigationViewItemBorderBrushPointerOver}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXNavigationViewItemForegroundPointerOver}" />
@@ -3710,7 +3696,9 @@
                 </VisualState>
                 <VisualState x:Name="Pressed">
                   <VisualState.Setters>
-                    <contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="Pressed" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
+																 Value="Pressed" />-->
                     <Setter Target="BackgroundBorder.Background" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundPressed}" />
                     <Setter Target="RevealBorder.BorderBrush" Value="{ThemeResource MaterialMUXNavigationViewItemBorderBrushPressed}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXNavigationViewItemForegroundPressed}" />
@@ -3727,7 +3715,9 @@
                 </VisualState>
                 <VisualState x:Name="PointerOverSelected">
                   <VisualState.Setters>
-                    <contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="PointerOver" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
+																 Value="PointerOver" />-->
                     <Setter Target="BackgroundBorder.Background" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundSelectedPointerOver}" />
                     <Setter Target="RevealBorder.BorderBrush" Value="{ThemeResource MaterialMUXNavigationViewItemBorderBrushSelectedPointerOver}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXNavigationViewItemForegroundSelectedPointerOver}" />
@@ -3736,7 +3726,9 @@
                 </VisualState>
                 <VisualState x:Name="PressedSelected">
                   <VisualState.Setters>
-                    <contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="Pressed" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
+																 Value="Pressed" />-->
                     <Setter Target="BackgroundBorder.Background" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundSelectedPressed}" />
                     <Setter Target="RevealBorder.BorderBrush" Value="{ThemeResource MaterialMUXNavigationViewItemBorderBrushSelectedPressed}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXNavigationViewItemForegroundSelectedPressed}" />
@@ -3948,7 +3940,9 @@
                     <Setter Target="LayoutRoot.Background" Value="{ThemeResource MaterialMUXTopNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPointerOver}" />
-                    <contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="PointerOver" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
+																 Value="PointerOver" />-->
                   </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="Pressed">
@@ -3956,7 +3950,9 @@
                     <Setter Target="LayoutRoot.Background" Value="{ThemeResource MaterialMUXTopNavigationViewItemBackgroundPressed}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundPressed}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPressed}" />
-                    <contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="Pressed" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
+																 Value="Pressed" />-->
                   </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="Selected">
@@ -3971,7 +3967,9 @@
                     <Setter Target="LayoutRoot.Background" Value="{ThemeResource MaterialMUXTopNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundSelectedPointerOver}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPointerOver}" />
-                    <contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="PointerOver" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
+																 Value="PointerOver" />-->
                   </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="PressedSelected">
@@ -3979,7 +3977,9 @@
                     <Setter Target="LayoutRoot.Background" Value="{ThemeResource MaterialMUXTopNavigationViewItemBackgroundPressed}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundSelectedPressed}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPressed}" />
-                    <contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="Pressed" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
+																 Value="Pressed" />-->
                   </VisualState.Setters>
                 </VisualState>
               </VisualStateGroup>
@@ -4036,7 +4036,9 @@
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPointerOver}" />
                     <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPointerOver}" />
-                    <contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="PointerOver" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
+																 Value="PointerOver" />-->
                   </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="Pressed">
@@ -4045,7 +4047,9 @@
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundPressed}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPressed}" />
                     <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPressed}" />
-                    <contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="Pressed" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
+																 Value="Pressed" />-->
                   </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="Selected">
@@ -4062,7 +4066,9 @@
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundSelectedPointerOver}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPointerOver}" />
                     <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPointerOver}" />
-                    <contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="PointerOver" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
+																 Value="PointerOver" />-->
                   </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="PressedSelected">
@@ -4071,7 +4077,9 @@
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialMUXNavigationViewItemBackgroundSelectedPressed}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPressed}" />
                     <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource MaterialMUXTopNavigationViewItemForegroundPressed}" />
-                    <contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="Pressed" />
+                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
+																 Value="Pressed" />-->
                   </VisualState.Setters>
                 </VisualState>
               </VisualStateGroup>
@@ -6101,11 +6109,7 @@
                     <Setter Target="FocusRing.Opacity" Value="{StaticResource MaterialFocusedOpacity}" />
                   </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="PointerFocused">
-                  <VisualState.Setters>
-                    <Setter Target="FocusRing.Opacity" Value="{StaticResource MaterialFocusedOpacity}" />
-                  </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="PointerFocused" />
                 <VisualState x:Name="Unfocused" />
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
@@ -6710,7 +6714,9 @@
     <Setter Property="CornerRadius" Value="{StaticResource TextBoxOutlinedCorderRadius}" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
-    <Setter Property="Padding" Value="12,16" />
+    <!--<Setter Property="Padding"
+				Value="12,16" />-->
+    <Setter Property="Padding" Value="12,4,8,4" />
     <Setter Property="MinHeight" Value="50" />
     <!-- Workaround for WinUI issue: https://github.com/microsoft/microsoft-ui-xaml/issues/6388 -->
     <Setter Property="um:ControlExtensions.Icon" Value="{x:Null}" />
@@ -6772,18 +6778,18 @@
               <ColumnDefinition Width="*" />
               <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <ContentPresenter x:Name="IconPresenter" Content="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}" HorizontalAlignment="Center" MaxHeight="34" MaxWidth="34" MinWidth="25" Margin="0,0,8,0" VerticalAlignment="Bottom" Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
-            <ScrollViewer x:Name="ContentElement" Grid.Column="1" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}" IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}" IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}" IsTabStop="False" IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}" VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" VerticalAlignment="Bottom" ZoomMode="Disabled" AutomationProperties.AccessibilityView="Raw">
+            <ContentPresenter x:Name="IconPresenter" Content="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}" HorizontalAlignment="Center" MaxHeight="34" MaxWidth="34" MinWidth="25" Margin="0,0,8,0" VerticalAlignment="Center" Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+            <ScrollViewer x:Name="ContentElement" Grid.Column="1" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}" IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}" IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}" IsTabStop="False" IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}" VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" ZoomMode="Disabled" AutomationProperties.AccessibilityView="Raw">
               <ScrollViewer.RenderTransform>
                 <CompositeTransform x:Name="ContentElement_CompositeTransform" />
               </ScrollViewer.RenderTransform>
             </ScrollViewer>
-            <TextBlock x:Name="PlaceholderElement" Grid.Column="1" Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" IsHitTestVisible="False" RenderTransformOrigin="0,0.5" Text="{TemplateBinding PlaceholderText}" TextAlignment="{TemplateBinding TextAlignment}" TextWrapping="{TemplateBinding TextWrapping}" VerticalAlignment="Top">
+            <TextBlock x:Name="PlaceholderElement" Grid.Column="1" Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" IsHitTestVisible="False" RenderTransformOrigin="0,0.5" Text="{TemplateBinding PlaceholderText}" TextAlignment="{TemplateBinding TextAlignment}" TextWrapping="{TemplateBinding TextWrapping}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
               <TextBlock.RenderTransform>
                 <CompositeTransform x:Name="PlaceholderElement_CompositeTransform" />
               </TextBlock.RenderTransform>
             </TextBlock>
-            <Button x:Name="DeleteButton" Grid.Column="2" Foreground="{TemplateBinding BorderBrush}" IsTabStop="False" Style="{StaticResource DeleteButtonStyle}" VerticalAlignment="Bottom" Visibility="Collapsed" AutomationProperties.AccessibilityView="Raw" />
+            <Button x:Name="DeleteButton" Grid.Column="2" Foreground="{TemplateBinding BorderBrush}" IsTabStop="False" Style="{StaticResource DeleteButtonStyle}" VerticalAlignment="Stretch" Visibility="Collapsed" AutomationProperties.AccessibilityView="Raw" />
           </Grid>
         </ControlTemplate>
       </Setter.Value>
@@ -7003,11 +7009,7 @@
                     <Setter Target="FocusedOverlay.Opacity" Value="1" />
                   </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="PointerFocused">
-                  <VisualState.Setters>
-                    <Setter Target="FocusedOverlay.Opacity" Value="1" />
-                  </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="PointerFocused" />
                 <VisualState x:Name="Unfocused">
                   <VisualState.Setters>
                     <Setter Target="FocusedOverlay.Opacity" Value="0" />
@@ -7348,12 +7350,7 @@
                     <Setter Target="SwitchKnobOffShadow.Opacity" Value="0.2" />
                   </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="PointerFocused">
-                  <VisualState.Setters>
-                    <Setter Target="SwitchKnobOnShadow.Opacity" Value="0.2" />
-                    <Setter Target="SwitchKnobOffShadow.Opacity" Value="0.2" />
-                  </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="PointerFocused" />
                 <VisualState x:Name="Unfocused">
                   <VisualState.Setters>
                     <Setter Target="SwitchKnobOnShadow.Opacity" Value="0" />

--- a/src/library/Uno.Material/Generated/mergedpages.xaml
+++ b/src/library/Uno.Material/Generated/mergedpages.xaml
@@ -6714,8 +6714,6 @@
     <Setter Property="CornerRadius" Value="{StaticResource TextBoxOutlinedCorderRadius}" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
-    <!--<Setter Property="Padding"
-				Value="12,16" />-->
     <Setter Property="Padding" Value="12,4,8,4" />
     <Setter Property="MinHeight" Value="50" />
     <!-- Workaround for WinUI issue: https://github.com/microsoft/microsoft-ui-xaml/issues/6388 -->

--- a/src/library/Uno.Material/Styles/Controls/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/TextBox.xaml
@@ -278,8 +278,10 @@
 				Value="Left" />
 		<Setter Property="VerticalContentAlignment"
 				Value="Center" />
+		<!--<Setter Property="Padding"
+				Value="12,16" />-->
 		<Setter Property="Padding"
-				Value="12,16" />
+				Value="12,4,8,4" />
 		<Setter Property="MinHeight"
 				Value="50" />
 
@@ -385,7 +387,7 @@
 										  MaxWidth="34"
 										  MinWidth="25"
 										  Margin="0,0,8,0"
-										  VerticalAlignment="Bottom"
+										  VerticalAlignment="Center"
 										  Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
 
 						<ScrollViewer x:Name="ContentElement"
@@ -398,7 +400,7 @@
 									  IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
 									  VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
 									  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-									  VerticalAlignment="Bottom"
+									  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
 									  ZoomMode="Disabled"
 									  AutomationProperties.AccessibilityView="Raw">
 							<ScrollViewer.RenderTransform>
@@ -415,7 +417,7 @@
 								   Text="{TemplateBinding PlaceholderText}"
 								   TextAlignment="{TemplateBinding TextAlignment}"
 								   TextWrapping="{TemplateBinding TextWrapping}"
-								   VerticalAlignment="Top">
+								   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
 							<TextBlock.RenderTransform>
 								<CompositeTransform x:Name="PlaceholderElement_CompositeTransform" />
 							</TextBlock.RenderTransform>
@@ -426,7 +428,7 @@
 								Foreground="{TemplateBinding BorderBrush}"
 								IsTabStop="False"
 								Style="{StaticResource DeleteButtonStyle}"
-								VerticalAlignment="Bottom"
+								VerticalAlignment="Stretch"
 								Visibility="Collapsed"
 								AutomationProperties.AccessibilityView="Raw" />
 					</Grid>

--- a/src/library/Uno.Material/Styles/Controls/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/TextBox.xaml
@@ -278,8 +278,6 @@
 				Value="Left" />
 		<Setter Property="VerticalContentAlignment"
 				Value="Center" />
-		<!--<Setter Property="Padding"
-				Value="12,16" />-->
 		<Setter Property="Padding"
 				Value="12,4,8,4" />
 		<Setter Property="MinHeight"


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->

`TextBox` and `PasswordBox` may have different heights with `Uno.Material 1.4.0-dev.17` with a custom font and some custom font size settings even if they are configured the exact same way. They also have different button alignments.

Before when height is not manually set:
![Animation_14](https://user-images.githubusercontent.com/57812285/160480911-97456f0f-f3c4-497e-91d6-9d1fa22b2083.gif)

Before when height is manually set:
![Animation_15](https://user-images.githubusercontent.com/57812285/160480936-1fdf3c35-9cd5-42b6-9bc8-4ece68dba021.gif)

After:
![Animation_16](https://user-images.githubusercontent.com/57812285/160481795-39df8313-b907-469c-8f93-1959483e55c6.gif)

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] ~~Tested MacOS~~
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information

<!-- Please provide any additional information if necessary -->

N/A

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

N/A
