### PR TITLE
fix(CBI): template-selector not being applied

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/ComboBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ComboBox.xaml
@@ -242,6 +242,7 @@
 										  Padding="{TemplateBinding Padding}"
 										  Content="{TemplateBinding Content}"
 										  ContentTemplate="{TemplateBinding ContentTemplate}"
+										  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
 										  ContentTransitions="{TemplateBinding ContentTransitions}"
 										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
 										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />


### PR DESCRIPTION
﻿GitHub Issue: #848

## PR Type

What kind of change does this PR introduce?
- Bugfix

## Description
`ComboBox.ItemTemplateSelector` only works for the unopened selected item, but not for the `ComboBoxItem`s found in the dropdown.

## PR Checklist 
Please check if your PR fulfills the following requirements:
- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information
Continuation of #848 with `ItemTemplate`, we fixed that but forgot `ItemTemplateSelector`...