### PR TITLE
Package Dependency Fix

### DIFF
--- a/src/library/Uno.Cupertino/Uno.Cupertino.csproj
+++ b/src/library/Uno.Cupertino/Uno.Cupertino.csproj
@@ -8,10 +8,10 @@
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>portable</DebugType>
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
-		
+
 		<UnoXamlResourcesTrimming>true</UnoXamlResourcesTrimming>
 	</PropertyGroup>
-	
+
 	<PropertyGroup>
 		<PackageDescription>A set of Cupertino styles for WinUI Controls to be used in Uno Platform and </PackageDescription>
 		<PackageDescription Condition="'$(UseWinUI)'=='true'">$(PackageDescription) WinAppSDK projects</PackageDescription>
@@ -52,7 +52,7 @@
 			</PropertyGroup>
 
 			<ItemGroup>
-				<PackageReference Include="Uno.WinUI" Version="4.5.12" />
+				<PackageReference Include="Uno.WinUI" Version="4.5.12" Condition="'$(TargetFramework)'!='net5.0-windows10.0.18362'" />
 
 				<PackageReference Include="Uno.WinUI.Lottie" Version="4.5.12" Condition="'$(TargetFramework)'!='net5.0-windows10.0.18362'" />
 
@@ -75,7 +75,7 @@
 					<DependentUpon>%(Filename)</DependentUpon>
 				</Compile>
 			</ItemGroup>
-			
+
 			<ItemGroup Condition="'$(TargetFramework)'!='net5.0-windows10.0.18362'">
 				<IncludeXamlNamespaces Include="lottie_not_win" />
 				<ExcludeXamlNamespaces Include="lottie_win" />
@@ -120,11 +120,11 @@
 			</ItemGroup>
 		</Otherwise>
 	</Choose>
-	
+
 	<ItemGroup>
 		<UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
     <EmbeddedResource Include="LinkerConfig.xml">
       <LogicalName>$(AssemblyName).xml</LogicalName>

--- a/src/library/Uno.Material/Uno.Material.csproj
+++ b/src/library/Uno.Material/Uno.Material.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/3.0.23">
 	<PropertyGroup>
 		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'!=''">$(TargetFrameworkOverride)</TargetFrameworks>
@@ -10,7 +10,7 @@
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		<UnoUIUseRoslynSourceGenerators>true</UnoUIUseRoslynSourceGenerators>
 		<NoWarn>$(NoWarn);UNO0001</NoWarn>
-		
+
 		<UnoXamlResourcesTrimming>true</UnoXamlResourcesTrimming>
 	</PropertyGroup>
 
@@ -57,7 +57,7 @@
 			</PropertyGroup>
 
 			<ItemGroup>
-				<PackageReference Include="Uno.WinUI" Version="4.5.12" />
+				<PackageReference Include="Uno.WinUI" Version="4.5.12" Condition="'$(TargetFramework)'!='net5.0-windows10.0.18362'" />
 
 				<PackageReference Include="Uno.WinUI.Lottie" Version="4.5.12" Condition="'$(TargetFramework)'!='net5.0-windows10.0.18362'" />
 
@@ -109,7 +109,6 @@
 			<ItemGroup Condition="'$(TargetFramework)'!='uap10.0.18362'">
 				<PackageReference Include="Uno.UI.Lottie" Version="4.5.12" />
 			</ItemGroup>
-
 
 			<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">
 				<Content Include="@(LottieJson)" />

--- a/src/library/Uno.Themes.WinUI.Markup/Uno.Themes.WinUI.Markup.csproj
+++ b/src/library/Uno.Themes.WinUI.Markup/Uno.Themes.WinUI.Markup.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
+<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
 
 	<!--
 	Adding project references to this project requires some manual adjustments.
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.12" />
+		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.13" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.Contains('-windows10'))">


### PR DESCRIPTION
﻿GitHub Issue: #

- n/a

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description

This PR updates the csproj to conditionally include the Uno.UI/Uno.WinUI packages based on the TFM. If the TFM contains `-windows` it will exclude the Uno package and bring in the appropriate WinUI resources. This also will help to future proof when the target is updated from net5 as the condition will still evaluate correctly for net6, net7, etc.

Also updates Uno.WinUI.Markup to the latest


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
