### PR TITLE
fix: Only remove ProgressRing for Windows WinUI3 platforms

### DIFF
--- a/src/library/Uno.Material/MaterialResourcesV2.cs
+++ b/src/library/Uno.Material/MaterialResourcesV2.cs
@@ -112,7 +112,8 @@ namespace Uno.Material
 			Add("MaterialOutlinedPasswordBoxStyle");
 			Add("MaterialOutlinedTextBoxStyle");
 			Add("MaterialProgressBarStyle", isImplicit: true);
-#if !WinUI
+			//WinUI 3 currently does not support the DeterminateSource and IndeterminateSource properties on Windows 
+#if !WinUI_Desktop
 			Add("MaterialProgressRingStyle", isImplicit: true);
 #endif
 			Add("MaterialRadioButtonStyle", isImplicit: true);

--- a/src/library/Uno.Material/Styles/Controls/v2/ProgressRing.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ProgressRing.xaml
@@ -3,6 +3,7 @@
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:lottie_win="using:Microsoft.Toolkit.Uwp.UI.Lottie"
 					xmlns:lottie_not_win="using:Microsoft.Toolkit.Uwp.UI.Lottie"
+					xmlns:IsNotWinUI3="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsTypeNotPresent(Microsoft.UI.Xaml.FrameworkElement)"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_win="http://uno.ui/not_win"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -19,7 +20,8 @@
 	<lottie_not_win:LottieVisualSource x:Key="M3MaterialIndeterminateAnimation_Uno"
 									   UriSource="embedded://Uno.Material/Uno.Material.Assets.MaterialIndeterminate.json" />
 
-	<Style x:Key="MaterialProgressRingStyle"
+	<!-- WinUI 3 currently does not support the DeterminateSource and IndeterminateSource properties on Windows -->
+	<IsNotWinUI3:Style x:Key="MaterialProgressRingStyle"
 		   TargetType="muxc:ProgressRing">
 		<win:Setter Property="DeterminateSource"
 						   Value="{StaticResource M3MaterialDeterminateAnimation_Win}" />
@@ -33,6 +35,6 @@
 				Value="{StaticResource PrimaryBrush}" />
 		<Setter Property="Background"
 				Value="{StaticResource PrimaryLowBrush}" />
-	</Style>
+	</IsNotWinUI3:Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
WinUI 3 currently does not support the [DeterminateSource](https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.controls.progressring.determinatesource?view=winui-2.8-prerelease) and [IndeterminateSource](https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.controls.progressring.indeterminatesource?view=winui-2.8-prerelease) properties. These properties are needed for the Material style. So we should not include the ProgressRing Material styles when running a Windows WinUI 3.

WinUI Uno platforms support the DeterminateSource and IndeterminateSource so we only need to remove the ProgressBar for Windows WinUI 3