### PR TITLE
fix(PasswordBox): Make v1 PasswordBox reveal button unclickable when hidden

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v1/PasswordBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/PasswordBox.xaml
@@ -18,7 +18,7 @@
 				Value="44" />
 		<Setter Property="CornerRadius"
 				Value="22" />
-
+		
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="Button">
@@ -136,9 +136,15 @@
 									<VisualState.Setters>
 										<Setter Target="RevealButton.Opacity"
 												Value="1" />
+										<Setter Target="RevealButton.IsHitTestVisible"
+												Value="True" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="ButtonCollapsed">
+									<VisualState.Setters>
+										<Setter Target="RevealButton.IsHitTestVisible"
+												Value="False" />
+									</VisualState.Setters>
 									<Storyboard>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="RevealButton"
 																	   Storyboard.TargetProperty="Opacity">
@@ -244,6 +250,7 @@
 
 
 							<Button x:Name="RevealButton"
+									IsHitTestVisible="False"
 									Style="{StaticResource RevealButtonStyle}"
 									Foreground="{TemplateBinding BorderBrush}"
 									Opacity="0"
@@ -347,9 +354,15 @@
 									<VisualState.Setters>
 										<Setter Target="RevealButton.Opacity"
 												Value="1" />
+										<Setter Target="RevealButton.IsHitTestVisible"
+												Value="True" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="ButtonCollapsed">
+									<VisualState.Setters>
+										<Setter Target="RevealButton.IsHitTestVisible"
+												Value="False" />
+									</VisualState.Setters>
 									<Storyboard>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="RevealButton"
 																	   Storyboard.TargetProperty="Opacity">
@@ -452,6 +465,7 @@
 							</TextBlock>
 
 							<Button x:Name="RevealButton"
+									IsHitTestVisible="False"
 									Style="{StaticResource RevealButtonStyle}"
 									Foreground="{TemplateBinding BorderBrush}"
 									Opacity="0"


### PR DESCRIPTION
closes https://github.com/unoplatform/nventive-private/issues/400

## PR Type

What kind of change does this PR introduce?

- Bugfix


## Description

PasswordBox's RevealButton should prevent itself from being clicked while in the ButtonCollapsed Visual State