### PR TITLE
fix: exclude progressring from winui

### DIFF
--- a/src/library/Uno.Material/MaterialResourcesV2.cs
+++ b/src/library/Uno.Material/MaterialResourcesV2.cs
@@ -112,7 +112,9 @@ namespace Uno.Material
 			Add("MaterialOutlinedPasswordBoxStyle");
 			Add("MaterialOutlinedTextBoxStyle");
 			Add("MaterialProgressBarStyle", isImplicit: true);
+#if !WinUI
 			Add("MaterialProgressRingStyle", isImplicit: true);
+#endif
 			Add("MaterialRadioButtonStyle", isImplicit: true);
 			Add("MaterialSecondaryCheckBoxStyle");
 			Add("MaterialSecondaryFabStyle");


### PR DESCRIPTION
﻿Fixes crash on Material WinUI
﻿
﻿Should maybe only be conditional if WinUI=True and Windows=True?