### PR TITLE
fix(winui): MenuFlyout&Item crashes

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v1/Flyout.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/Flyout.xaml
@@ -130,8 +130,6 @@
 
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.(RevealBrush.State)"
-												Value="PointerOver" />
 										<Setter Target="CommonStatesOverlay.Background"
 												Value="{StaticResource MaterialOnSurfaceHoverBrush}" />
 									</VisualState.Setters>
@@ -143,8 +141,6 @@
 
 								<VisualState x:Name="Pressed">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.(RevealBrush.State)"
-												Value="Pressed" />
 										<Setter Target="CommonStatesOverlay.Background"
 												Value="{StaticResource MaterialOnSurfacePressedBrush}" />
 									</VisualState.Setters>
@@ -281,8 +277,6 @@
 
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.(RevealBrush.State)"
-												Value="PointerOver" />
 										<Setter Target="CommonStatesOverlay.Background"
 												Value="{StaticResource MaterialOnSurfaceHoverBrush}" />
 									</VisualState.Setters>
@@ -294,8 +288,6 @@
 
 								<VisualState x:Name="Pressed">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.(RevealBrush.State)"
-												Value="Pressed" />
 										<Setter Target="CommonStatesOverlay.Background"
 												Value="{StaticResource MaterialOnSurfacePressedBrush}" />
 									</VisualState.Setters>
@@ -446,8 +438,6 @@
 
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.(RevealBrush.State)"
-												Value="PointerOver" />
 										<Setter Target="CommonStatesOverlay.Background"
 												Value="{StaticResource MaterialOnSurfaceHoverBrush}" />
 									</VisualState.Setters>
@@ -455,8 +445,6 @@
 
 								<VisualState x:Name="Pressed">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.(RevealBrush.State)"
-												Value="Pressed" />
 										<Setter Target="CommonStatesOverlay.Background"
 												Value="{StaticResource MaterialOnSurfacePressedBrush}" />
 									</VisualState.Setters>
@@ -464,8 +452,6 @@
 
 								<VisualState x:Name="SubMenuOpened">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.(RevealBrush.State)"
-												Value="Pressed" />
 										<Setter Target="CommonStatesOverlay.Background"
 												Value="{StaticResource MaterialOnSurfaceSelectedBrush}" />
 									</VisualState.Setters>

--- a/src/library/Uno.Material/Styles/Controls/v2/Flyout.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/Flyout.xaml
@@ -18,7 +18,6 @@
 	<x:Double x:Key="MaterialFlyoutMenuToggleCheckGlyphHeight">16</x:Double>
 	<x:Double x:Key="MaterialFlyoutMenuSeparatorHeight">1</x:Double>
 	<x:Double x:Key="MaterialFlyoutFontSize">14</x:Double>
-	<x:Double x:Key="MaterialFlyoutCharacterSpacing">7.143</x:Double>
 	<GridLength x:Key="MaterialFlyoutMenuItemRightMargin">38</GridLength>
 
 	<!--  Material FlyoutPresenter Style  -->
@@ -76,8 +75,6 @@
 		        Value="Medium" />
 		<Setter Property="FontFamily"
 		        Value="{StaticResource MaterialMediumFontFamily}" />
-		<Setter Property="CharacterSpacing"
-		        Value="{StaticResource MaterialFlyoutCharacterSpacing}" />
 		<!--  End: Label Large Typo  -->
 		<Setter Property="MinWidth"
 		        Value="{StaticResource MaterialFlyoutPresenterMinWidth}" />
@@ -108,8 +105,6 @@
 		        Value="Medium" />
 		<Setter Property="FontFamily"
 		        Value="{StaticResource MaterialMediumFontFamily}" />
-		<Setter Property="CharacterSpacing"
-		        Value="{StaticResource MaterialFlyoutCharacterSpacing}" />
 		<!--  End: Label Large Typo  -->
 		<Setter Property="MinWidth"
 		        Value="{StaticResource MaterialFlyoutPresenterMinWidth}" />
@@ -155,8 +150,6 @@
 
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.(RevealBrush.State)"
-										        Value="PointerOver" />
 										<Setter Target="CommonStatesOverlay.Background"
 										        Value="{StaticResource OnSurfaceHoverBrush}" />
 									</VisualState.Setters>
@@ -168,8 +161,6 @@
 
 								<VisualState x:Name="Pressed">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.(RevealBrush.State)"
-										        Value="Pressed" />
 										<Setter Target="CommonStatesOverlay.Background"
 										        Value="{StaticResource OnSurfacePressedBrush}" />
 									</VisualState.Setters>
@@ -265,7 +256,7 @@
 						      android:Visibility="Collapsed"
 						      ios:Visibility="Collapsed">
 							<TextBlock x:Name="KeyboardAcceleratorTextBlock"
-							           MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.KeyboardAcceleratorTextMinWidth}"							           
+							           MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.KeyboardAcceleratorTextMinWidth}"
 							           VerticalAlignment="Center"
 							           AutomationProperties.AccessibilityView="Raw"
 							           Foreground="{StaticResource OnSurfaceVariantBrush}"
@@ -320,8 +311,6 @@
 
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.(RevealBrush.State)"
-										        Value="PointerOver" />
 										<Setter Target="CommonStatesOverlay.Background"
 										        Value="{StaticResource OnSurfaceHoverBrush}" />
 									</VisualState.Setters>
@@ -333,8 +322,6 @@
 
 								<VisualState x:Name="Pressed">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.(RevealBrush.State)"
-										        Value="Pressed" />
 										<Setter Target="CommonStatesOverlay.Background"
 										        Value="{StaticResource OnSurfacePressedBrush}" />
 									</VisualState.Setters>
@@ -502,8 +489,6 @@
 
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.(RevealBrush.State)"
-										        Value="PointerOver" />
 										<Setter Target="CommonStatesOverlay.Background"
 										        Value="{StaticResource OnSurfaceHoverBrush}" />
 									</VisualState.Setters>
@@ -511,8 +496,6 @@
 
 								<VisualState x:Name="Pressed">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.(RevealBrush.State)"
-										        Value="Pressed" />
 										<Setter Target="CommonStatesOverlay.Background"
 										        Value="{StaticResource OnSurfacePressedBrush}" />
 									</VisualState.Setters>
@@ -520,8 +503,6 @@
 
 								<VisualState x:Name="SubMenuOpened">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.(RevealBrush.State)"
-										        Value="Pressed" />
 										<Setter Target="CommonStatesOverlay.Background"
 										        Value="{StaticResource OnSurfaceSelectedBrush}" />
 									</VisualState.Setters>


### PR DESCRIPTION
﻿GitHub Issue: closes unoplatform/uno#9231
## PR Type

What kind of change does this PR introduce?
- Bugfix

## Description
- fix MenuFlyout crash when opened
- fix MenuFlyoutItem crash when moused over

## PR Checklist
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested Windows
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information
MenuFlyout is due to wrong value type being set to `MenuFlyoutPresenter.CharacterSpacing` (of type `int`)
MenuFlyoutItem is due to SolidColorBrush being used instead, and kept `LayoutRoot.(RevealBrush.State)` from the old style