### PR TITLE
fix(NavigationView): invalid resource references

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/NavigationView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/NavigationView.xaml
@@ -1238,8 +1238,8 @@
 									<Grid x:Name="PaneContentGrid"
 										  HorizontalAlignment="Left"
 										  CornerRadius="16"
-										  BorderBrush="{StaticResource MaterialMUXNavigationViewPaneBorderBrush}"
-										  BorderThickness="{StaticResource MaterialMUXNavigationViewPaneBorderThickness}"
+										  BorderBrush="{StaticResource MaterialNavigationViewPaneBorderBrush}"
+										  BorderThickness="{StaticResource MaterialNavigationViewPaneBorderThickness}"
 										  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}">
 										<Grid.RowDefinitions>
 											<!-- 0: ?, 1: Padding, 2: ContentPanel, 3: AutoSuggestPanel, 4: CustomContent, 5: Padding, 6: NonHeaderPanel -->
@@ -1599,8 +1599,8 @@
 									<Grid x:Name="PaneContentGrid"
 										  HorizontalAlignment="Left"
 										  CornerRadius="16"
-										  BorderBrush="{StaticResource MaterialMUXNavigationViewPaneBorderBrush}"
-										  BorderThickness="{StaticResource MaterialMUXNavigationViewPaneBorderThickness}"
+										  BorderBrush="{StaticResource MaterialNavigationViewPaneBorderBrush}"
+										  BorderThickness="{StaticResource MaterialNavigationViewPaneBorderThickness}"
 										  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}">
 										<Grid.RowDefinitions>
 											<!-- 0: ?, 1: Padding, 2: ContentPanel, 3: AutoSuggestPanel, 4: CustomContent, 5: Padding, 6: NonHeaderPanel -->


### PR DESCRIPTION
﻿GitHub Issue: re: #856

## PR Type

What kind of change does this PR introduce?
- Bugfix

## Description
MaterialNavigationViewStyle (v2) is referencing non-existent v1 mux resources, and crashes on windows head.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information
<!-- Please provide any additional information if necessary -->