### PR TITLE
fix(CheckBox): Avoid resource name clash for Path Data resources with xamlmerge

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/CheckBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/CheckBox.xaml
@@ -9,8 +9,8 @@
 					xmlns:xamarin="http://uno.ui/xamarin"
 					mc:Ignorable="android ios not_ios wasm xamarin">
 
-	<x:String x:Key="HyphenGlyphPathStyle">M0,0L32,0 32,5.3 0,5.3z</x:String>
-	<x:String x:Key="CheckGlyphPathStyle">M28.718018,0L32,3.2819897 10.666016,24.616999 0,13.951997 3.2810059,10.670007 10.666016,18.055033z</x:String>
+	<x:String x:Key="CheckBoxHyphenGlyphPathStyle">M0,0L32,0 32,5.3 0,5.3z</x:String>
+	<x:String x:Key="CheckBoxCheckGlyphPathStyle">M28.718018,0L32,3.2819897 10.666016,24.616999 0,13.951997 3.2810059,10.670007 10.666016,18.055033z</x:String>
 
 	<GridLength x:Key="CheckAreaLength">40</GridLength>
 	<x:Double x:Key="FocusAreaSize">40</x:Double>
@@ -488,7 +488,7 @@
 								  CornerRadius="2" />
 
 							<Path x:Name="HyphenGlyph"
-								  Data="{StaticResource HyphenGlyphPathStyle}"
+								  Data="{StaticResource CheckBoxHyphenGlyphPathStyle}"
 								  Fill="{TemplateBinding Foreground}"
 								  VerticalAlignment="Center"
 								  HorizontalAlignment="Center"
@@ -500,7 +500,7 @@
 								  xamarin:Margin="0,2,0,0" />
 
 							<Path x:Name="CheckGlyph"
-								  Data="{StaticResource CheckGlyphPathStyle}"
+								  Data="{StaticResource CheckBoxCheckGlyphPathStyle}"
 								  Fill="{TemplateBinding Foreground}"
 								  VerticalAlignment="Center"
 								  HorizontalAlignment="Center"

--- a/src/library/Uno.Material/Styles/Controls/Flyout.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Flyout.xaml
@@ -7,8 +7,8 @@
 					xmlns:android="http://uno.ui/android"
 					mc:Ignorable="not_win ios android">
 
-	<x:String x:Key="CheckGlyphPathStyle">M30.561941,0L31.997,1.393004 10.467954,23.597999 0,15.350999 1.2379759,13.780992 10.287961,20.909952z</x:String>
-	<x:String x:Key="RightArrowPathStyle">M0,0L25.194,16 0,32z</x:String>
+	<x:String x:Key="FlyoutCheckGlyphPathStyle">M30.561941,0L31.997,1.393004 10.467954,23.597999 0,15.350999 1.2379759,13.780992 10.287961,20.909952z</x:String>
+	<x:String x:Key="FlyoutRightArrowPathStyle">M0,0L25.194,16 0,32z</x:String>
 	<x:Double x:Key="FlyoutPresenterMinWidth">112</x:Double>
 	<x:Double x:Key="FlyoutMenuItemHeight">48</x:Double>
 	<GridLength x:Key="FlyoutMenuItemRightMargin">38</GridLength>
@@ -365,7 +365,7 @@
 							</Grid.ColumnDefinitions>
 
 							<Path x:Name="CheckGlyph"
-								  Data="{StaticResource CheckGlyphPathStyle}"
+								  Data="{StaticResource FlyoutCheckGlyphPathStyle}"
 								  Fill="{TemplateBinding Foreground}"
 								  VerticalAlignment="Center"
 								  Stretch="Uniform"
@@ -537,7 +537,7 @@
 									   Grid.Column="0" />
 
 							<Path x:Name="SubItemChevron"
-								  Data="{StaticResource RightArrowPathStyle}"
+								  Data="{StaticResource FlyoutRightArrowPathStyle}"
 								  Fill="{TemplateBinding Foreground}"
 								  VerticalAlignment="Center"
 								  Stretch="Uniform"


### PR DESCRIPTION
closes https://github.com/unoplatform/nventive-private/issues/357

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Two resources existed in Uno.Material with the key `CheckGlyphPathStyle`, one in `CheckBox.xaml` and one in `Flyout.xaml`. As a result of the XamlMerge, there can be only one true CheckGlyphPathStyle so the Flyout Path Data was being used for the CheckBox's Check Glyph data
