### PR TITLE
feat: added material style for ContentDialog

### DIFF
--- a/doc/material-controls-styles.md
+++ b/doc/material-controls-styles.md
@@ -1,9 +1,9 @@
 # Material Controls Styles
-Control|Style Key|IsDefaultStyle*|
+Control|Style Key|IsDefaultStyle*
 -|-|-
-AppBarButton|AppBarButtonStyle|True|
+AppBarButton|AppBarButtonStyle|True
 Button|ElevatedButtonStyle|
-Button|FilledButtonStyle|True|
+Button|FilledButtonStyle|True
 Button|FilledTonalButtonStyle|
 Button|OutlinedButtonStyle|
 Button|TextButtonStyle|
@@ -20,26 +20,27 @@ Button|LargeFabStyle|
 Button|SurfaceLargeFabStyle|
 Button|SecondaryLargeFabStyle|
 Button|TertiaryLargeFabStyle|
-CalendarDatePicker|CalendarDatePickerStyle|True|
-CalendarView|CalendarViewStyle|True|
-CheckBox|CheckBoxStyle|True|
-ComboBox|ComboBoxStyle|True|
-CommandBar|CommandBarStyle|True|
-DatePicker|DatePickerStyle|True|
-FlyoutPresenter|FlyoutPresenterStyle|True|
-HyperlinkButton|HyperlinkButtonStyle|True|
+CalendarDatePicker|CalendarDatePickerStyle|True
+CalendarView|CalendarViewStyle|True
+CheckBox|CheckBoxStyle|True
+ComboBox|ComboBoxStyle|True
+CommandBar|CommandBarStyle|True
+ContentDialog|ContentDialogStyle|True
+DatePicker|DatePickerStyle|True
+FlyoutPresenter|FlyoutPresenterStyle|True
+HyperlinkButton|HyperlinkButtonStyle|True
 HyperlinkButton|SecondaryHyperlinkButtonStyle|
-ListView|ListViewStyle|True|
-ListViewItem|ListViewItemStyle|True|
-MenuFlyoutPresenter|MenuFlyoutPresenterStyle|True|
-muxc:NavigationView|NavigationViewStyle|True|
-muxc:NavigationViewItem|NavigationViewItemStyle|True|
-PasswordBox|FilledPasswordBoxStyle|True|
+ListView|ListViewStyle|True
+ListViewItem|ListViewItemStyle|True
+MenuFlyoutPresenter|MenuFlyoutPresenterStyle|True
+muxc:NavigationView|NavigationViewStyle|True
+muxc:NavigationViewItem|NavigationViewItemStyle|True
+PasswordBox|FilledPasswordBoxStyle|True
 PasswordBox|OutlinedPasswordBoxStyle|
-ProgressBar|ProgressBarStyle|True|
-ProgressRing|ProgressRingStyle|True|
-RadioButton|RadioButtonStyle|True|
-Slider|SliderStyle|True|
+ProgressBar|ProgressBarStyle|True
+ProgressRing|ProgressRingStyle|True
+RadioButton|RadioButtonStyle|True
+Slider|SliderStyle|True
 TextBlock|DisplayLarge|
 TextBlock|DisplayMedium|
 TextBlock|DisplaySmall|
@@ -53,12 +54,12 @@ TextBlock|LabelLarge|
 TextBlock|LabelMedium|
 TextBlock|LabelSmall|
 TextBlock|BodyLarge|
-TextBlock|BodyMedium|True|
+TextBlock|BodyMedium|True
 TextBlock|BodySmall|
-TextBox|FilledTextBoxStyle|True|
+TextBox|FilledTextBoxStyle|True
 TextBox|OutlinedTextBoxStyle|
-ToggleButton|TextToggleButtonStyle|True|
+ToggleButton|TextToggleButtonStyle|True
 ToggleButton|IconToggleButtonStyle|
-ToggleSwitch|ToggleSwitchStyle|True|
+ToggleSwitch|ToggleSwitchStyle|True
 
 IsDefaultStyle*: Styles in this column will be set as the default implicit style for the matching control

--- a/doc/material-controls-styles.md
+++ b/doc/material-controls-styles.md
@@ -23,6 +23,7 @@ Button|TertiaryLargeFabStyle|
 CalendarDatePicker|CalendarDatePickerStyle|True
 CalendarView|CalendarViewStyle|True
 CheckBox|CheckBoxStyle|True
+CheckBox|SecondaryCheckBoxStyle|
 ComboBox|ComboBoxStyle|True
 CommandBar|CommandBarStyle|True
 ContentDialog|ContentDialogStyle|True
@@ -35,11 +36,12 @@ ListViewItem|ListViewItemStyle|True
 MenuFlyoutPresenter|MenuFlyoutPresenterStyle|True
 muxc:NavigationView|NavigationViewStyle|True
 muxc:NavigationViewItem|NavigationViewItemStyle|True
+muxc:ProgressBar|ProgressBarStyle|True
+muxc:ProgressRing|ProgressRingStyle|True
 PasswordBox|FilledPasswordBoxStyle|True
 PasswordBox|OutlinedPasswordBoxStyle|
-ProgressBar|ProgressBarStyle|True
-ProgressRing|ProgressRingStyle|True
 RadioButton|RadioButtonStyle|True
+RadioButton|SecondaryRadioButtonStyle|
 Slider|SliderStyle|True
 TextBlock|DisplayLarge|
 TextBlock|DisplayMedium|
@@ -53,9 +55,13 @@ TextBlock|TitleSmall|
 TextBlock|LabelLarge|
 TextBlock|LabelMedium|
 TextBlock|LabelSmall|
+TextBlock|LabelExtraSmall|
 TextBlock|BodyLarge|
 TextBlock|BodyMedium|True
 TextBlock|BodySmall|
+TextBlock|CaptionLarge|
+TextBlock|CaptionMedium|
+TextBlock|CaptionSmall|
 TextBox|FilledTextBoxStyle|True
 TextBox|OutlinedTextBoxStyle|
 ToggleButton|TextToggleButtonStyle|True

--- a/src/library/Uno.Material/Generated/mergedpages.v2.xaml
+++ b/src/library/Uno.Material/Generated/mergedpages.v2.xaml
@@ -1726,6 +1726,158 @@
     <ios:Setter Property="Template" Value="{StaticResource NativeM3CommandBarTemplate}" />
     <android:Setter Property="Template" Value="{StaticResource NativeM3CommandBarTemplate}" />
   </Style>
+  <!--origin: Styles\Controls\v2\ContentDialog.xaml-->
+  <x:Double x:Key="MaterialContentDialogMinWidth">320</x:Double>
+  <x:Double x:Key="MaterialContentDialogMaxWidth">548</x:Double>
+  <x:Double x:Key="MaterialContentDialogMinHeight">184</x:Double>
+  <x:Double x:Key="MaterialContentDialogMaxHeight">756</x:Double>
+  <GridLength x:Key="MaterialContentDialogContentDialogButtonSpacing">8</GridLength>
+  <StaticResource x:Key="MaterialContentDialogTitleForeground" ResourceKey="OnSurfaceBrush" />
+  <StaticResource x:Key="MaterialContentDialogContentForeground" ResourceKey="OnSurfaceLowBrush" />
+  <Style x:Key="MaterialContentDialogButtonStyle" TargetType="Button" BasedOn="{StaticResource MaterialTextButtonStyle}">
+    <Setter Property="CornerRadius" Value="4" />
+    <Setter Property="HorizontalAlignment" Value="Right" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+  </Style>
+  <Style x:Key="MaterialContentDialogStyle" TargetType="ContentDialog">
+    <Setter Property="Background" Value="{StaticResource SurfaceBrush}" />
+    <Setter Property="Foreground" Value="{StaticResource MaterialContentDialogContentForeground}" />
+    <Setter Property="CornerRadius" Value="4" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="PrimaryButtonStyle" Value="{StaticResource MaterialContentDialogButtonStyle}" />
+    <Setter Property="SecondaryButtonStyle" Value="{StaticResource MaterialContentDialogButtonStyle}" />
+    <Setter Property="CloseButtonStyle" Value="{StaticResource MaterialContentDialogButtonStyle}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ContentDialog">
+          <Border x:Name="Container">
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="DialogShowingStates">
+                <VisualStateGroup.Transitions>
+                  <VisualTransition To="DialogHidden" />
+                  <VisualTransition To="DialogShowing" />
+                </VisualStateGroup.Transitions>
+                <VisualState x:Name="DialogHidden" />
+                <VisualState x:Name="DialogShowing">
+                  <VisualState.Setters>
+                    <Setter Target="PrimaryButton.IsTabStop" Value="True" />
+                    <Setter Target="SecondaryButton.IsTabStop" Value="True" />
+                    <Setter Target="CloseButton.IsTabStop" Value="True" />
+                    <Setter Target="LayoutRoot.Visibility" Value="Visible" />
+                    <Setter Target="BackgroundElement.TabFocusNavigation" Value="Cycle" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="DialogShowingWithoutSmokeLayer">
+                  <VisualState.Setters>
+                    <Setter Target="PrimaryButton.IsTabStop" Value="True" />
+                    <Setter Target="SecondaryButton.IsTabStop" Value="True" />
+                    <Setter Target="CloseButton.IsTabStop" Value="True" />
+                    <Setter Target="LayoutRoot.Visibility" Value="Visible" />
+                    <Setter Target="LayoutRoot.Background" Value="{x:Null}" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="DialogSizingStates">
+                <VisualState x:Name="DefaultDialogSizing" />
+                <VisualState x:Name="FullDialogSizing" />
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="ButtonsVisibilityStates">
+                <VisualState x:Name="AllVisible" />
+                <VisualState x:Name="NoneVisible">
+                  <VisualState.Setters>
+                    <Setter Target="CommandSpace.Visibility" Value="Collapsed" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="PrimaryVisible">
+                  <VisualState.Setters>
+                    <Setter Target="FirstSpacer.Width" Value="0" />
+                    <Setter Target="SecondaryButton.Visibility" Value="Collapsed" />
+                    <Setter Target="SecondSpacer.Width" Value="0" />
+                    <Setter Target="CloseButton.Visibility" Value="Collapsed" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="SecondaryVisible">
+                  <VisualState.Setters>
+                    <Setter Target="PrimaryButton.Visibility" Value="Collapsed" />
+                    <Setter Target="FirstSpacer.Width" Value="0" />
+                    <Setter Target="SecondSpacer.Width" Value="0" />
+                    <Setter Target="CloseButton.Visibility" Value="Collapsed" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="CloseVisible">
+                  <VisualState.Setters>
+                    <Setter Target="PrimaryButton.Visibility" Value="Collapsed" />
+                    <Setter Target="FirstSpacer.Width" Value="0" />
+                    <Setter Target="SecondaryButton.Visibility" Value="Collapsed" />
+                    <Setter Target="SecondSpacer.Width" Value="0" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="PrimaryAndSecondaryVisible">
+                  <VisualState.Setters>
+                    <Setter Target="SecondSpacer.Width" Value="0" />
+                    <Setter Target="CloseButton.Visibility" Value="Collapsed" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="PrimaryAndCloseVisible">
+                  <VisualState.Setters>
+                    <Setter Target="FirstSpacer.Width" Value="0" />
+                    <Setter Target="SecondaryButton.Visibility" Value="Collapsed" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="SecondaryAndCloseVisible">
+                  <VisualState.Setters>
+                    <Setter Target="PrimaryButton.Visibility" Value="Collapsed" />
+                    <Setter Target="FirstSpacer.Width" Value="0" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="DefaultButtonStates" />
+              <VisualStateGroup x:Name="DialogBorderStates" />
+            </VisualStateManager.VisualStateGroups>
+            <Grid x:Name="LayoutRoot">
+              <Rectangle x:Name="SmokeLayerBackground" Fill="{StaticResource OnSurfaceLowBrush}" />
+              <Border x:Name="BackgroundElement" Background="{TemplateBinding Background}" FlowDirection="{TemplateBinding FlowDirection}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" BackgroundSizing="InnerBorderEdge" CornerRadius="{TemplateBinding CornerRadius}" MinWidth="{StaticResource MaterialContentDialogMinWidth}" MaxWidth="{StaticResource MaterialContentDialogMaxWidth}" MinHeight="{StaticResource MaterialContentDialogMinHeight}" MaxHeight="{StaticResource MaterialContentDialogMaxHeight}" Margin="16" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <Border.RenderTransform>
+                  <ScaleTransform x:Name="ScaleTransform" />
+                </Border.RenderTransform>
+                <Grid x:Name="DialogSpace">
+                  <Grid.RowDefinitions>
+                    <!-- 0: Title, 1: Content, 2: CommandSpace -->
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                  </Grid.RowDefinitions>
+                  <ContentControl Grid.Row="0" x:Name="Title" Content="{TemplateBinding Title}" ContentTemplate="{TemplateBinding TitleTemplate}" FontSize="{StaticResource MaterialTitleMediumFontSize}" FontWeight="{StaticResource MaterialTitleMediumFontWeight}" FontFamily="{StaticResource MaterialTitleMediumFontFamily}" Foreground="{StaticResource MaterialContentDialogTitleForeground}" Padding="24,20,24,12" HorizontalAlignment="Left" VerticalAlignment="Top" IsTabStop="False">
+                    <ContentControl.Template>
+                      <ControlTemplate TargetType="ContentControl">
+                        <ContentPresenter Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" ContentTransitions="{TemplateBinding ContentTransitions}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" MaxLines="2" TextWrapping="Wrap" Margin="{TemplateBinding Padding}" />
+                      </ControlTemplate>
+                    </ContentControl.Template>
+                  </ContentControl>
+                  <ScrollViewer Grid.Row="1" x:Name="ContentScrollViewer" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Disabled" Padding="24,4,24,8" ZoomMode="Disabled" IsTabStop="False">
+                    <ContentPresenter x:Name="Content" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" FontSize="{StaticResource MaterialBodyMediumFontSize}" FontWeight="{StaticResource MaterialBodyMediumFontWeight}" FontFamily="{StaticResource MaterialBodyMediumFontFamily}" Foreground="{TemplateBinding Foreground}" TextWrapping="Wrap" />
+                  </ScrollViewer>
+                  <Grid x:Name="CommandSpace" Grid.Row="2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Padding="8" XYFocusKeyboardNavigation="Enabled">
+                    <Grid.ColumnDefinitions>
+                      <ColumnDefinition x:Name="CloseColumn" Width="Auto" />
+                      <ColumnDefinition x:Name="SecondSpacer" Width="{StaticResource MaterialContentDialogContentDialogButtonSpacing}" />
+                      <ColumnDefinition x:Name="SecondaryColumn" Width="Auto" />
+                      <ColumnDefinition x:Name="FirstSpacer" Width="{StaticResource MaterialContentDialogContentDialogButtonSpacing}" />
+                      <ColumnDefinition x:Name="PrimaryColumn" Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Button Grid.Column="0" x:Name="CloseButton" Content="{TemplateBinding CloseButtonText}" IsTabStop="False" ElementSoundMode="FocusOnly" Style="{TemplateBinding CloseButtonStyle}" />
+                    <Button Grid.Column="2" x:Name="SecondaryButton" Content="{TemplateBinding SecondaryButtonText}" IsEnabled="{TemplateBinding IsSecondaryButtonEnabled}" IsTabStop="False" ElementSoundMode="FocusOnly" Style="{TemplateBinding SecondaryButtonStyle}" />
+                    <Button Grid.Column="4" x:Name="PrimaryButton" Content="{TemplateBinding PrimaryButtonText}" IsEnabled="{TemplateBinding IsPrimaryButtonEnabled}" IsTabStop="False" ElementSoundMode="FocusOnly" Style="{TemplateBinding PrimaryButtonStyle}" />
+                  </Grid>
+                </Grid>
+              </Border>
+            </Grid>
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
   <!--origin: Styles\Controls\v2\DatePicker.xaml-->
   <x:Double x:Key="MaterialDateTimeFlyoutBorderThickness">1</x:Double>
   <x:Double x:Key="MaterialDatePickerSpacerThemeWidth">1</x:Double>

--- a/src/library/Uno.Material/MaterialResourcesV2.cs
+++ b/src/library/Uno.Material/MaterialResourcesV2.cs
@@ -79,6 +79,7 @@ namespace Uno.Material
 			Add("MaterialCaptionMedium");
 			Add("MaterialCaptionSmall");
 			Add("MaterialCheckBoxStyle", isImplicit: true);
+			Add("MaterialContentDialogStyle", isImplicit: true);
 			Add("MaterialComboBoxStyle", isImplicit: true);
 			Add("MaterialCommandBarStyle", isImplicit: true);
 			Add("MaterialDatePickerStyle", isImplicit: true);

--- a/src/library/Uno.Material/Styles/Controls/v2/ContentDialog.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ContentDialog.xaml
@@ -1,0 +1,240 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+	<x:Double x:Key="MaterialContentDialogMinWidth">320</x:Double>
+	<x:Double x:Key="MaterialContentDialogMaxWidth">548</x:Double>
+	<x:Double x:Key="MaterialContentDialogMinHeight">184</x:Double>
+	<x:Double x:Key="MaterialContentDialogMaxHeight">756</x:Double>
+	<GridLength x:Key="MaterialContentDialogContentDialogButtonSpacing">8</GridLength>
+
+	<StaticResource x:Key="MaterialContentDialogTitleForeground" ResourceKey="OnSurfaceBrush" />
+	<StaticResource x:Key="MaterialContentDialogContentForeground" ResourceKey="OnSurfaceLowBrush" />
+
+	<Style x:Key="MaterialContentDialogButtonStyle"
+		   TargetType="Button"
+		   BasedOn="{StaticResource MaterialTextButtonStyle}">
+		<Setter Property="CornerRadius" Value="4" />
+
+		<Setter Property="HorizontalAlignment" Value="Right" />
+		<Setter Property="VerticalAlignment" Value="Stretch" />
+	</Style>
+
+	<Style x:Key="MaterialContentDialogStyle"
+		   TargetType="ContentDialog">
+
+		<Setter Property="Background" Value="{StaticResource SurfaceBrush}" />
+		<Setter Property="Foreground" Value="{StaticResource MaterialContentDialogContentForeground}" />
+		<Setter Property="CornerRadius" Value="4" />
+
+		<Setter Property="HorizontalAlignment" Value="Stretch" />
+		<Setter Property="VerticalAlignment" Value="Stretch" />
+
+		<Setter Property="PrimaryButtonStyle" Value="{StaticResource MaterialContentDialogButtonStyle}" />
+		<Setter Property="SecondaryButtonStyle" Value="{StaticResource MaterialContentDialogButtonStyle}" />
+		<Setter Property="CloseButtonStyle" Value="{StaticResource MaterialContentDialogButtonStyle}" />
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="ContentDialog">
+					<Border x:Name="Container">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="DialogShowingStates">
+								<VisualStateGroup.Transitions>
+									<VisualTransition To="DialogHidden" />
+									<VisualTransition To="DialogShowing" />
+								</VisualStateGroup.Transitions>
+
+								<VisualState x:Name="DialogHidden" />
+								<VisualState x:Name="DialogShowing">
+									<VisualState.Setters>
+										<Setter Target="PrimaryButton.IsTabStop" Value="True" />
+										<Setter Target="SecondaryButton.IsTabStop" Value="True" />
+										<Setter Target="CloseButton.IsTabStop" Value="True" />
+										<Setter Target="LayoutRoot.Visibility" Value="Visible" />
+										<Setter Target="BackgroundElement.TabFocusNavigation" Value="Cycle" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="DialogShowingWithoutSmokeLayer">
+									<VisualState.Setters>
+										<Setter Target="PrimaryButton.IsTabStop" Value="True" />
+										<Setter Target="SecondaryButton.IsTabStop" Value="True" />
+										<Setter Target="CloseButton.IsTabStop" Value="True" />
+										<Setter Target="LayoutRoot.Visibility" Value="Visible" />
+										<Setter Target="LayoutRoot.Background" Value="{x:Null}" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="DialogSizingStates">
+								<VisualState x:Name="DefaultDialogSizing" />
+								<VisualState x:Name="FullDialogSizing" />
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="ButtonsVisibilityStates">
+								<VisualState x:Name="AllVisible" />
+								<VisualState x:Name="NoneVisible">
+									<VisualState.Setters>
+										<Setter Target="CommandSpace.Visibility" Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PrimaryVisible">
+									<VisualState.Setters>
+										<Setter Target="FirstSpacer.Width" Value="0" />
+										<Setter Target="SecondaryButton.Visibility" Value="Collapsed" />
+										<Setter Target="SecondSpacer.Width" Value="0" />
+										<Setter Target="CloseButton.Visibility" Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="SecondaryVisible">
+									<VisualState.Setters>
+										<Setter Target="PrimaryButton.Visibility" Value="Collapsed" />
+										<Setter Target="FirstSpacer.Width" Value="0" />
+										<Setter Target="SecondSpacer.Width" Value="0" />
+										<Setter Target="CloseButton.Visibility" Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="CloseVisible">
+									<VisualState.Setters>
+										<Setter Target="PrimaryButton.Visibility" Value="Collapsed" />
+										<Setter Target="FirstSpacer.Width" Value="0" />
+										<Setter Target="SecondaryButton.Visibility" Value="Collapsed" />
+										<Setter Target="SecondSpacer.Width" Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PrimaryAndSecondaryVisible">
+									<VisualState.Setters>
+										<Setter Target="SecondSpacer.Width" Value="0" />
+										<Setter Target="CloseButton.Visibility" Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PrimaryAndCloseVisible">
+									<VisualState.Setters>
+										<Setter Target="FirstSpacer.Width" Value="0" />
+										<Setter Target="SecondaryButton.Visibility" Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="SecondaryAndCloseVisible">
+									<VisualState.Setters>
+										<Setter Target="PrimaryButton.Visibility" Value="Collapsed" />
+										<Setter Target="FirstSpacer.Width" Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="DefaultButtonStates" />
+							<VisualStateGroup x:Name="DialogBorderStates" />
+						</VisualStateManager.VisualStateGroups>
+
+						<Grid x:Name="LayoutRoot">
+							<Rectangle x:Name="SmokeLayerBackground"
+									   Fill="{StaticResource OnSurfaceLowBrush}" />
+							<Border x:Name="BackgroundElement"
+									Background="{TemplateBinding Background}"
+									FlowDirection="{TemplateBinding FlowDirection}"
+									BorderThickness="{TemplateBinding BorderThickness}"
+									BorderBrush="{TemplateBinding BorderBrush}"
+									BackgroundSizing="InnerBorderEdge"
+									CornerRadius="{TemplateBinding CornerRadius}"
+									MinWidth="{StaticResource MaterialContentDialogMinWidth}"
+									MaxWidth="{StaticResource MaterialContentDialogMaxWidth}"
+									MinHeight="{StaticResource MaterialContentDialogMinHeight}"
+									MaxHeight="{StaticResource MaterialContentDialogMaxHeight}"
+									Margin="16"
+									HorizontalAlignment="Center"
+									VerticalAlignment="Center">
+								<Border.RenderTransform>
+									<ScaleTransform x:Name="ScaleTransform" />
+								</Border.RenderTransform>
+
+								<Grid x:Name="DialogSpace">
+									<Grid.RowDefinitions>
+										<!-- 0: Title, 1: Content, 2: CommandSpace -->
+										<RowDefinition Height="Auto" />
+										<RowDefinition Height="*" />
+										<RowDefinition Height="Auto" />
+									</Grid.RowDefinitions>
+
+									<ContentControl Grid.Row="0"
+													x:Name="Title"
+													Content="{TemplateBinding Title}"
+													ContentTemplate="{TemplateBinding TitleTemplate}"
+													FontSize="{StaticResource MaterialTitleMediumFontSize}"
+													FontWeight="{StaticResource MaterialTitleMediumFontWeight}"
+													FontFamily="{StaticResource MaterialTitleMediumFontFamily}"
+													Foreground="{StaticResource MaterialContentDialogTitleForeground}"
+													Padding="24,20,24,12"
+													HorizontalAlignment="Left"
+													VerticalAlignment="Top"
+													IsTabStop="False">
+										<ContentControl.Template>
+											<ControlTemplate TargetType="ContentControl">
+												<ContentPresenter Content="{TemplateBinding Content}"
+																  ContentTemplate="{TemplateBinding ContentTemplate}"
+																  ContentTransitions="{TemplateBinding ContentTransitions}"
+																  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+																  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+																  MaxLines="2"
+																  TextWrapping="Wrap"
+																  Margin="{TemplateBinding Padding}" />
+											</ControlTemplate>
+										</ContentControl.Template>
+									</ContentControl>
+									<ScrollViewer Grid.Row="1"
+												  x:Name="ContentScrollViewer"
+												  HorizontalScrollBarVisibility="Disabled"
+												  VerticalScrollBarVisibility="Disabled"
+												  Padding="24,4,24,8"
+												  ZoomMode="Disabled"
+												  IsTabStop="False">
+										<ContentPresenter x:Name="Content"
+														  ContentTemplate="{TemplateBinding ContentTemplate}"
+														  Content="{TemplateBinding Content}"
+														  FontSize="{StaticResource MaterialBodyMediumFontSize}"
+														  FontWeight="{StaticResource MaterialBodyMediumFontWeight}"
+														  FontFamily="{StaticResource MaterialBodyMediumFontFamily}"
+														  Foreground="{TemplateBinding Foreground}"
+														  TextWrapping="Wrap" />
+									</ScrollViewer>
+									<Grid x:Name="CommandSpace"
+										  Grid.Row="2"
+										  HorizontalAlignment="Right"
+										  VerticalAlignment="Bottom"
+										  Padding="8"
+										  XYFocusKeyboardNavigation="Enabled">
+
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition x:Name="CloseColumn" Width="Auto" />
+											<ColumnDefinition x:Name="SecondSpacer" Width="{StaticResource MaterialContentDialogContentDialogButtonSpacing}" />
+											<ColumnDefinition x:Name="SecondaryColumn" Width="Auto" />
+											<ColumnDefinition x:Name="FirstSpacer" Width="{StaticResource MaterialContentDialogContentDialogButtonSpacing}" />
+											<ColumnDefinition x:Name="PrimaryColumn" Width="Auto" />
+										</Grid.ColumnDefinitions>
+
+										<Button Grid.Column="0"
+												x:Name="CloseButton"
+												Content="{TemplateBinding CloseButtonText}"
+												IsTabStop="False"
+												ElementSoundMode="FocusOnly"
+												Style="{TemplateBinding CloseButtonStyle}" />
+										<Button Grid.Column="2"
+												x:Name="SecondaryButton"
+												Content="{TemplateBinding SecondaryButtonText}"
+												IsEnabled="{TemplateBinding IsSecondaryButtonEnabled}"
+												IsTabStop="False"
+												ElementSoundMode="FocusOnly"
+												Style="{TemplateBinding SecondaryButtonStyle}" />
+										<Button Grid.Column="4"
+												x:Name="PrimaryButton"
+												Content="{TemplateBinding PrimaryButtonText}"
+												IsEnabled="{TemplateBinding IsPrimaryButtonEnabled}"
+												IsTabStop="False"
+												ElementSoundMode="FocusOnly"
+												Style="{TemplateBinding PrimaryButtonStyle}" />
+
+									</Grid>
+								</Grid>
+							</Border>
+						</Grid>
+					</Border>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+</ResourceDictionary>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ContentDialogSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ContentDialogSamplePage.xaml
@@ -1,0 +1,31 @@
+﻿<Page x:Class="Uno.Themes.Samples.Content.Controls.ContentDialogSamplePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Themes.Samples.Content.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:sample="using:Uno.Themes.Samples"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<sample:SamplePageLayout>
+		<sample:SamplePageLayout.M3MaterialTemplate>
+			<DataTemplate>
+				<ScrollViewer HorizontalScrollMode="Disabled"
+							  HorizontalScrollBarVisibility="Disabled">
+					<StackPanel Spacing="16">
+						<Button Content="Alert"
+								Click="ShowContentDialog"
+								Tag="Alert" />
+						<Button Content="Simple"
+								Click="ShowContentDialog"
+								Tag="Simple" />
+						<Button Content="Confirmation"
+								Click="ShowContentDialog"
+								Tag="Confirmation" />
+					</StackPanel>
+				</ScrollViewer>
+			</DataTemplate>
+		</sample:SamplePageLayout.M3MaterialTemplate>
+	</sample:SamplePageLayout>
+</Page>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ContentDialogSamplePage.xaml.cs
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ContentDialogSamplePage.xaml.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Uno.Themes.Samples.Entities;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.Themes.Samples.Content.Controls
+{
+	[SamplePage(
+		SampleCategory.Controls,
+		nameof(ContentDialog),
+		Description = "Represents a dialog box that can be customized to contain checkboxes, hyperlinks, buttons and any other XAML content.",
+		DocumentationLink = "https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Controls.ContentDialog"
+	)]
+	public sealed partial class ContentDialogSamplePage : Page
+	{
+		public ContentDialogSamplePage()
+		{
+			this.InitializeComponent();
+		}
+
+		private async void ShowContentDialog(object sender, RoutedEventArgs e)
+		{
+			var mappings = new Dictionary<string, Func<ContentDialog>>
+			{
+				["Alert"] = BuildAlertContentDialog,
+				["Simple"] = BuildSimpleContentDialog,
+				["Confirmation"] = BuildConfirmationContentDialog,
+			};
+
+			if ((sender as Button)?.Tag is string context && mappings.TryGetValue(context, out var builder))
+			{
+				var dialog = builder();
+
+				await dialog.ShowAsync();
+			}
+			else
+			{
+				throw new InvalidOperationException();
+			}
+		}
+
+		private ContentDialog BuildAlertContentDialog() => new ContentDialog()
+		{
+			Title = "Dialog header",
+			Content = "Dialog body text",
+
+			PrimaryButtonText = "OK",
+			CloseButtonText = "CANCEL",
+		};
+
+		private ContentDialog BuildSimpleContentDialog()
+		{
+			var list = new ListView
+			{
+				ItemsSource = Enumerable.Range(1, 3).Select(x => $"Item {x}"),
+				IsItemClickEnabled = true,
+			};
+			var dialog = new ContentDialog()
+			{
+				Title = "Dialog header",
+				Content = list,
+			};
+			list.ItemClick += (s, e) => dialog.Hide();
+
+			return dialog;
+		}
+
+		private ContentDialog BuildConfirmationContentDialog()
+		{
+			var list = new ListView
+			{
+				ItemsSource = Enumerable.Range(1, 3).Select(x => $"Item {x}"),
+			};
+			var dialog = new ContentDialog()
+			{
+				Title = "Dialog header",
+				Content = list,
+				
+				PrimaryButtonText = "OK",
+				IsPrimaryButtonEnabled = false,
+				CloseButtonText = "CANCEL",
+			};
+			list.SelectionChanged += (s, e) => dialog.IsPrimaryButtonEnabled = list.SelectedIndex != -1;
+
+			return dialog;
+		}
+	}
+}

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Uno.Themes.Samples.Shared.projitems
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Uno.Themes.Samples.Shared.projitems
@@ -31,6 +31,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Content\Controls\ComboBoxSamplePage.xaml.cs">
       <DependentUpon>ComboBoxSamplePage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Content\Controls\ContentDialogSamplePage.xaml.cs">
+      <DependentUpon>ContentDialogSamplePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Content\Controls\DatePickerSamplePage.xaml.cs">
       <DependentUpon>DatePickerSamplePage.xaml</DependentUpon>
     </Compile>
@@ -151,6 +154,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Content\Controls\ComboBoxSamplePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Content\Controls\ContentDialogSamplePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>


### PR DESCRIPTION
﻿GitHub Issue: resolved #637

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature

## Description
Added material style and sample for ContentDialog

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [ ] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information
fixed an issue where when only M3MaterialTemplate is specified, the SamplePageLayout would not display anything beside page header/footer.