### PR TITLE
fix: NavigationView material style footer

### DIFF
--- a/src/library/Uno.Material/Generated/mergedpages.v2.xaml
+++ b/src/library/Uno.Material/Generated/mergedpages.v2.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d not_win android ios not_ios wasm xamarin skia contract4NotPresent contract7NotPresent macos lottie_not_win todo" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:um="using:Uno.Material" xmlns:toolkit="using:Uno.UI.Toolkit" xmlns:not_win="http://uno.ui/not_win" xmlns:uno="using:Uno.UI.Xaml.Controls" xmlns:android="http://uno.ui/android" xmlns:ios="http://uno.ui/ios" xmlns:not_ios="http://uno.ui/not_ios" xmlns:wasm="http://uno.ui/wasm" xmlns:xamarin="http://uno.ui/xamarin" xmlns:media="using:Microsoft.UI.Xaml.Media" xmlns:controls="using:Microsoft.UI.Xaml.Controls" xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives" xmlns:skia="http://uno.ui/skia" xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:contract4NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,4)" xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)" xmlns:macos="http://uno.ui/macos" xmlns:not_macos="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:lottie_win="using:Microsoft.Toolkit.Uwp.UI.Lottie" xmlns:lottie_not_win="using:Microsoft.Toolkit.Uwp.UI.Lottie" xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:todo="todo" xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+<ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d not_win android ios not_ios wasm xamarin todo skia contract4NotPresent contract7NotPresent macos lottie_not_win" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:um="using:Uno.Material" xmlns:toolkit="using:Uno.UI.Toolkit" xmlns:not_win="http://uno.ui/not_win" xmlns:uno="using:Uno.UI.Xaml.Controls" xmlns:android="http://uno.ui/android" xmlns:ios="http://uno.ui/ios" xmlns:not_ios="http://uno.ui/not_ios" xmlns:wasm="http://uno.ui/wasm" xmlns:xamarin="http://uno.ui/xamarin" xmlns:media="using:Microsoft.UI.Xaml.Media" xmlns:controls="using:Microsoft.UI.Xaml.Controls" xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives" xmlns:skia="http://uno.ui/skia" xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:contract4NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,4)" xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)" xmlns:todo="what should be done" xmlns:macos="http://uno.ui/macos" xmlns:not_macos="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:lottie_win="using:Microsoft.Toolkit.Uwp.UI.Lottie" xmlns:lottie_not_win="using:Microsoft.Toolkit.Uwp.UI.Lottie" xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <ResourceDictionary.MergedDictionaries>
     <um:MaterialFonts />
     <um:MaterialColorsV2 />
@@ -545,7 +545,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="Button">
-          <Grid x:Name="RootGrid" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+          <Grid x:Name="RootGrid" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="CommonStates">
                 <VisualState x:Name="Normal" />
@@ -3568,11 +3568,11 @@
         <ControlTemplate TargetType="Button">
           <Grid x:Name="LayoutRoot" MinWidth="{TemplateBinding MinWidth}" Height="{TemplateBinding MinHeight}" Margin="{TemplateBinding Padding}" Background="{TemplateBinding Background}" HorizontalAlignment="Stretch">
             <Grid.ColumnDefinitions>
-              <ColumnDefinition x:Name="PaneToggleButtonIconWidthColumn" Width="{ThemeResource MaterialNavigationViewPaneToggleButtonWidth}" />
+              <ColumnDefinition x:Name="PaneToggleButtonIconWidthColumn" />
               <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
-              <RowDefinition Height="{ThemeResource MaterialNavigationViewPaneToggleButtonHeight}" />
+              <RowDefinition />
             </Grid.RowDefinitions>
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="CommonStates">
@@ -3664,7 +3664,7 @@
                     <Setter Target="RootGrid.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
                   </VisualState.Setters>
@@ -3674,7 +3674,7 @@
                     <Setter Target="RootGrid.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPressed}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPressed}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
                   </VisualState.Setters>
@@ -3717,7 +3717,7 @@
                     <Setter Target="RootGrid.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
                   </VisualState.Setters>
@@ -3727,7 +3727,7 @@
                     <Setter Target="RootGrid.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPressed}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPressed}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
                   </VisualState.Setters>
@@ -3757,7 +3757,7 @@
     <Setter Property="Margin" Value="{ThemeResource MaterialNavigationViewHeaderMargin}" />
     <Setter Property="VerticalAlignment" Value="Stretch" />
   </Style>
-  <Style x:Key="MaterialBaseNavigationViewStyle" TargetType="controls:NavigationView">
+  <Style x:Key="MaterialPaddedNavigationViewStyle" TargetType="controls:NavigationView">
     <Setter Property="PaneToggleButtonStyle" Value="{StaticResource MaterialNavigationViewPaneToggleButtonStyle}" />
     <Setter Property="IsTabStop" Value="False" />
     <Setter Property="CompactPaneLength" Value="{ThemeResource MaterialNavigationViewCompactPaneLength}" />
@@ -3771,13 +3771,15 @@
                 <VisualState x:Name="Expanded" />
                 <VisualState x:Name="Minimal">
                   <VisualState.Setters>
-                    <Setter Target="HeaderContent.Margin" Value="{ThemeResource MaterialNavigationViewMinimalHeaderMargin}" />
+                    <Setter Target="HeaderContent.Margin" Value="{StaticResource MaterialNavigationViewMinimalHeaderMargin}" />
+                    <Setter Target="ContentOffset.Height" Value="{StaticResource MaterialNavigationViewPaneToggleButtonHeight}" />
                   </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="TopNavigationMinimal" />
                 <VisualState x:Name="MinimalWithBackButton">
                   <VisualState.Setters>
-                    <Setter Target="HeaderContent.Margin" Value="{ThemeResource MaterialNavigationViewMinimalHeaderMargin}" />
+                    <Setter Target="HeaderContent.Margin" Value="{StaticResource MaterialNavigationViewMinimalHeaderMargin}" />
+                    <Setter Target="ContentOffset.Height" Value="{StaticResource MaterialNavigationViewPaneToggleButtonHeight}" />
                   </VisualState.Setters>
                 </VisualState>
               </VisualStateGroup>
@@ -3843,6 +3845,16 @@
                   </VisualState.Setters>
                 </VisualState>
               </VisualStateGroup>
+              <todo:VisualStateGroup x:Name="PaneSeparatorStates">
+                <!-- removed: the toggling is based on relative height of items vs nav-view -->
+                <!-- regardless if any footer/footer-items is used, and the impl is finicky -->
+                <VisualState x:Name="SeparatorCollapsed" />
+                <VisualState x:Name="SeparatorVisible">
+                  <VisualState.Setters>
+                    <Setter Target="VisualItemsSeparator.Visibility" Value="Visible" />
+                  </VisualState.Setters>
+                </VisualState>
+              </todo:VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
             <!-- Content layouts -->
             <Grid>
@@ -3858,15 +3870,19 @@
               <!-- Displaymode (compact/minimal/normal) left -->
               <SplitView x:Name="RootSplitView" Background="{TemplateBinding Background}" CompactPaneLength="{TemplateBinding CompactPaneLength}" DisplayMode="Inline" IsPaneOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPaneOpen, Mode=TwoWay}" IsTabStop="False" OpenPaneLength="{TemplateBinding OpenPaneLength}" PaneBackground="{ThemeResource MaterialNavigationViewDefaultPaneBackground}" xamarin:Style="{StaticResource MaterialNavigationViewResetSplitViewStyle}" Grid.Row="1">
                 <SplitView.Pane>
-                  <Grid x:Name="PaneContentGrid" HorizontalAlignment="Left" CornerRadius="16" BorderBrush="{StaticResource MaterialNavigationViewPaneBorderBrush}" BorderThickness="{StaticResource MaterialNavigationViewPaneBorderThickness}" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}">
+                  <Grid x:Name="PaneContentGrid" HorizontalAlignment="Left" CornerRadius="16" BorderBrush="{StaticResource MaterialMUXNavigationViewPaneBorderBrush}" BorderThickness="{StaticResource MaterialMUXNavigationViewPaneBorderThickness}" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}">
                     <Grid.RowDefinitions>
-                      <RowDefinition x:Name="PaneContentGridToggleButtonRow" Height="Auto" MinHeight="{StaticResource MaterialNavigationViewPaneHeaderRowMinHeight}" />
-                      <RowDefinition Height="8" />
-                      <!-- above list margin -->
+                      <!-- 0: ?, 1: Padding, 2: ContentPanel, 3: AutoSuggestPanel, 4: CustomContent, 5: Padding, 6: NonHeaderPanel -->
+                      <RowDefinition Height="Auto" />
+                      <RowDefinition Height="0" todo:Comment="above button margin + back button space" />
+                      <RowDefinition x:Name="PaneContentGridToggleButtonRow" Height="Auto" />
+                      <RowDefinition Height="Auto" />
+                      <RowDefinition Height="Auto" />
+                      <RowDefinition Height="0" todo:Comment="above list margin" />
                       <RowDefinition x:Name="ItemsContainerRow" Height="*" />
                     </Grid.RowDefinitions>
-                    <Grid x:Name="PaneHeaderContentBorderWrapper" MinHeight="{StaticResource MaterialNavigationViewPaneHeaderRowMinHeight}">
-                      <!-- TODO: Uno specific: MinHeight and x:Name used here as RowDefinifiont.MinHeight does not work (issue #4727) -->
+                    <Grid x:Name="ContentPaneTopPadding" Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}" />
+                    <Grid x:Name="PaneHeaderContentBorderWrapper" Grid.Row="2" MinHeight="{StaticResource MaterialNavigationViewPaneHeaderRowMinHeight}">
                       <Grid.RowDefinitions>
                         <RowDefinition x:Name="PaneHeaderContentBorderRow" />
                       </Grid.RowDefinitions>
@@ -3875,14 +3891,44 @@
                         <ColumnDefinition x:Name="PaneHeaderToggleButtonColumn" />
                         <ColumnDefinition Width="*" />
                       </Grid.ColumnDefinitions>
-                      <ContentControl x:Name="PaneHeaderContentBorder" IsTabStop="False" VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch" Grid.Column="2" />
+                      <ContentControl x:Name="PaneHeaderContentBorder" Grid.Column="2" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" IsTabStop="False" />
                     </Grid>
+                    <todo:Grid x:Name="AutoSuggestArea" Grid.Row="3" />
+                    <ContentControl x:Name="PaneCustomContentBorder" Grid.Row="4" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" IsTabStop="False" />
                     <!-- "Non header" content -->
-                    <!-- MenuItems -->
-                    <ScrollViewer x:Name="ItemsContainerGrid" Grid.Row="2" Margin="0,0,0,8" MinHeight="{ThemeResource MaterialNavigationViewItemOnLeftMinHeight}" TabNavigation="Local" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" VerticalScrollBarVisibility="Auto">
-                      <!-- Left nav ItemsRepeater -->
-                      <controls:ItemsRepeater x:Name="MenuItemsHost" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" AutomationProperties.AccessibilityView="Content" />
-                    </ScrollViewer>
+                    <Grid x:Name="ItemsContainerGrid" Grid.Row="6">
+                      <Grid.RowDefinitions>
+                        <!-- 0: MenuItems, 1: Separator if overflow, 2: PaneFooter, 3 FooterItems -->
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                      </Grid.RowDefinitions>
+                      <!-- R0: MenuItems -->
+                      <controls:ItemsRepeaterScrollHost HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                        <ScrollViewer x:Name="MenuItemsScrollViewer" TabNavigation="Local" VerticalScrollBarVisibility="Auto">
+                          <controls:ItemsRepeater x:Name="MenuItemsHost" AutomationProperties.AccessibilityView="Content" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}">
+                            <controls:ItemsRepeater.Layout>
+                              <controls:StackLayout />
+                            </controls:ItemsRepeater.Layout>
+                          </controls:ItemsRepeater>
+                        </ScrollViewer>
+                      </controls:ItemsRepeaterScrollHost>
+                      <!-- R0: Separator (removed: see comment on PaneSeparatorStates) -->
+                      <todo:NavigationViewItemSeparator x:Name="VisualItemsSeparator" Grid.Row="1" Margin="0,0,0,2" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Collapsed" />
+                      <!-- R2: PaneFooter -->
+                      <ContentControl x:Name="FooterContentBorder" Grid.Row="2" Margin="0,0,0,4" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" IsTabStop="False" />
+                      <!-- R3: FooterItems -->
+                      <controls:ItemsRepeaterScrollHost Grid.Row="3">
+                        <ScrollViewer x:Name="FooterItemsScrollViewer" contract7Present:VerticalAnchorRatio="1" VerticalScrollBarVisibility="Auto">
+                          <controls:ItemsRepeater x:Name="FooterMenuItemsHost" AutomationProperties.AccessibilityView="Content">
+                            <controls:ItemsRepeater.Layout>
+                              <controls:StackLayout />
+                            </controls:ItemsRepeater.Layout>
+                          </controls:ItemsRepeater>
+                        </ScrollViewer>
+                      </controls:ItemsRepeaterScrollHost>
+                    </Grid>
                   </Grid>
                 </SplitView.Pane>
                 <SplitView.Content>
@@ -3896,8 +3942,235 @@
                       <ColumnDefinition Width="Auto" />
                       <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
-                    <Grid x:Name="ContentTopPadding" Grid.ColumnSpan="2" Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}" />
-                    <Grid x:Name="ContentLeftPadding" Grid.Row="1" />
+                    <todo:Grid x:Name="ContentTopPadding" Grid.ColumnSpan="2" Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}" />
+                    <todo:Grid x:Name="ContentLeftPadding" Grid.Row="1" />
+                    <Grid x:Name="ContentOffset" Grid.Row="1" />
+                    <ContentControl x:Name="HeaderContent" Grid.Row="1" Grid.Column="1" MinHeight="{StaticResource MaterialNavigationViewPaneToggleButtonHeight}" IsTabStop="False" Content="{TemplateBinding Header}" ContentTemplate="{TemplateBinding HeaderTemplate}" VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch" Style="{StaticResource MaterialNavigationViewTitleHeaderContentControlTextStyle}" />
+                    <ContentPresenter AutomationProperties.LandmarkType="Main" Grid.Row="2" Grid.ColumnSpan="2" Content="{TemplateBinding Content}" />
+                  </Grid>
+                </SplitView.Content>
+              </SplitView>
+            </Grid>
+            <!-- Button grid -->
+            <!--
+							TODO: Uno Specific: Canvas.ZIndex is not implemented, so the
+							button Grid is moved below the content SplitView in the template
+						-->
+            <Grid x:Name="PaneToggleButtonGrid" Margin="0,0,0,8" HorizontalAlignment="Left" VerticalAlignment="Top" Canvas.ZIndex="100">
+              <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+              </Grid.RowDefinitions>
+              <Grid x:Name="TogglePaneTopPadding" Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}" />
+              <Grid x:Name="ButtonHolderGrid" Grid.Row="1">
+                <Button x:Name="NavigationViewBackButton" Style="{StaticResource NavigationBackButtonNormalStyle}" VerticalAlignment="Top" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.BackButtonVisibility}" IsEnabled="{TemplateBinding IsBackEnabled}">
+                  <ToolTipService.ToolTip>
+                    <ToolTip x:Name="NavigationViewBackButtonToolTip" />
+                  </ToolTipService.ToolTip>
+                </Button>
+                <Button x:Name="NavigationViewCloseButton" Style="{StaticResource NavigationBackButtonNormalStyle}" VerticalAlignment="Top">
+                  <ToolTipService.ToolTip>
+                    <ToolTip x:Name="NavigationViewCloseButtonToolTip" />
+                  </ToolTipService.ToolTip>
+                </Button>
+                <Button x:Name="TogglePaneButton" Style="{TemplateBinding PaneToggleButtonStyle}" AutomationProperties.LandmarkType="Navigation" HorizontalAlignment="Center" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.PaneToggleButtonVisibility}" VerticalAlignment="Top">
+                  <TextBlock x:Name="PaneTitleTextBlock" Grid.Column="0" Text="{TemplateBinding PaneTitle}" HorizontalAlignment="Left" VerticalAlignment="Center" Style="{StaticResource MaterialNavigationViewItemHeaderTextStyle}" />
+                </Button>
+                <Grid x:Name="PaneTitleHolder" Visibility="Collapsed">
+                  <ContentControl x:Name="PaneTitlePresenter" Margin="{ThemeResource MaterialNavigationViewPaneTitlePresenterMargin}" IsTabStop="False" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" />
+                </Grid>
+              </Grid>
+            </Grid>
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="MaterialBaseNavigationViewStyle" TargetType="controls:NavigationView">
+    <Setter Property="PaneToggleButtonStyle" Value="{StaticResource MaterialNavigationViewPaneToggleButtonStyle}" />
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="CompactPaneLength" Value="{ThemeResource MaterialNavigationViewCompactPaneLength}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="controls:NavigationView">
+          <Grid x:Name="RootGrid">
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="DisplayModeGroup">
+                <VisualState x:Name="Compact" />
+                <VisualState x:Name="Expanded" />
+                <VisualState x:Name="Minimal">
+                  <VisualState.Setters>
+                    <Setter Target="HeaderContent.Margin" Value="{StaticResource MaterialNavigationViewMinimalHeaderMargin}" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="TopNavigationMinimal" />
+                <VisualState x:Name="MinimalWithBackButton">
+                  <VisualState.Setters>
+                    <Setter Target="HeaderContent.Margin" Value="{StaticResource MaterialNavigationViewMinimalHeaderMargin}" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="TogglePaneGroup">
+                <VisualState x:Name="TogglePaneButtonVisible" />
+                <VisualState x:Name="TogglePaneButtonCollapsed" />
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="HeaderGroup">
+                <VisualState x:Name="HeaderVisible" />
+                <VisualState x:Name="HeaderCollapsed">
+                  <VisualState.Setters>
+                    <Setter Target="HeaderContent.Visibility" Value="Collapsed" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="AutoSuggestGroup">
+                <VisualState x:Name="AutoSuggestBoxVisible" />
+                <VisualState x:Name="AutoSuggestBoxCollapsed" />
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="PaneStateGroup">
+                <VisualState x:Name="NotClosedCompact" />
+                <VisualState x:Name="ClosedCompact" />
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="PaneStateListSizeGroup">
+                <VisualState x:Name="ListSizeFull" />
+                <VisualState x:Name="ListSizeCompact">
+                  <VisualState.Setters>
+                    <Setter Target="PaneContentGrid.Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CompactPaneLength}" />
+                    <Setter Target="PaneTitleTextBlock.Visibility" Value="Collapsed" />
+                    <Setter Target="PaneHeaderContentBorder.Visibility" Value="Collapsed" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="TitleBarVisibilityGroup">
+                <VisualState x:Name="TitleBarVisible" />
+                <VisualState x:Name="TitleBarCollapsed">
+                  <VisualState.Setters>
+                    <Setter Target="PaneContentGrid.Margin" Value="0,32,0,0" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="OverflowLabelGroup">
+                <VisualState x:Name="OverflowButtonWithLabel" />
+                <VisualState x:Name="OverflowButtonNoLabel" />
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="BackButtonGroup">
+                <VisualState x:Name="BackButtonVisible" />
+                <VisualState x:Name="BackButtonCollapsed">
+                  <VisualState.Setters>
+                    <Setter Target="BackButtonPlaceholderOnTopNav.Width" Value="0" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="PaneVisibilityGroup">
+                <VisualState x:Name="PaneVisible" />
+                <VisualState x:Name="PaneCollapsed">
+                  <VisualState.Setters>
+                    <!-- Note that RootSplitView.DisplayMode is set in code so we don't want to -->
+                    <!-- write it here and interfere. But these values work together to hide -->
+                    <!-- the left pane. -->
+                    <Setter Target="RootSplitView.CompactPaneLength" Value="0" />
+                    <Setter Target="PaneToggleButtonGrid.Visibility" Value="Collapsed" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <todo:VisualStateGroup x:Name="PaneSeparatorStates">
+                <!-- removed: the toggling is based on relative height of items vs nav-view -->
+                <!-- regardless if any footer/footer-items is used, and the impl is finicky -->
+                <VisualState x:Name="SeparatorCollapsed" />
+                <VisualState x:Name="SeparatorVisible">
+                  <VisualState.Setters>
+                    <Setter Target="VisualItemsSeparator.Visibility" Value="Visible" />
+                  </VisualState.Setters>
+                </VisualState>
+              </todo:VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <!-- Content layouts -->
+            <Grid>
+              <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+              </Grid.RowDefinitions>
+              <!-- DisplayMode top -->
+              <StackPanel x:Name="TopNavArea">
+                <!-- As of Microsoft.UI.Xaml 2.6.0-prerelease.210430001, PaneTitleOnTopPane must be present in the template -->
+                <ContentControl x:Name="PaneTitleOnTopPane" Visibility="Collapsed" />
+              </StackPanel>
+              <!-- Displaymode (compact/minimal/normal) left -->
+              <SplitView x:Name="RootSplitView" Background="{TemplateBinding Background}" CompactPaneLength="{TemplateBinding CompactPaneLength}" DisplayMode="Inline" IsPaneOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPaneOpen, Mode=TwoWay}" IsTabStop="False" OpenPaneLength="{TemplateBinding OpenPaneLength}" PaneBackground="{ThemeResource MaterialNavigationViewDefaultPaneBackground}" xamarin:Style="{StaticResource MaterialNavigationViewResetSplitViewStyle}" Grid.Row="1">
+                <SplitView.Pane>
+                  <Grid x:Name="PaneContentGrid" HorizontalAlignment="Left" CornerRadius="16" BorderBrush="{StaticResource MaterialMUXNavigationViewPaneBorderBrush}" BorderThickness="{StaticResource MaterialMUXNavigationViewPaneBorderThickness}" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}">
+                    <Grid.RowDefinitions>
+                      <!-- 0: ?, 1: Padding, 2: ContentPanel, 3: AutoSuggestPanel, 4: CustomContent, 5: Padding, 6: NonHeaderPanel -->
+                      <RowDefinition Height="Auto" />
+                      <RowDefinition Height="0" todo:Comment="above button margin + back button space" />
+                      <RowDefinition x:Name="PaneContentGridToggleButtonRow" Height="Auto" />
+                      <RowDefinition Height="Auto" />
+                      <RowDefinition Height="Auto" />
+                      <RowDefinition Height="0" todo:Comment="above list margin" />
+                      <RowDefinition x:Name="ItemsContainerRow" Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid x:Name="ContentPaneTopPadding" Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}" />
+                    <Grid x:Name="PaneHeaderContentBorderWrapper" Grid.Row="2" MinHeight="{StaticResource MaterialNavigationViewPaneHeaderRowMinHeight}">
+                      <Grid.RowDefinitions>
+                        <RowDefinition x:Name="PaneHeaderContentBorderRow" />
+                      </Grid.RowDefinitions>
+                      <Grid.ColumnDefinitions>
+                        <ColumnDefinition x:Name="PaneHeaderCloseButtonColumn" />
+                        <ColumnDefinition x:Name="PaneHeaderToggleButtonColumn" />
+                        <ColumnDefinition Width="*" />
+                      </Grid.ColumnDefinitions>
+                      <ContentControl x:Name="PaneHeaderContentBorder" Grid.Column="2" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" IsTabStop="False" />
+                    </Grid>
+                    <todo:Grid x:Name="AutoSuggestArea" Grid.Row="3" />
+                    <ContentControl x:Name="PaneCustomContentBorder" Grid.Row="4" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" IsTabStop="False" />
+                    <!-- "Non header" content -->
+                    <Grid x:Name="ItemsContainerGrid" Grid.Row="6">
+                      <Grid.RowDefinitions>
+                        <!-- 0: MenuItems, 1: Separator if overflow, 2: PaneFooter, 3 FooterItems -->
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                      </Grid.RowDefinitions>
+                      <!-- R0: MenuItems -->
+                      <controls:ItemsRepeaterScrollHost HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                        <ScrollViewer x:Name="MenuItemsScrollViewer" TabNavigation="Local" VerticalScrollBarVisibility="Auto">
+                          <controls:ItemsRepeater x:Name="MenuItemsHost" AutomationProperties.AccessibilityView="Content" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}">
+                            <controls:ItemsRepeater.Layout>
+                              <controls:StackLayout />
+                            </controls:ItemsRepeater.Layout>
+                          </controls:ItemsRepeater>
+                        </ScrollViewer>
+                      </controls:ItemsRepeaterScrollHost>
+                      <!-- R0: Separator (removed: see comment on PaneSeparatorStates) -->
+                      <todo:NavigationViewItemSeparator x:Name="VisualItemsSeparator" Grid.Row="1" Margin="0,0,0,2" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Collapsed" />
+                      <!-- R2: PaneFooter -->
+                      <ContentControl x:Name="FooterContentBorder" Grid.Row="2" Margin="0,0,0,4" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" IsTabStop="False" />
+                      <!-- R3: FooterItems -->
+                      <controls:ItemsRepeaterScrollHost Grid.Row="3">
+                        <ScrollViewer x:Name="FooterItemsScrollViewer" contract7Present:VerticalAnchorRatio="1" VerticalScrollBarVisibility="Auto">
+                          <controls:ItemsRepeater x:Name="FooterMenuItemsHost" AutomationProperties.AccessibilityView="Content">
+                            <controls:ItemsRepeater.Layout>
+                              <controls:StackLayout />
+                            </controls:ItemsRepeater.Layout>
+                          </controls:ItemsRepeater>
+                        </ScrollViewer>
+                      </controls:ItemsRepeaterScrollHost>
+                    </Grid>
+                  </Grid>
+                </SplitView.Pane>
+                <SplitView.Content>
+                  <Grid x:Name="ContentGrid">
+                    <Grid.RowDefinitions>
+                      <RowDefinition Height="Auto" />
+                      <RowDefinition Height="Auto" />
+                      <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                      <ColumnDefinition Width="Auto" />
+                      <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <todo:Grid x:Name="ContentTopPadding" Grid.ColumnSpan="2" Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}" />
+                    <todo:Grid x:Name="ContentLeftPadding" Grid.Row="1" />
                     <ContentControl x:Name="HeaderContent" Grid.Row="1" Grid.Column="1" MinHeight="{StaticResource MaterialNavigationViewPaneToggleButtonHeight}" IsTabStop="False" Content="{TemplateBinding Header}" ContentTemplate="{TemplateBinding HeaderTemplate}" VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch" Style="{StaticResource MaterialNavigationViewTitleHeaderContentControlTextStyle}" />
                     <ContentPresenter AutomationProperties.LandmarkType="Main" Grid.Row="2" Grid.ColumnSpan="2" Content="{TemplateBinding Content}" />
                   </Grid>
@@ -3963,7 +4236,7 @@
                 <VisualState x:Name="Normal" />
                 <VisualState x:Name="PointerOver">
                   <VisualState.Setters>
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
                     <Setter Target="BackgroundBorder.Background" Value="{ThemeResource MaterialNavigationViewItemBackgroundPointerOver}" />
@@ -3974,7 +4247,7 @@
                 </VisualState>
                 <VisualState x:Name="Pressed">
                   <VisualState.Setters>
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
                     <Setter Target="BackgroundBorder.Background" Value="{ThemeResource MaterialNavigationViewItemBackgroundPressed}" />
@@ -3993,7 +4266,7 @@
                 </VisualState>
                 <VisualState x:Name="PointerOverSelected">
                   <VisualState.Setters>
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
                     <Setter Target="BackgroundBorder.Background" Value="{ThemeResource MaterialNavigationViewItemBackgroundSelectedPointerOver}" />
@@ -4004,7 +4277,7 @@
                 </VisualState>
                 <VisualState x:Name="PressedSelected">
                   <VisualState.Setters>
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
                     <Setter Target="BackgroundBorder.Background" Value="{ThemeResource MaterialNavigationViewItemBackgroundSelectedPressed}" />
@@ -4220,7 +4493,7 @@
                     <Setter Target="LayoutRoot.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
                   </VisualState.Setters>
@@ -4230,7 +4503,7 @@
                     <Setter Target="LayoutRoot.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPressed}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPressed}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
                   </VisualState.Setters>
@@ -4247,7 +4520,7 @@
                     <Setter Target="LayoutRoot.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundSelectedPointerOver}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
                   </VisualState.Setters>
@@ -4257,7 +4530,7 @@
                     <Setter Target="LayoutRoot.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPressed}" />
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundSelectedPressed}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
                   </VisualState.Setters>
@@ -4316,7 +4589,7 @@
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPointerOver}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
                     <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
                   </VisualState.Setters>
@@ -4327,7 +4600,7 @@
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPressed}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
                     <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
                   </VisualState.Setters>
@@ -4346,7 +4619,7 @@
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundSelectedPointerOver}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
                     <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
                   </VisualState.Setters>
@@ -4357,7 +4630,7 @@
                     <Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundSelectedPressed}" />
                     <Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
                     <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
-                    <!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+                    <!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
                     <!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
                   </VisualState.Setters>
@@ -5826,7 +6099,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="ToggleButton">
-          <Grid x:Name="RootGrid" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+          <Grid x:Name="RootGrid" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="CommonStates">
                 <VisualState x:Name="Normal" />

--- a/src/library/Uno.Material/MaterialResourcesV2.cs
+++ b/src/library/Uno.Material/MaterialResourcesV2.cs
@@ -108,6 +108,7 @@ namespace Uno.Material
 			Add("MaterialListViewStyle", isImplicit: true);
 			Add("MaterialMenuFlyoutPresenterStyle", isImplicit: true);
 			Add("MaterialNavigationViewItemStyle", isImplicit: true);
+			Add("MaterialPaddedNavigationViewStyle");
 			Add("MaterialNavigationViewStyle", isImplicit: true);
 			Add("MaterialOutlinedButtonStyle");
 			Add("MaterialOutlinedPasswordBoxStyle");

--- a/src/library/Uno.Material/Styles/Controls/v2/NavigationView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/NavigationView.xaml
@@ -13,7 +13,8 @@
 					xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
 					xmlns:primitiveContract7Present="using:Microsoft.UI.Xaml.Controls.Primitives"
-					mc:Ignorable="skia xamarin contract4NotPresent contract7NotPresent">
+					xmlns:todo="what should be done"
+					mc:Ignorable="todo skia xamarin contract4NotPresent contract7NotPresent">
 
 	<!--
 		Source taken/modified from: https://github.com/unoplatform/uno/tree/2e4c84310d8f88f24d2cae284cec8f5c93375a22
@@ -839,12 +840,11 @@
 						  Background="{TemplateBinding Background}"
 						  HorizontalAlignment="Stretch">
 						<Grid.ColumnDefinitions>
-							<ColumnDefinition x:Name="PaneToggleButtonIconWidthColumn"
-											  Width="{ThemeResource MaterialNavigationViewPaneToggleButtonWidth}" />
+							<ColumnDefinition x:Name="PaneToggleButtonIconWidthColumn" />
 							<ColumnDefinition Width="*" />
 						</Grid.ColumnDefinitions>
 						<Grid.RowDefinitions>
-							<RowDefinition Height="{ThemeResource MaterialNavigationViewPaneToggleButtonHeight}" />
+							<RowDefinition />
 						</Grid.RowDefinitions>
 
 						<VisualStateManager.VisualStateGroups>
@@ -965,7 +965,7 @@
 										<Setter Target="RootGrid.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPointerOver}" />
 										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPointerOver}" />
 										<Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
 									</VisualState.Setters>
@@ -975,7 +975,7 @@
 										<Setter Target="RootGrid.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPressed}" />
 										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPressed}" />
 										<Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
 									</VisualState.Setters>
@@ -1035,7 +1035,7 @@
 										<Setter Target="RootGrid.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPointerOver}" />
 										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPointerOver}" />
 										<Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
 									</VisualState.Setters>
@@ -1045,7 +1045,7 @@
 										<Setter Target="RootGrid.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPressed}" />
 										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPressed}" />
 										<Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="RootGrid.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
 									</VisualState.Setters>
@@ -1080,8 +1080,7 @@
 	<Style x:Key="MaterialNavigationViewItemHeaderTextStyle"
 		   TargetType="TextBlock"
 		   BasedOn="{StaticResource MaterialTitleSmall}">
-		<Setter Property="Foreground"
-				Value="{StaticResource OnSurfaceBrush}" />
+		<Setter Property="Foreground" Value="{StaticResource OnSurfaceBrush}" />
 	</Style>
 
 	<!-- based on TitleSmall TextBlockStyle -->
@@ -1094,7 +1093,7 @@
 		<Setter Property="VerticalAlignment" Value="Stretch" />
 	</Style>
 
-	<Style x:Key="MaterialBaseNavigationViewStyle"
+	<Style x:Key="MaterialPaddedNavigationViewStyle"
 		   TargetType="muxc:NavigationView">
 		<Setter Property="PaneToggleButtonStyle" Value="{StaticResource MaterialNavigationViewPaneToggleButtonStyle}" />
 		<Setter Property="IsTabStop" Value="False" />
@@ -1111,7 +1110,8 @@
 
 								<VisualState x:Name="Minimal">
 									<VisualState.Setters>
-										<Setter Target="HeaderContent.Margin" Value="{ThemeResource MaterialNavigationViewMinimalHeaderMargin}" />
+										<Setter Target="HeaderContent.Margin" Value="{StaticResource MaterialNavigationViewMinimalHeaderMargin}" />
+										<Setter Target="ContentOffset.Height" Value="{StaticResource MaterialNavigationViewPaneToggleButtonHeight}" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -1119,7 +1119,8 @@
 
 								<VisualState x:Name="MinimalWithBackButton">
 									<VisualState.Setters>
-										<Setter Target="HeaderContent.Margin" Value="{ThemeResource MaterialNavigationViewMinimalHeaderMargin}" />
+										<Setter Target="HeaderContent.Margin" Value="{StaticResource MaterialNavigationViewMinimalHeaderMargin}" />
+										<Setter Target="ContentOffset.Height" Value="{StaticResource MaterialNavigationViewPaneToggleButtonHeight}" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -1154,8 +1155,7 @@
 									<VisualState.Setters>
 										<Setter Target="PaneContentGrid.Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CompactPaneLength}" />
 										<Setter Target="PaneTitleTextBlock.Visibility" Value="Collapsed" />
-										<Setter Target="PaneHeaderContentBorder.Visibility"
-												Value="Collapsed" />
+										<Setter Target="PaneHeaderContentBorder.Visibility" Value="Collapsed" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -1195,6 +1195,17 @@
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
+
+							<todo:VisualStateGroup x:Name="PaneSeparatorStates">
+								<!-- removed: the toggling is based on relative height of items vs nav-view -->
+								<!-- regardless if any footer/footer-items is used, and the impl is finicky -->
+								<VisualState x:Name="SeparatorCollapsed" />
+								<VisualState x:Name="SeparatorVisible">
+									<VisualState.Setters>
+										<Setter Target="VisualItemsSeparator.Visibility" Value="Visible"/>
+									</VisualState.Setters>
+								</VisualState>
+							</todo:VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 
 						<!-- Content layouts -->
@@ -1227,22 +1238,30 @@
 									<Grid x:Name="PaneContentGrid"
 										  HorizontalAlignment="Left"
 										  CornerRadius="16"
-										  BorderBrush="{StaticResource MaterialNavigationViewPaneBorderBrush}"
-										  BorderThickness="{StaticResource MaterialNavigationViewPaneBorderThickness}"
+										  BorderBrush="{StaticResource MaterialMUXNavigationViewPaneBorderBrush}"
+										  BorderThickness="{StaticResource MaterialMUXNavigationViewPaneBorderThickness}"
 										  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}">
 										<Grid.RowDefinitions>
+											<!-- 0: ?, 1: Padding, 2: ContentPanel, 3: AutoSuggestPanel, 4: CustomContent, 5: Padding, 6: NonHeaderPanel -->
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="0"
+														   todo:Comment="above button margin + back button space" />
 											<RowDefinition x:Name="PaneContentGridToggleButtonRow"
-														   Height="Auto"
-														   MinHeight="{StaticResource MaterialNavigationViewPaneHeaderRowMinHeight}" />
-											<RowDefinition Height="8" />
-											<!-- above list margin -->
+														   Height="Auto" />
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="0"
+														   todo:Comment="above list margin" />
 											<RowDefinition x:Name="ItemsContainerRow"
 														   Height="*" />
 										</Grid.RowDefinitions>
 
+										<Grid x:Name="ContentPaneTopPadding"
+											  Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}" />
+
 										<Grid x:Name="PaneHeaderContentBorderWrapper"
+											  Grid.Row="2"
 											  MinHeight="{StaticResource MaterialNavigationViewPaneHeaderRowMinHeight}">
-											<!-- TODO: Uno specific: MinHeight and x:Name used here as RowDefinifiont.MinHeight does not work (issue #4727) -->
 											<Grid.RowDefinitions>
 												<RowDefinition x:Name="PaneHeaderContentBorderRow" />
 											</Grid.RowDefinitions>
@@ -1254,27 +1273,78 @@
 											</Grid.ColumnDefinitions>
 
 											<ContentControl x:Name="PaneHeaderContentBorder"
-															IsTabStop="False"
-															VerticalContentAlignment="Stretch"
+															Grid.Column="2"
 															HorizontalContentAlignment="Stretch"
-															Grid.Column="2" />
+															VerticalContentAlignment="Stretch"
+															IsTabStop="False" />
 										</Grid>
 
+										<todo:Grid x:Name="AutoSuggestArea"
+												   Grid.Row="3" />
+
+										<ContentControl x:Name="PaneCustomContentBorder"
+														Grid.Row="4"
+														HorizontalContentAlignment="Stretch"
+														VerticalContentAlignment="Stretch"
+														IsTabStop="False" />
+
 										<!-- "Non header" content -->
-										<!-- MenuItems -->
-										<ScrollViewer x:Name="ItemsContainerGrid"
-													  Grid.Row="2"
-													  Margin="0,0,0,8"
-													  MinHeight="{ThemeResource MaterialNavigationViewItemOnLeftMinHeight}"
-													  TabNavigation="Local"
-													  HorizontalAlignment="Stretch"
-													  VerticalAlignment="Stretch"
-													  VerticalScrollBarVisibility="Auto">
-											<!-- Left nav ItemsRepeater -->
-											<muxc:ItemsRepeater x:Name="MenuItemsHost"
-																AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
-																AutomationProperties.AccessibilityView="Content" />
-										</ScrollViewer>
+										<Grid x:Name="ItemsContainerGrid"
+											  Grid.Row="6">
+											<Grid.RowDefinitions>
+												<!-- 0: MenuItems, 1: Separator if overflow, 2: PaneFooter, 3 FooterItems -->
+												<RowDefinition Height="*" />
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+											</Grid.RowDefinitions>
+
+											<!-- R0: MenuItems -->
+											<muxc:ItemsRepeaterScrollHost HorizontalAlignment="Stretch"
+																		  VerticalAlignment="Stretch">
+												<ScrollViewer x:Name="MenuItemsScrollViewer"
+															  TabNavigation="Local"
+															  VerticalScrollBarVisibility="Auto">
+													<muxc:ItemsRepeater x:Name="MenuItemsHost"
+																		AutomationProperties.AccessibilityView="Content"
+																		AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}">
+														<muxc:ItemsRepeater.Layout>
+															<muxc:StackLayout />
+														</muxc:ItemsRepeater.Layout>
+													</muxc:ItemsRepeater>
+												</ScrollViewer>
+											</muxc:ItemsRepeaterScrollHost>
+
+											<!-- R0: Separator (removed: see comment on PaneSeparatorStates) -->
+											<todo:NavigationViewItemSeparator x:Name="VisualItemsSeparator"
+																			  Grid.Row="1"
+																			  Margin="0,0,0,2"
+																			  HorizontalAlignment="Stretch"
+																			  VerticalAlignment="Center"
+																			  Visibility="Collapsed" />
+
+											<!-- R2: PaneFooter -->
+											<ContentControl x:Name="FooterContentBorder"
+															Grid.Row="2"
+															Margin="0,0,0,4"
+															HorizontalContentAlignment="Stretch"
+															VerticalContentAlignment="Stretch"
+															IsTabStop="False" />
+
+											<!-- R3: FooterItems -->
+											<muxc:ItemsRepeaterScrollHost Grid.Row="3">
+												<ScrollViewer x:Name="FooterItemsScrollViewer"
+															  contract7Present:VerticalAnchorRatio="1"
+															  VerticalScrollBarVisibility="Auto">
+													<muxc:ItemsRepeater x:Name="FooterMenuItemsHost"
+																		AutomationProperties.AccessibilityView="Content">
+														<muxc:ItemsRepeater.Layout>
+															<muxc:StackLayout />
+														</muxc:ItemsRepeater.Layout>
+													</muxc:ItemsRepeater>
+												</ScrollViewer>
+											</muxc:ItemsRepeaterScrollHost>
+										</Grid>
 									</Grid>
 								</SplitView.Pane>
 
@@ -1290,12 +1360,373 @@
 											<ColumnDefinition Width="*" />
 										</Grid.ColumnDefinitions>
 
-										<Grid x:Name="ContentTopPadding"
+										<todo:Grid x:Name="ContentTopPadding"
 											  Grid.ColumnSpan="2"
 											  Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}"
 											  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}" />
 
-										<Grid x:Name="ContentLeftPadding"
+										<todo:Grid x:Name="ContentLeftPadding"
+											  Grid.Row="1" />
+										<Grid x:Name="ContentOffset"
+											  Grid.Row="1" />
+
+										<ContentControl x:Name="HeaderContent"
+														Grid.Row="1"
+														Grid.Column="1"
+														MinHeight="{StaticResource MaterialNavigationViewPaneToggleButtonHeight}"
+														IsTabStop="False"
+														Content="{TemplateBinding Header}"
+														ContentTemplate="{TemplateBinding HeaderTemplate}"
+														VerticalContentAlignment="Stretch"
+														HorizontalContentAlignment="Stretch"
+														Style="{StaticResource MaterialNavigationViewTitleHeaderContentControlTextStyle}" />
+
+										<ContentPresenter AutomationProperties.LandmarkType="Main"
+														  Grid.Row="2"
+														  Grid.ColumnSpan="2"
+														  Content="{TemplateBinding Content}" />
+									</Grid>
+								</SplitView.Content>
+							</SplitView>
+
+						</Grid>
+
+						<!-- Button grid -->
+						<!--
+							TODO: Uno Specific: Canvas.ZIndex is not implemented, so the
+							button Grid is moved below the content SplitView in the template
+						-->
+						<Grid x:Name="PaneToggleButtonGrid"
+							  Margin="0,0,0,8"
+							  HorizontalAlignment="Left"
+							  VerticalAlignment="Top"
+							  Canvas.ZIndex="100">
+
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+							</Grid.RowDefinitions>
+
+							<Grid x:Name="TogglePaneTopPadding"
+								  Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}" />
+
+							<Grid x:Name="ButtonHolderGrid"
+								  Grid.Row="1">
+								<Button x:Name="NavigationViewBackButton"
+										Style="{StaticResource NavigationBackButtonNormalStyle}"
+										VerticalAlignment="Top"
+										Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.BackButtonVisibility}"
+										IsEnabled="{TemplateBinding IsBackEnabled}">
+									<ToolTipService.ToolTip>
+										<ToolTip x:Name="NavigationViewBackButtonToolTip" />
+									</ToolTipService.ToolTip>
+								</Button>
+								<Button x:Name="NavigationViewCloseButton"
+										Style="{StaticResource NavigationBackButtonNormalStyle}"
+										VerticalAlignment="Top">
+									<ToolTipService.ToolTip>
+										<ToolTip x:Name="NavigationViewCloseButtonToolTip" />
+									</ToolTipService.ToolTip>
+								</Button>
+								<Button x:Name="TogglePaneButton"
+										Style="{TemplateBinding PaneToggleButtonStyle}"
+										AutomationProperties.LandmarkType="Navigation"
+										HorizontalAlignment="Center"
+										Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.PaneToggleButtonVisibility}"
+										VerticalAlignment="Top">
+									<TextBlock x:Name="PaneTitleTextBlock"
+											   Grid.Column="0"
+											   Text="{TemplateBinding PaneTitle}"
+											   HorizontalAlignment="Left"
+											   VerticalAlignment="Center"
+											   Style="{StaticResource MaterialNavigationViewItemHeaderTextStyle}" />
+								</Button>
+								<Grid x:Name="PaneTitleHolder"
+									  Visibility="Collapsed">
+									<ContentControl x:Name="PaneTitlePresenter"
+													Margin="{ThemeResource MaterialNavigationViewPaneTitlePresenterMargin}"
+													IsTabStop="False"
+													HorizontalContentAlignment="Stretch"
+													VerticalContentAlignment="Stretch" />
+								</Grid>
+							</Grid>
+						</Grid>
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+	<Style x:Key="MaterialBaseNavigationViewStyle"
+		   TargetType="muxc:NavigationView">
+		<Setter Property="PaneToggleButtonStyle" Value="{StaticResource MaterialNavigationViewPaneToggleButtonStyle}" />
+		<Setter Property="IsTabStop" Value="False" />
+		<Setter Property="CompactPaneLength" Value="{ThemeResource MaterialNavigationViewCompactPaneLength}" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="muxc:NavigationView">
+					<Grid x:Name="RootGrid">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="DisplayModeGroup">
+								<VisualState x:Name="Compact" />
+
+								<VisualState x:Name="Expanded" />
+
+								<VisualState x:Name="Minimal">
+									<VisualState.Setters>
+										<Setter Target="HeaderContent.Margin" Value="{StaticResource MaterialNavigationViewMinimalHeaderMargin}" />
+									</VisualState.Setters>
+								</VisualState>
+
+								<VisualState x:Name="TopNavigationMinimal" />
+
+								<VisualState x:Name="MinimalWithBackButton">
+									<VisualState.Setters>
+										<Setter Target="HeaderContent.Margin" Value="{StaticResource MaterialNavigationViewMinimalHeaderMargin}" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="TogglePaneGroup">
+								<VisualState x:Name="TogglePaneButtonVisible" />
+								<VisualState x:Name="TogglePaneButtonCollapsed" />
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="HeaderGroup">
+								<VisualState x:Name="HeaderVisible" />
+								<VisualState x:Name="HeaderCollapsed">
+									<VisualState.Setters>
+										<Setter Target="HeaderContent.Visibility" Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="AutoSuggestGroup">
+								<VisualState x:Name="AutoSuggestBoxVisible" />
+								<VisualState x:Name="AutoSuggestBoxCollapsed" />
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="PaneStateGroup">
+								<VisualState x:Name="NotClosedCompact" />
+								<VisualState x:Name="ClosedCompact" />
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="PaneStateListSizeGroup">
+								<VisualState x:Name="ListSizeFull" />
+								<VisualState x:Name="ListSizeCompact">
+									<VisualState.Setters>
+										<Setter Target="PaneContentGrid.Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CompactPaneLength}" />
+										<Setter Target="PaneTitleTextBlock.Visibility" Value="Collapsed" />
+										<Setter Target="PaneHeaderContentBorder.Visibility" Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="TitleBarVisibilityGroup">
+								<VisualState x:Name="TitleBarVisible" />
+								<VisualState x:Name="TitleBarCollapsed">
+									<VisualState.Setters>
+										<Setter Target="PaneContentGrid.Margin" Value="0,32,0,0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="OverflowLabelGroup">
+								<VisualState x:Name="OverflowButtonWithLabel" />
+								<VisualState x:Name="OverflowButtonNoLabel" />
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="BackButtonGroup">
+								<VisualState x:Name="BackButtonVisible" />
+								<VisualState x:Name="BackButtonCollapsed">
+									<VisualState.Setters>
+										<Setter Target="BackButtonPlaceholderOnTopNav.Width" Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="PaneVisibilityGroup">
+								<VisualState x:Name="PaneVisible" />
+								<VisualState x:Name="PaneCollapsed">
+									<VisualState.Setters>
+										<!-- Note that RootSplitView.DisplayMode is set in code so we don't want to -->
+										<!-- write it here and interfere. But these values work together to hide -->
+										<!-- the left pane. -->
+										<Setter Target="RootSplitView.CompactPaneLength" Value="0" />
+										<Setter Target="PaneToggleButtonGrid.Visibility" Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<todo:VisualStateGroup x:Name="PaneSeparatorStates">
+								<!-- removed: the toggling is based on relative height of items vs nav-view -->
+								<!-- regardless if any footer/footer-items is used, and the impl is finicky -->
+								<VisualState x:Name="SeparatorCollapsed" />
+								<VisualState x:Name="SeparatorVisible">
+									<VisualState.Setters>
+										<Setter Target="VisualItemsSeparator.Visibility" Value="Visible"/>
+									</VisualState.Setters>
+								</VisualState>
+							</todo:VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+
+						<!-- Content layouts -->
+						<Grid>
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="*" />
+							</Grid.RowDefinitions>
+
+							<!-- DisplayMode top -->
+							<StackPanel x:Name="TopNavArea">
+								<!-- As of Microsoft.UI.Xaml 2.6.0-prerelease.210430001, PaneTitleOnTopPane must be present in the template -->
+								<ContentControl x:Name="PaneTitleOnTopPane"
+												Visibility="Collapsed" />
+							</StackPanel>
+
+							<!-- Displaymode (compact/minimal/normal) left -->
+							<SplitView x:Name="RootSplitView"
+									   Background="{TemplateBinding Background}"
+									   CompactPaneLength="{TemplateBinding CompactPaneLength}"
+									   DisplayMode="Inline"
+									   IsPaneOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPaneOpen, Mode=TwoWay}"
+									   IsTabStop="False"
+									   OpenPaneLength="{TemplateBinding OpenPaneLength}"
+									   PaneBackground="{ThemeResource MaterialNavigationViewDefaultPaneBackground}"
+									   xamarin:Style="{StaticResource MaterialNavigationViewResetSplitViewStyle}"
+									   Grid.Row="1">
+
+								<SplitView.Pane>
+									<Grid x:Name="PaneContentGrid"
+										  HorizontalAlignment="Left"
+										  CornerRadius="16"
+										  BorderBrush="{StaticResource MaterialMUXNavigationViewPaneBorderBrush}"
+										  BorderThickness="{StaticResource MaterialMUXNavigationViewPaneBorderThickness}"
+										  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}">
+										<Grid.RowDefinitions>
+											<!-- 0: ?, 1: Padding, 2: ContentPanel, 3: AutoSuggestPanel, 4: CustomContent, 5: Padding, 6: NonHeaderPanel -->
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="0"
+														   todo:Comment="above button margin + back button space" />
+											<RowDefinition x:Name="PaneContentGridToggleButtonRow"
+														   Height="Auto" />
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="0"
+														   todo:Comment="above list margin" />
+											<RowDefinition x:Name="ItemsContainerRow"
+														   Height="*" />
+										</Grid.RowDefinitions>
+
+										<Grid x:Name="ContentPaneTopPadding"
+											  Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}" />
+
+										<Grid x:Name="PaneHeaderContentBorderWrapper"
+											  Grid.Row="2"
+											  MinHeight="{StaticResource MaterialNavigationViewPaneHeaderRowMinHeight}">
+											<Grid.RowDefinitions>
+												<RowDefinition x:Name="PaneHeaderContentBorderRow" />
+											</Grid.RowDefinitions>
+
+											<Grid.ColumnDefinitions>
+												<ColumnDefinition x:Name="PaneHeaderCloseButtonColumn" />
+												<ColumnDefinition x:Name="PaneHeaderToggleButtonColumn" />
+												<ColumnDefinition Width="*" />
+											</Grid.ColumnDefinitions>
+
+											<ContentControl x:Name="PaneHeaderContentBorder"
+															Grid.Column="2"
+															HorizontalContentAlignment="Stretch"
+															VerticalContentAlignment="Stretch"
+															IsTabStop="False" />
+										</Grid>
+
+										<todo:Grid x:Name="AutoSuggestArea"
+												   Grid.Row="3" />
+
+										<ContentControl x:Name="PaneCustomContentBorder"
+														Grid.Row="4"
+														HorizontalContentAlignment="Stretch"
+														VerticalContentAlignment="Stretch"
+														IsTabStop="False" />
+
+										<!-- "Non header" content -->
+										<Grid x:Name="ItemsContainerGrid"
+											  Grid.Row="6">
+											<Grid.RowDefinitions>
+												<!-- 0: MenuItems, 1: Separator if overflow, 2: PaneFooter, 3 FooterItems -->
+												<RowDefinition Height="*" />
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+											</Grid.RowDefinitions>
+
+											<!-- R0: MenuItems -->
+											<muxc:ItemsRepeaterScrollHost HorizontalAlignment="Stretch"
+																		  VerticalAlignment="Stretch">
+												<ScrollViewer x:Name="MenuItemsScrollViewer"
+															  TabNavigation="Local"
+															  VerticalScrollBarVisibility="Auto">
+													<muxc:ItemsRepeater x:Name="MenuItemsHost"
+																		AutomationProperties.AccessibilityView="Content"
+																		AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}">
+														<muxc:ItemsRepeater.Layout>
+															<muxc:StackLayout />
+														</muxc:ItemsRepeater.Layout>
+													</muxc:ItemsRepeater>
+												</ScrollViewer>
+											</muxc:ItemsRepeaterScrollHost>
+
+											<!-- R0: Separator (removed: see comment on PaneSeparatorStates) -->
+											<todo:NavigationViewItemSeparator x:Name="VisualItemsSeparator"
+																			  Grid.Row="1"
+																			  Margin="0,0,0,2"
+																			  HorizontalAlignment="Stretch"
+																			  VerticalAlignment="Center"
+																			  Visibility="Collapsed" />
+
+											<!-- R2: PaneFooter -->
+											<ContentControl x:Name="FooterContentBorder"
+															Grid.Row="2"
+															Margin="0,0,0,4"
+															HorizontalContentAlignment="Stretch"
+															VerticalContentAlignment="Stretch"
+															IsTabStop="False" />
+
+											<!-- R3: FooterItems -->
+											<muxc:ItemsRepeaterScrollHost Grid.Row="3">
+												<ScrollViewer x:Name="FooterItemsScrollViewer"
+															  contract7Present:VerticalAnchorRatio="1"
+															  VerticalScrollBarVisibility="Auto">
+													<muxc:ItemsRepeater x:Name="FooterMenuItemsHost"
+																		AutomationProperties.AccessibilityView="Content">
+														<muxc:ItemsRepeater.Layout>
+															<muxc:StackLayout />
+														</muxc:ItemsRepeater.Layout>
+													</muxc:ItemsRepeater>
+												</ScrollViewer>
+											</muxc:ItemsRepeaterScrollHost>
+										</Grid>
+									</Grid>
+								</SplitView.Pane>
+
+								<SplitView.Content>
+									<Grid x:Name="ContentGrid">
+										<Grid.RowDefinitions>
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="Auto" />
+											<RowDefinition Height="*" />
+										</Grid.RowDefinitions>
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition Width="Auto" />
+											<ColumnDefinition Width="*" />
+										</Grid.ColumnDefinitions>
+
+										<todo:Grid x:Name="ContentTopPadding"
+											  Grid.ColumnSpan="2"
+											  Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}"
+											  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}" />
+
+										<todo:Grid x:Name="ContentLeftPadding"
 											  Grid.Row="1" />
 
 										<ContentControl x:Name="HeaderContent"
@@ -1424,7 +1855,7 @@
 								<VisualState x:Name="Normal" />
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
 										<Setter Target="BackgroundBorder.Background" Value="{ThemeResource MaterialNavigationViewItemBackgroundPointerOver}" />
@@ -1435,7 +1866,7 @@
 								</VisualState>
 								<VisualState x:Name="Pressed">
 									<VisualState.Setters>
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
 										<Setter Target="BackgroundBorder.Background" Value="{ThemeResource MaterialNavigationViewItemBackgroundPressed}" />
@@ -1455,7 +1886,7 @@
 								</VisualState>
 								<VisualState x:Name="PointerOverSelected">
 									<VisualState.Setters>
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
 										<Setter Target="BackgroundBorder.Background" Value="{ThemeResource MaterialNavigationViewItemBackgroundSelectedPointerOver}" />
@@ -1466,7 +1897,7 @@
 								</VisualState>
 								<VisualState x:Name="PressedSelected">
 									<VisualState.Setters>
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
 										<Setter Target="BackgroundBorder.Background" Value="{ThemeResource MaterialNavigationViewItemBackgroundSelectedPressed}" />
@@ -1538,8 +1969,8 @@
 							<!-- dont apply Margin on Ripple, as it will be applied twice (on the Ripple and on its template root) -->
 							<!-- material#446: skia:Opacity to workaround Ripple opacity issue -->
 							<um:Ripple Feedback="{StaticResource MaterialNavigationViewRippleFeedback}"
-											 skia:Opacity="0.12"
-											 CornerRadius="{TemplateBinding CornerRadius}" />
+									   skia:Opacity="0.12"
+									   CornerRadius="{TemplateBinding CornerRadius}" />
 						</Border>
 
 						<!-- disabled hit-test because we dont want the content or the chevron to block the click event -->
@@ -1814,7 +2245,7 @@
 										<Setter Target="LayoutRoot.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPointerOver}" />
 										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPointerOver}" />
 										<Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
 									</VisualState.Setters>
@@ -1824,7 +2255,7 @@
 										<Setter Target="LayoutRoot.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPressed}" />
 										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPressed}" />
 										<Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
 									</VisualState.Setters>
@@ -1841,7 +2272,7 @@
 										<Setter Target="LayoutRoot.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPointerOver}" />
 										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundSelectedPointerOver}" />
 										<Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
 									</VisualState.Setters>
@@ -1851,7 +2282,7 @@
 										<Setter Target="LayoutRoot.Background" Value="{ThemeResource MaterialTopNavigationViewItemBackgroundPressed}" />
 										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundSelectedPressed}" />
 										<Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
 									</VisualState.Setters>
@@ -1935,7 +2366,7 @@
 										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPointerOver}" />
 										<Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
 										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
 									</VisualState.Setters>
@@ -1946,7 +2377,7 @@
 										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundPressed}" />
 										<Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
 										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
 									</VisualState.Setters>
@@ -1965,7 +2396,7 @@
 										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundSelectedPointerOver}" />
 										<Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
 										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPointerOver}" />
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="PointerOver" />-->
 									</VisualState.Setters>
@@ -1976,7 +2407,7 @@
 										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource MaterialNavigationViewItemBackgroundSelectedPressed}" />
 										<Setter Target="Icon.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
 										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource MaterialTopNavigationViewItemForegroundPressed}" />
-										<!--Removing RevealBrush usage for now as it is not present in WinUI 3-->
+										<!-- Removing RevealBrush usage for now as it is not present in WinUI 3 -->
 										<!--<contract4Present:Setter Target="LayoutRoot.(media:RevealBrush.State)"
 																 Value="Pressed" />-->
 									</VisualState.Setters>
@@ -2578,7 +3009,7 @@
 
 	<!--#endregion-->
 
-	<!--#region Aliases & Default Styles -->
+	<!--#region Aliases & Default Styles-->
 
 	<Style x:Key="MaterialNavigationViewStyle"
 		   TargetType="muxc:NavigationView"
@@ -2588,6 +3019,6 @@
 		   TargetType="muxc:NavigationViewItem"
 		   BasedOn="{StaticResource MaterialBaseNavigationViewItemStyle}" />
 
-	<!--#endregion -->
+	<!--#endregion-->
 
 </ResourceDictionary>

--- a/src/library/Uno.Material/Styles/Controls/v2/ToggleSwitch.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ToggleSwitch.xaml
@@ -4,7 +4,7 @@
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:todo="todo"
+					xmlns:todo="what should be done"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
 					mc:Ignorable="ios android todo">
 

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Shell.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Shell.xaml
@@ -15,18 +15,15 @@
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
 
-
 		<!-- We set CompactModeThresholdWidth to a very high value so that it never happens. We don't want to use the compact mode. -->
 		<muxc:NavigationView Grid.Row="2"
 							 x:Name="NavigationViewControl"
 							 OpenPaneLength="260"
 							 IsSettingsVisible="False"
-							 IsPaneOpen="True"
-							 IsPaneVisible="True"
-							 IsPaneToggleButtonVisible="False"
+							 IsPaneToggleButtonVisible="True"
 							 IsBackButtonVisible="Collapsed"
-							 SizeChanged="NavigationViewControl_SizeChanged"
-							 PaneDisplayMode="LeftMinimal"
+							 DisplayModeChanged="NavigationViewControl_DisplayModeChanged"
+							 PaneDisplayMode="Auto"
 							 IsBackEnabled="False"
 							 IsTabStop="False"
 							 Style="{StaticResource MaterialNavigationViewStyle}">
@@ -56,12 +53,5 @@
 			   Grid.RowSpan="3"
 			   Visibility="Collapsed"
 			   xamarin:Style="{StaticResource NativeDefaultFrame}" />
-
-		<!-- Custom pane toggle button -->
-		<Button Grid.Row="2"
-				x:Name="NavViewToggleButton"
-				Click="NavViewToggleButton_Click"
-				HorizontalAlignment="Left"
-				Style="{StaticResource PaneToggleButtonStyle}" />
 	</Grid>
 </UserControl>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Shell.xaml.cs
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Shell.xaml.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Linq;
 using Uno.Themes.Samples.Helpers;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 using MUXC = Microsoft.UI.Xaml.Controls;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
@@ -110,10 +112,6 @@ namespace Uno.Themes.Samples
 				? Visibility.Visible
 				: Visibility.Collapsed;
 
-			NavViewToggleButton.Visibility = isInsideNestedSample
-				? Visibility.Collapsed
-				: Visibility.Visible;
-
 			// toggle built-in back button for wasm (from browser) and uwp (on title bar)
 			SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = isInsideNestedSample
 				? AppViewBackButtonVisibility.Visible
@@ -157,32 +155,11 @@ namespace Uno.Themes.Samples
 			return true;
 		}
 
-		private void NavViewToggleButton_Click(object sender, RoutedEventArgs e)
+		private void NavigationViewControl_DisplayModeChanged(MUXC.NavigationView sender, MUXC.NavigationViewDisplayModeChangedEventArgs e)
 		{
-			if (NavigationViewControl.PaneDisplayMode == MUXC.NavigationViewPaneDisplayMode.LeftMinimal)
+			if (e.DisplayMode == MUXC.NavigationViewDisplayMode.Expanded)
 			{
-				NavigationViewControl.IsPaneOpen = !NavigationViewControl.IsPaneOpen;
-			}
-			else if (NavigationViewControl.PaneDisplayMode == MUXC.NavigationViewPaneDisplayMode.Left)
-			{
-				NavigationViewControl.IsPaneVisible = !NavigationViewControl.IsPaneVisible;
 				NavigationViewControl.IsPaneOpen = NavigationViewControl.IsPaneVisible;
-			}
-		}
-
-		private void NavigationViewControl_SizeChanged(object sender, SizeChangedEventArgs e)
-		{
-			// This could be done using VisualState with Adaptive triggers, but an issue prevents this currently - https://github.com/unoplatform/uno/issues/5168
-			var desktopWidth = (double)Application.Current.Resources["DesktopAdaptiveThresholdWidth"];
-			if (e.NewSize.Width >= desktopWidth && NavigationViewControl.PaneDisplayMode != MUXC.NavigationViewPaneDisplayMode.Left)
-			{
-				NavigationViewControl.PaneDisplayMode = MUXC.NavigationViewPaneDisplayMode.Left;
-				NavigationViewControl.IsPaneOpen = true;
-			}
-			else if (e.NewSize.Width < desktopWidth && NavigationViewControl.PaneDisplayMode != MUXC.NavigationViewPaneDisplayMode.LeftMinimal)
-			{
-				NavigationViewControl.IsPaneVisible = true;
-				NavigationViewControl.PaneDisplayMode = MUXC.NavigationViewPaneDisplayMode.LeftMinimal;
 			}
 		}
 	}

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Skia.Gtk/Uno.Themes.Samples.Skia.Gtk.csproj
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Skia.Gtk/Uno.Themes.Samples.Skia.Gtk.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 		<OutputType Condition="'$(Configuration)'=='Reelase'">WinExe</OutputType>
@@ -39,6 +39,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.1-preview.79" />
+		<PackageReference Include="SkiaSharp.Views.Uno" Version="2.88.1-preview.79" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.0.59" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.0.59" />
 		<PackageReference Include="Uno.UI.Skia.Gtk" Version="4.5.0-dev.645" />


### PR DESCRIPTION
﻿GitHub Issue: resolved #856

## PR Type

What kind of change does this PR introduce?
- Bugfix

## Description
- the following properties of the NavigationView should now display correctly: PaneCustomContent, PaneFooter, FooterMenuItems, IsSettingsVisible
- added a new `MaterialPaddedNavigationViewStyle`(alias: `PaddedNavigationViewStyle`) that will dynamically adjust padding for content in "Minimal" mode

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [ ] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)