### PR TITLE
feat: markup extensions exposing resource keys

### DIFF
--- a/src/library/Uno.Themes.WinUI.Markup/AssemblyInfo.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/AssemblyInfo.cs
@@ -1,3 +1,5 @@
 ﻿using System.Reflection;
+using Microsoft.UI.Xaml.MarkupHelpers.Internals;
 
 [assembly: AssemblyMetadata("IsTrimmable", "True")]
+[assembly: ResourceDefinitionClass(typeof(Uno.Themes.Markup.Theme))]

--- a/src/library/Uno.Themes.WinUI.Markup/ResourceValue.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/ResourceValue.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Microsoft.UI.Xaml.MarkupHelpers;
+
+namespace Uno.Themes.Markup
+{
+	public struct ResourceValue<T>
+	{
+		public ResourceValue(string key)
+		{
+			Key = key;
+		}
+
+		public string Key { get; }
+
+		public static implicit operator Action<IDependencyPropertyBuilder<T>>(ResourceValue<T> resource) =>
+			x => x.ThemeResource(resource.Key);
+	}
+}

--- a/src/library/Uno.Themes.WinUI.Markup/ResourceValue.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/ResourceValue.cs
@@ -7,7 +7,7 @@ namespace Uno.Themes.Markup
 {
 	public struct ResourceValue<T>
 	{
-		public ResourceValue(string key, bool isThemeResource = true)
+		public ResourceValue(string key, bool isThemeResource = false)
 		{
 			Key = key;
 			IsThemeResource = isThemeResource;
@@ -18,13 +18,8 @@ namespace Uno.Themes.Markup
 		public bool IsThemeResource { get; }
 
 		public static implicit operator Action<IDependencyPropertyBuilder<T>>(ResourceValue<T> resource) =>
-			x => GetResourceBasedOnIsThemeResourceProperty(resource);
-
-		private static Action<IDependencyPropertyBuilder<T>> GetResourceBasedOnIsThemeResourceProperty(ResourceValue<T> resource)
-		{
-			return resource.IsThemeResource ?
+			resource.IsThemeResource ?
 				ThemeResource.Get<T>(resource.Key)
 				: StaticResource.Get<T>(resource.Key);
-		}
 	}
 }

--- a/src/library/Uno.Themes.WinUI.Markup/ResourceValue.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/ResourceValue.cs
@@ -1,18 +1,30 @@
 ﻿using System;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.MarkupHelpers;
+
 
 namespace Uno.Themes.Markup
 {
 	public struct ResourceValue<T>
 	{
-		public ResourceValue(string key)
+		public ResourceValue(string key, bool isThemeResource = true)
 		{
 			Key = key;
+			IsThemeResource = isThemeResource;
 		}
 
 		public string Key { get; }
 
+		public bool IsThemeResource { get; }
+
 		public static implicit operator Action<IDependencyPropertyBuilder<T>>(ResourceValue<T> resource) =>
-			x => x.ThemeResource(resource.Key);
+			x => GetResourceBasedOnIsThemeResourceProperty(resource);
+
+		private static Action<IDependencyPropertyBuilder<T>> GetResourceBasedOnIsThemeResourceProperty(ResourceValue<T> resource)
+		{
+			return resource.IsThemeResource ?
+				ThemeResource.Get<T>(resource.Key)
+				: StaticResource.Get<T>(resource.Key);
+		}
 	}
 }

--- a/src/library/Uno.Themes.WinUI.Markup/Theme.Brushes.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme.Brushes.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.MarkupHelpers;
+﻿using Microsoft.UI.Xaml.MarkupHelpers.Internals;
 using Microsoft.UI.Xaml.Media;
 
 namespace Uno.Themes.Markup
@@ -11,422 +9,991 @@ namespace Uno.Themes.Markup
 		{
 			public static class Primary
 			{
-				public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("PrimaryBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("PrimaryHoverBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("PrimaryFocusedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("PrimaryPressedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("PrimaryDraggedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("PrimarySelectedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("PrimaryMediumBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("PrimaryLowBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("PrimaryDisabledBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("PrimaryDisabledLowBrush");
+				[ResourceKeyDefinition(typeof(Brush), "PrimaryBrush")]
+				public static ResourceValue<Brush> Default => new("PrimaryBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "PrimaryHoverBrush")]
+				public static ResourceValue<Brush> Hover => new("PrimaryHoverBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "PrimaryFocusedBrush")]
+				public static ResourceValue<Brush> Focused => new("PrimaryFocusedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "PrimaryPressedBrush")]
+				public static ResourceValue<Brush> Pressed => new("PrimaryPressedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "PrimaryDraggedBrush")]
+				public static ResourceValue<Brush> Dragged => new("PrimaryDraggedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "PrimarySelectedBrush")]
+				public static ResourceValue<Brush> Selected => new("PrimarySelectedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "PrimaryMediumBrush")]
+				public static ResourceValue<Brush> Medium => new("PrimaryMediumBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "PrimaryLowBrush")]
+				public static ResourceValue<Brush> Low => new("PrimaryLowBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "PrimaryDisabledBrush")]
+				public static ResourceValue<Brush> Disabled => new("PrimaryDisabledBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "PrimaryDisabledLowBrush")]
+				public static ResourceValue<Brush> DisabledLow => new("PrimaryDisabledLowBrush");
 
 				public static class Inverse
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("PrimaryInverseBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("PrimaryInverseHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("PrimaryInverseFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("PrimaryInversePressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("PrimaryInverseDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("PrimaryInverseSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("PrimaryInverseMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("PrimaryInverseLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("PrimaryInverseDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("PrimaryInverseDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseBrush")]
+					public static ResourceValue<Brush> Default => new("PrimaryInverseBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("PrimaryInverseHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("PrimaryInverseFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryInversePressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("PrimaryInversePressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("PrimaryInverseDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("PrimaryInverseSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("PrimaryInverseMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseLowBrush")]
+					public static ResourceValue<Brush> Low => new("PrimaryInverseLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("PrimaryInverseDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("PrimaryInverseDisabledLowBrush");
 				}
 
 				public static class Container
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("PrimaryContainerBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("PrimaryContainerHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("PrimaryContainerFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("PrimaryContainerPressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("PrimaryContainerDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("PrimaryContainerSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("PrimaryContainerMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("PrimaryContainerLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("PrimaryContainerDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("PrimaryContainerDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerBrush")]
+					public static ResourceValue<Brush> Default => new("PrimaryContainerBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("PrimaryContainerHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("PrimaryContainerFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerPressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("PrimaryContainerPressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("PrimaryContainerDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("PrimaryContainerSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("PrimaryContainerMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerLowBrush")]
+					public static ResourceValue<Brush> Low => new("PrimaryContainerLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("PrimaryContainerDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("PrimaryContainerDisabledLowBrush");
 				}
 
 				public static class VariantLight
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("PrimaryVariantLightBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("PrimaryVariantLightHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("PrimaryVariantLightFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("PrimaryVariantLightPressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("PrimaryVariantLightDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("PrimaryVariantLightSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("PrimaryVariantLightMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("PrimaryVariantLightLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("PrimaryVariantLightDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("PrimaryVariantLightDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightBrush")]
+					public static ResourceValue<Brush> Default => new("PrimaryVariantLightBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("PrimaryVariantLightHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("PrimaryVariantLightFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightPressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("PrimaryVariantLightPressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("PrimaryVariantLightDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("PrimaryVariantLightSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("PrimaryVariantLightMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightLowBrush")]
+					public static ResourceValue<Brush> Low => new("PrimaryVariantLightLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("PrimaryVariantLightDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("PrimaryVariantLightDisabledLowBrush");
 				}
 
 				public static class VariantDark
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("PrimaryVariantDarkBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("PrimaryVariantDarkHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("PrimaryVariantDarkFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("PrimaryVariantDarkPressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("PrimaryVariantDarkDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("PrimaryVariantDarkSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("PrimaryVariantDarkMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("PrimaryVariantDarkLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("PrimaryVariantDarkDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("PrimaryVariantDarkDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkBrush")]
+					public static ResourceValue<Brush> Default => new("PrimaryVariantDarkBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("PrimaryVariantDarkHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("PrimaryVariantDarkFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkPressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("PrimaryVariantDarkPressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("PrimaryVariantDarkDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("PrimaryVariantDarkSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("PrimaryVariantDarkMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkLowBrush")]
+					public static ResourceValue<Brush> Low => new("PrimaryVariantDarkLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("PrimaryVariantDarkDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("PrimaryVariantDarkDisabledLowBrush");
 				}
 			}
 
 			public static class OnPrimary
 			{
-				public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("OnPrimaryBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("OnPrimaryHoverBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("OnPrimaryFocusedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("OnPrimaryPressedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("OnPrimaryDraggedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("OnPrimarySelectedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("OnPrimaryMediumBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("OnPrimaryLowBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("OnPrimaryDisabledBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("OnPrimaryDisabledLowBrush");
+				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryBrush")]
+				public static ResourceValue<Brush> Default => new("OnPrimaryBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryHoverBrush")]
+				public static ResourceValue<Brush> Hover => new("OnPrimaryHoverBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryFocusedBrush")]
+				public static ResourceValue<Brush> Focused => new("OnPrimaryFocusedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryPressedBrush")]
+				public static ResourceValue<Brush> Pressed => new("OnPrimaryPressedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryDraggedBrush")]
+				public static ResourceValue<Brush> Dragged => new("OnPrimaryDraggedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnPrimarySelectedBrush")]
+				public static ResourceValue<Brush> Selected => new("OnPrimarySelectedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryMediumBrush")]
+				public static ResourceValue<Brush> Medium => new("OnPrimaryMediumBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryLowBrush")]
+				public static ResourceValue<Brush> Low => new("OnPrimaryLowBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryDisabledBrush")]
+				public static ResourceValue<Brush> Disabled => new("OnPrimaryDisabledBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryDisabledLowBrush")]
+				public static ResourceValue<Brush> DisabledLow => new("OnPrimaryDisabledLowBrush");
 
 				public static class Container
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("OnPrimaryContainerBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("OnPrimaryContainerHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("OnPrimaryContainerFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("OnPrimaryContainerPressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("OnPrimaryContainerDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("OnPrimaryContainerSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("OnPrimaryContainerMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("OnPrimaryContainerLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("OnPrimaryContainerDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("OnPrimaryContainerDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerBrush")]
+					public static ResourceValue<Brush> Default => new("OnPrimaryContainerBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("OnPrimaryContainerHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("OnPrimaryContainerFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerPressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("OnPrimaryContainerPressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("OnPrimaryContainerDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("OnPrimaryContainerSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("OnPrimaryContainerMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerLowBrush")]
+					public static ResourceValue<Brush> Low => new("OnPrimaryContainerLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("OnPrimaryContainerDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("OnPrimaryContainerDisabledLowBrush");
 				}
 			}
 
 			public static class Secondary
 			{
-				public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("SecondaryBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("SecondaryHoverBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("SecondaryFocusedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("SecondaryPressedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("SecondaryDraggedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("SecondarySelectedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("SecondaryMediumBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("SecondaryLowBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("SecondaryDisabledBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("SecondaryDisabledLowBrush");
+				[ResourceKeyDefinition(typeof(Brush), "SecondaryBrush")]
+				public static ResourceValue<Brush> Default => new("SecondaryBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SecondaryHoverBrush")]
+				public static ResourceValue<Brush> Hover => new("SecondaryHoverBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SecondaryFocusedBrush")]
+				public static ResourceValue<Brush> Focused => new("SecondaryFocusedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SecondaryPressedBrush")]
+				public static ResourceValue<Brush> Pressed => new("SecondaryPressedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SecondaryDraggedBrush")]
+				public static ResourceValue<Brush> Dragged => new("SecondaryDraggedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SecondarySelectedBrush")]
+				public static ResourceValue<Brush> Selected => new("SecondarySelectedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SecondaryMediumBrush")]
+				public static ResourceValue<Brush> Medium => new("SecondaryMediumBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SecondaryLowBrush")]
+				public static ResourceValue<Brush> Low => new("SecondaryLowBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SecondaryDisabledBrush")]
+				public static ResourceValue<Brush> Disabled => new("SecondaryDisabledBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SecondaryDisabledLowBrush")]
+				public static ResourceValue<Brush> DisabledLow => new("SecondaryDisabledLowBrush");
 
 				public static class Container
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("SecondaryContainerBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("SecondaryContainerHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("SecondaryContainerFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("SecondaryContainerPressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("SecondaryContainerDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("SecondaryContainerSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("SecondaryContainerMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("SecondaryContainerLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("SecondaryContainerDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("SecondaryContainerDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerBrush")]
+					public static ResourceValue<Brush> Default => new("SecondaryContainerBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("SecondaryContainerHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("SecondaryContainerFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerPressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("SecondaryContainerPressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("SecondaryContainerDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("SecondaryContainerSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("SecondaryContainerMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerLowBrush")]
+					public static ResourceValue<Brush> Low => new("SecondaryContainerLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("SecondaryContainerDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("SecondaryContainerDisabledLowBrush");
 				}
 
 				public static class VariantLight
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("SecondaryVariantLightBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("SecondaryVariantLightHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("SecondaryVariantLightFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("SecondaryVariantLightPressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("SecondaryVariantLightDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("SecondaryVariantLightSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("SecondaryVariantLightMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("SecondaryVariantLightLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("SecondaryVariantLightDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("SecondaryVariantLightDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightBrush")]
+					public static ResourceValue<Brush> Default => new("SecondaryVariantLightBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("SecondaryVariantLightHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("SecondaryVariantLightFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightPressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("SecondaryVariantLightPressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("SecondaryVariantLightDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("SecondaryVariantLightSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("SecondaryVariantLightMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightLowBrush")]
+					public static ResourceValue<Brush> Low => new("SecondaryVariantLightLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("SecondaryVariantLightDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("SecondaryVariantLightDisabledLowBrush");
 				}
 
 				public static class VariantDark
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("SecondaryVariantDarkBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("SecondaryVariantDarkHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("SecondaryVariantDarkFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("SecondaryVariantDarkPressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("SecondaryVariantDarkDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("SecondaryVariantDarkSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("SecondaryVariantDarkMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("SecondaryVariantDarkLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("SecondaryVariantDarkDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("SecondaryVariantDarkDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkBrush")]
+					public static ResourceValue<Brush> Default => new("SecondaryVariantDarkBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("SecondaryVariantDarkHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("SecondaryVariantDarkFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkPressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("SecondaryVariantDarkPressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("SecondaryVariantDarkDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("SecondaryVariantDarkSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("SecondaryVariantDarkMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkLowBrush")]
+					public static ResourceValue<Brush> Low => new("SecondaryVariantDarkLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("SecondaryVariantDarkDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("SecondaryVariantDarkDisabledLowBrush");
 				}
 			}
 
 			public static class OnSecondary
 			{
-				public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("OnSecondaryBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("OnSecondaryHoverBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("OnSecondaryFocusedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("OnSecondaryPressedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("OnSecondaryDraggedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("OnSecondarySelectedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("OnSecondaryMediumBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("OnSecondaryLowBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("OnSecondaryDisabledBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("OnSecondaryDisabledLowBrush");
+				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryBrush")]
+				public static ResourceValue<Brush> Default => new("OnSecondaryBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryHoverBrush")]
+				public static ResourceValue<Brush> Hover => new("OnSecondaryHoverBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryFocusedBrush")]
+				public static ResourceValue<Brush> Focused => new("OnSecondaryFocusedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryPressedBrush")]
+				public static ResourceValue<Brush> Pressed => new("OnSecondaryPressedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryDraggedBrush")]
+				public static ResourceValue<Brush> Dragged => new("OnSecondaryDraggedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSecondarySelectedBrush")]
+				public static ResourceValue<Brush> Selected => new("OnSecondarySelectedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryMediumBrush")]
+				public static ResourceValue<Brush> Medium => new("OnSecondaryMediumBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryLowBrush")]
+				public static ResourceValue<Brush> Low => new("OnSecondaryLowBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryDisabledBrush")]
+				public static ResourceValue<Brush> Disabled => new("OnSecondaryDisabledBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryDisabledLowBrush")]
+				public static ResourceValue<Brush> DisabledLow => new("OnSecondaryDisabledLowBrush");
 
 				public static class Container
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("OnSecondaryContainerBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("OnSecondaryContainerHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("OnSecondaryContainerFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("OnSecondaryContainerPressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("OnSecondaryContainerDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("OnSecondaryContainerSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("OnSecondaryContainerMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("OnSecondaryContainerLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("OnSecondaryContainerDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("OnSecondaryContainerDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerBrush")]
+					public static ResourceValue<Brush> Default => new("OnSecondaryContainerBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("OnSecondaryContainerHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("OnSecondaryContainerFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerPressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("OnSecondaryContainerPressedBrush");
+
+					public static ResourceValue<Brush> Dragged => new("OnSecondaryContainerDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("OnSecondaryContainerSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("OnSecondaryContainerMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerLowBrush")]
+					public static ResourceValue<Brush> Low => new("OnSecondaryContainerLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("OnSecondaryContainerDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("OnSecondaryContainerDisabledLowBrush");
 				}
 			}
 
 			public static class Tertiary
 			{
-				public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("TertiaryBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("TertiaryHoverBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("TertiaryFocusedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("TertiaryPressedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("TertiaryDraggedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("TertiarySelectedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("TertiaryMediumBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("TertiaryLowBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("TertiaryDisabledBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("TertiaryDisabledLowBrush");
+				[ResourceKeyDefinition(typeof(Brush), "TertiaryBrush")]
+				public static ResourceValue<Brush> Default => new("TertiaryBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "TertiaryHoverBrush")]
+				public static ResourceValue<Brush> Hover => new("TertiaryHoverBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "TertiaryFocusedBrush")]
+				public static ResourceValue<Brush> Focused => new("TertiaryFocusedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "TertiaryPressedBrush")]
+				public static ResourceValue<Brush> Pressed => new("TertiaryPressedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "TertiaryDraggedBrush")]
+				public static ResourceValue<Brush> Dragged => new("TertiaryDraggedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "TertiarySelectedBrush")]
+				public static ResourceValue<Brush> Selected => new("TertiarySelectedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "TertiaryMediumBrush")]
+				public static ResourceValue<Brush> Medium => new("TertiaryMediumBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "TertiaryLowBrush")]
+				public static ResourceValue<Brush> Low => new("TertiaryLowBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "TertiaryDisabledBrush")]
+				public static ResourceValue<Brush> Disabled => new("TertiaryDisabledBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "TertiaryDisabledLowBrush")]
+				public static ResourceValue<Brush> DisabledLow => new("TertiaryDisabledLowBrush");
 
 				public static class Container
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("TertiaryContainerBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("TertiaryContainerHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("TertiaryContainerFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("TertiaryContainerPressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("TertiaryContainerDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("TertiaryContainerSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("TertiaryContainerMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("TertiaryContainerLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("TertiaryContainerDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("TertiaryContainerDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerBrush")]
+					public static ResourceValue<Brush> Default => new("TertiaryContainerBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("TertiaryContainerHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("TertiaryContainerFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerPressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("TertiaryContainerPressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("TertiaryContainerDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("TertiaryContainerSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("TertiaryContainerMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerLowBrush")]
+					public static ResourceValue<Brush> Low => new("TertiaryContainerLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("TertiaryContainerDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("TertiaryContainerDisabledLowBrush");
 				}
 			}
 
 			public static class OnTertiary
 			{
-				public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("OnTertiaryBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("OnTertiaryHoverBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("OnTertiaryFocusedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("OnTertiaryPressedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("OnTertiaryDraggedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("OnTertiarySelectedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("OnTertiaryMediumBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("OnTertiaryLowBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("OnTertiaryDisabledBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("OnTertiaryDisabledLowBrush");
+				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryBrush")]
+				public static ResourceValue<Brush> Default => new("OnTertiaryBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryHoverBrush")]
+				public static ResourceValue<Brush> Hover => new("OnTertiaryHoverBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryFocusedBrush")]
+				public static ResourceValue<Brush> Focused => new("OnTertiaryFocusedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryPressedBrush")]
+				public static ResourceValue<Brush> Pressed => new("OnTertiaryPressedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryDraggedBrush")]
+				public static ResourceValue<Brush> Dragged => new("OnTertiaryDraggedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnTertiarySelectedBrush")]
+				public static ResourceValue<Brush> Selected => new("OnTertiarySelectedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryMediumBrush")]
+				public static ResourceValue<Brush> Medium => new("OnTertiaryMediumBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryLowBrush")]
+				public static ResourceValue<Brush> Low => new("OnTertiaryLowBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryDisabledBrush")]
+				public static ResourceValue<Brush> Disabled => new("OnTertiaryDisabledBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryDisabledLowBrush")]
+				public static ResourceValue<Brush> DisabledLow => new("OnTertiaryDisabledLowBrush");
 
 				public static class Container
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("OnTertiaryContainerBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("OnTertiaryContainerHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("OnTertiaryContainerFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("OnTertiaryContainerPressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("OnTertiaryContainerDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("OnTertiaryContainerSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("OnTertiaryContainerMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("OnTertiaryContainerLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("OnTertiaryContainerDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("OnTertiaryContainerDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerBrush")]
+					public static ResourceValue<Brush> Default => new("OnTertiaryContainerBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("OnTertiaryContainerHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("OnTertiaryContainerFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerPressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("OnTertiaryContainerPressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("OnTertiaryContainerDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("OnTertiaryContainerSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("OnTertiaryContainerMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerLowBrush")]
+					public static ResourceValue<Brush> Low => new("OnTertiaryContainerLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("OnTertiaryContainerDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("OnTertiaryContainerDisabledLowBrush");
 				}
 			}
 
 			public static class Error
 			{
-				public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("ErrorBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("ErrorHoverBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("ErrorFocusedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("ErrorPressedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("ErrorDraggedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("ErrorSelectedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("ErrorMediumBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("ErrorLowBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("ErrorDisabledBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("ErrorDisabledLowBrush");
+				[ResourceKeyDefinition(typeof(Brush), "ErrorBrush")]
+				public static ResourceValue<Brush> Default => new("ErrorBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "ErrorHoverBrush")]
+				public static ResourceValue<Brush> Hover => new("ErrorHoverBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "ErrorFocusedBrush")]
+				public static ResourceValue<Brush> Focused => new("ErrorFocusedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "ErrorPressedBrush")]
+				public static ResourceValue<Brush> Pressed => new("ErrorPressedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "ErrorDraggedBrush")]
+				public static ResourceValue<Brush> Dragged => new("ErrorDraggedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "ErrorSelectedBrush")]
+				public static ResourceValue<Brush> Selected => new("ErrorSelectedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "ErrorMediumBrush")]
+				public static ResourceValue<Brush> Medium => new("ErrorMediumBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "ErrorLowBrush")]
+				public static ResourceValue<Brush> Low => new("ErrorLowBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "ErrorDisabledBrush")]
+				public static ResourceValue<Brush> Disabled => new("ErrorDisabledBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "ErrorDisabledLowBrush")]
+				public static ResourceValue<Brush> DisabledLow => new("ErrorDisabledLowBrush");
 
 				public static class Container
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("ErrorContainerBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("ErrorContainerHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("ErrorContainerFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("ErrorContainerPressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("ErrorContainerDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("ErrorContainerSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("ErrorContainerMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("ErrorContainerLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("ErrorContainerDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("ErrorContainerDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerBrush")]
+					public static ResourceValue<Brush> Default => new("ErrorContainerBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("ErrorContainerHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("ErrorContainerFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerPressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("ErrorContainerPressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("ErrorContainerDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("ErrorContainerSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("ErrorContainerMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerLowBrush")]
+					public static ResourceValue<Brush> Low => new("ErrorContainerLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("ErrorContainerDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("ErrorContainerDisabledLowBrush");
 				}
 			}
 
 			public static class OnError
 			{
-				public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("OnErrorBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("OnErrorHoverBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("OnErrorFocusedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("OnErrorPressedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("OnErrorDraggedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("OnErrorSelectedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("OnErrorMediumBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("OnErrorLowBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("OnErrorDisabledBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("OnErrorDisabledLowBrush");
+				[ResourceKeyDefinition(typeof(Brush), "OnErrorBrush")]
+				public static ResourceValue<Brush> Default => new("OnErrorBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnErrorHoverBrush")]
+				public static ResourceValue<Brush> Hover => new("OnErrorHoverBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnErrorFocusedBrush")]
+				public static ResourceValue<Brush> Focused => new("OnErrorFocusedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnErrorPressedBrush")]
+				public static ResourceValue<Brush> Pressed => new("OnErrorPressedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnErrorDraggedBrush")]
+				public static ResourceValue<Brush> Dragged => new("OnErrorDraggedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnErrorSelectedBrush")]
+				public static ResourceValue<Brush> Selected => new("OnErrorSelectedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnErrorMediumBrush")]
+				public static ResourceValue<Brush> Medium => new("OnErrorMediumBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnErrorLowBrush")]
+				public static ResourceValue<Brush> Low => new("OnErrorLowBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnErrorDisabledBrush")]
+				public static ResourceValue<Brush> Disabled => new("OnErrorDisabledBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnErrorDisabledLowBrush")]
+				public static ResourceValue<Brush> DisabledLow => new("OnErrorDisabledLowBrush");
 
 				public static class Container
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("OnErrorContainerBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("OnErrorContainerHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("OnErrorContainerFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("OnErrorContainerPressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("OnErrorContainerDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("OnErrorContainerSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("OnErrorContainerMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("OnErrorContainerLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("OnErrorContainerDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("OnErrorContainerDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerBrush")]
+					public static ResourceValue<Brush> Default => new("OnErrorContainerBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("OnErrorContainerHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("OnErrorContainerFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerPressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("OnErrorContainerPressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("OnErrorContainerDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("OnErrorContainerSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("OnErrorContainerMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerLowBrush")]
+					public static ResourceValue<Brush> Low => new("OnErrorContainerLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("OnErrorContainerDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("OnErrorContainerDisabledLowBrush");
 				}
 			}
 
 			public static class Background
 			{
-				public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("BackgroundBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("BackgroundHoverBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("BackgroundFocusedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("BackgroundPressedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("BackgroundDraggedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("BackgroundSelectedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("BackgroundMediumBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("BackgroundLowBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("BackgroundDisabledBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("BackgroundDisabledLowBrush");
+				[ResourceKeyDefinition(typeof(Brush), "BackgroundBrush")]
+				public static ResourceValue<Brush> Default => new("BackgroundBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "BackgroundHoverBrush")]
+				public static ResourceValue<Brush> Hover => new("BackgroundHoverBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "BackgroundFocusedBrush")]
+				public static ResourceValue<Brush> Focused => new("BackgroundFocusedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "BackgroundPressedBrush")]
+				public static ResourceValue<Brush> Pressed => new("BackgroundPressedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "BackgroundDraggedBrush")]
+				public static ResourceValue<Brush> Dragged => new("BackgroundDraggedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "BackgroundSelectedBrush")]
+				public static ResourceValue<Brush> Selected => new("BackgroundSelectedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "BackgroundMediumBrush")]
+				public static ResourceValue<Brush> Medium => new("BackgroundMediumBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "BackgroundLowBrush")]
+				public static ResourceValue<Brush> Low => new("BackgroundLowBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "BackgroundDisabledBrush")]
+				public static ResourceValue<Brush> Disabled => new("BackgroundDisabledBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "BackgroundDisabledLowBrush")]
+				public static ResourceValue<Brush> DisabledLow => new("BackgroundDisabledLowBrush");
 			}
 
 			public static class OnBackground
 			{
-				public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("OnBackgroundBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("OnBackgroundHoverBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("OnBackgroundFocusedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("OnBackgroundPressedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("OnBackgroundDraggedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("OnBackgroundSelectedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("OnBackgroundMediumBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("OnBackgroundLowBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("OnBackgroundDisabledBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("OnBackgroundDisabledLowBrush");
+				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundBrush")]
+				public static ResourceValue<Brush> Default => new("OnBackgroundBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundHoverBrush")]
+				public static ResourceValue<Brush> Hover => new("OnBackgroundHoverBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundFocusedBrush")]
+				public static ResourceValue<Brush> Focused => new("OnBackgroundFocusedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundPressedBrush")]
+				public static ResourceValue<Brush> Pressed => new("OnBackgroundPressedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundDraggedBrush")]
+				public static ResourceValue<Brush> Dragged => new("OnBackgroundDraggedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundSelectedBrush")]
+				public static ResourceValue<Brush> Selected => new("OnBackgroundSelectedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundMediumBrush")]
+				public static ResourceValue<Brush> Medium => new("OnBackgroundMediumBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundLowBrush")]
+				public static ResourceValue<Brush> Low => new("OnBackgroundLowBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundDisabledBrush")]
+				public static ResourceValue<Brush> Disabled => new("OnBackgroundDisabledBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundDisabledLowBrush")]
+				public static ResourceValue<Brush> DisabledLow => new("OnBackgroundDisabledLowBrush");
 			}
 
 			public static class Surface
 			{
-				public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("SurfaceBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("SurfaceHoverBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("SurfaceFocusedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("SurfacePressedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("SurfaceDraggedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("SurfaceSelectedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("SurfaceMediumBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("SurfaceLowBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("SurfaceDisabledBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("SurfaceDisabledLowBrush");
+				[ResourceKeyDefinition(typeof(Brush), "SurfaceBrush")]
+				public static ResourceValue<Brush> Default => new("SurfaceBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SurfaceHoverBrush")]
+				public static ResourceValue<Brush> Hover => new("SurfaceHoverBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SurfaceFocusedBrush")]
+				public static ResourceValue<Brush> Focused => new("SurfaceFocusedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SurfacePressedBrush")]
+				public static ResourceValue<Brush> Pressed => new("SurfacePressedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SurfaceDraggedBrush")]
+				public static ResourceValue<Brush> Dragged => new("SurfaceDraggedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SurfaceSelectedBrush")]
+				public static ResourceValue<Brush> Selected => new("SurfaceSelectedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SurfaceMediumBrush")]
+				public static ResourceValue<Brush> Medium => new("SurfaceMediumBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SurfaceLowBrush")]
+				public static ResourceValue<Brush> Low => new("SurfaceLowBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SurfaceDisabledBrush")]
+				public static ResourceValue<Brush> Disabled => new("SurfaceDisabledBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "SurfaceDisabledLowBrush")]
+				public static ResourceValue<Brush> DisabledLow => new("SurfaceDisabledLowBrush");
 
 				public static class Variant
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("SurfaceVariantBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("SurfaceVariantHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("SurfaceVariantFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("SurfaceVariantPressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("SurfaceVariantDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("SurfaceVariantSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("SurfaceVariantMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("SurfaceVariantLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("SurfaceVariantDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("SurfaceVariantDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantBrush")]
+					public static ResourceValue<Brush> Default => new("SurfaceVariantBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("SurfaceVariantHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("SurfaceVariantFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantPressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("SurfaceVariantPressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("SurfaceVariantDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("SurfaceVariantSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("SurfaceVariantMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantLowBrush")]
+					public static ResourceValue<Brush> Low => new("SurfaceVariantLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("SurfaceVariantDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("SurfaceVariantDisabledLowBrush");
 				}
 
 				public static class Inverse
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("SurfaceInverseBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("SurfaceInverseHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("SurfaceInverseFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("SurfaceInversePressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("SurfaceInverseDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("SurfaceInverseSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("SurfaceInverseMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("SurfaceInverseLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("SurfaceInverseDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("SurfaceInverseDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseBrush")]
+					public static ResourceValue<Brush> Default => new("SurfaceInverseBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("SurfaceInverseHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("SurfaceInverseFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceInversePressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("SurfaceInversePressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("SurfaceInverseDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("SurfaceInverseSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("SurfaceInverseMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseLowBrush")]
+					public static ResourceValue<Brush> Low => new("SurfaceInverseLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("SurfaceInverseDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("SurfaceInverseDisabledLowBrush");
 				}
 			}
 
 			public static class OnSurface
 			{
-				public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("OnSurfaceBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("OnSurfaceHoverBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("OnSurfaceFocusedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("OnSurfacePressedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("OnSurfaceDraggedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("OnSurfaceSelectedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("OnSurfaceMediumBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("OnSurfaceLowBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("OnSurfaceDisabledBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("OnSurfaceDisabledLowBrush");
+				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceBrush")]
+				public static ResourceValue<Brush> Default => new("OnSurfaceBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceHoverBrush")]
+				public static ResourceValue<Brush> Hover => new("OnSurfaceHoverBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceFocusedBrush")]
+				public static ResourceValue<Brush> Focused => new("OnSurfaceFocusedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSurfacePressedBrush")]
+				public static ResourceValue<Brush> Pressed => new("OnSurfacePressedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceDraggedBrush")]
+				public static ResourceValue<Brush> Dragged => new("OnSurfaceDraggedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceSelectedBrush")]
+				public static ResourceValue<Brush> Selected => new("OnSurfaceSelectedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceMediumBrush")]
+				public static ResourceValue<Brush> Medium => new("OnSurfaceMediumBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceLowBrush")]
+				public static ResourceValue<Brush> Low => new("OnSurfaceLowBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceDisabledBrush")]
+				public static ResourceValue<Brush> Disabled => new("OnSurfaceDisabledBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceDisabledLowBrush")]
+				public static ResourceValue<Brush> DisabledLow => new("OnSurfaceDisabledLowBrush");
 
 				public static class Variant
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("OnSurfaceVariantBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("OnSurfaceVariantHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("OnSurfaceVariantFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("OnSurfaceVariantPressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("OnSurfaceVariantDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("OnSurfaceVariantSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("OnSurfaceVariantMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("OnSurfaceVariantLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("OnSurfaceVariantDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("OnSurfaceVariantDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantBrush")]
+					public static ResourceValue<Brush> Default => new("OnSurfaceVariantBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("OnSurfaceVariantHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("OnSurfaceVariantFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantPressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("OnSurfaceVariantPressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("OnSurfaceVariantDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("OnSurfaceVariantSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("OnSurfaceVariantMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantLowBrush")]
+					public static ResourceValue<Brush> Low => new("OnSurfaceVariantLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("OnSurfaceVariantDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("OnSurfaceVariantDisabledLowBrush");
 				}
 
 				public static class Inverse
 				{
-					public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("OnSurfaceInverseBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("OnSurfaceInverseHoverBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("OnSurfaceInverseFocusedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("OnSurfaceInversePressedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("OnSurfaceInverseDraggedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("OnSurfaceInverseSelectedBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("OnSurfaceInverseMediumBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("OnSurfaceInverseLowBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("OnSurfaceInverseDisabledBrush");
-					public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("OnSurfaceInverseDisabledLowBrush");
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseBrush")]
+					public static ResourceValue<Brush> Default => new("OnSurfaceInverseBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseHoverBrush")]
+					public static ResourceValue<Brush> Hover => new("OnSurfaceInverseHoverBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseFocusedBrush")]
+					public static ResourceValue<Brush> Focused => new("OnSurfaceInverseFocusedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInversePressedBrush")]
+					public static ResourceValue<Brush> Pressed => new("OnSurfaceInversePressedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseDraggedBrush")]
+					public static ResourceValue<Brush> Dragged => new("OnSurfaceInverseDraggedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseSelectedBrush")]
+					public static ResourceValue<Brush> Selected => new("OnSurfaceInverseSelectedBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseMediumBrush")]
+					public static ResourceValue<Brush> Medium => new("OnSurfaceInverseMediumBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseLowBrush")]
+					public static ResourceValue<Brush> Low => new("OnSurfaceInverseLowBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseDisabledBrush")]
+					public static ResourceValue<Brush> Disabled => new("OnSurfaceInverseDisabledBrush");
+
+					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseDisabledLowBrush")]
+					public static ResourceValue<Brush> DisabledLow => new("OnSurfaceInverseDisabledLowBrush");
 				}
 			}
 
 			public static class Outline
 			{
-				public static Action<IDependencyPropertyBuilder<Brush>> Default => StaticResource.Get<Brush>("OutlineBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Hover => StaticResource.Get<Brush>("OutlineHoverBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Focused => StaticResource.Get<Brush>("OutlineFocusedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Pressed => StaticResource.Get<Brush>("OutlinePressedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Dragged => StaticResource.Get<Brush>("OutlineDraggedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Selected => StaticResource.Get<Brush>("OutlineSelectedBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Medium => StaticResource.Get<Brush>("OutlineMediumBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Low => StaticResource.Get<Brush>("OutlineLowBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> Disabled => StaticResource.Get<Brush>("OutlineDisabledBrush");
-				public static Action<IDependencyPropertyBuilder<Brush>> DisabledLow => StaticResource.Get<Brush>("OutlineDisabledLowBrush");
+				[ResourceKeyDefinition(typeof(Brush), "OutlineBrush")]
+				public static ResourceValue<Brush> Default => new("OutlineBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OutlineHoverBrush")]
+				public static ResourceValue<Brush> Hover => new("OutlineHoverBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OutlineFocusedBrush")]
+				public static ResourceValue<Brush> Focused => new("OutlineFocusedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OutlinePressedBrush")]
+				public static ResourceValue<Brush> Pressed => new("OutlinePressedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OutlineDraggedBrush")]
+				public static ResourceValue<Brush> Dragged => new("OutlineDraggedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OutlineSelectedBrush")]
+				public static ResourceValue<Brush> Selected => new("OutlineSelectedBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OutlineMediumBrush")]
+				public static ResourceValue<Brush> Medium => new("OutlineMediumBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OutlineLowBrush")]
+				public static ResourceValue<Brush> Low => new("OutlineLowBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OutlineDisabledBrush")]
+				public static ResourceValue<Brush> Disabled => new("OutlineDisabledBrush");
+
+				[ResourceKeyDefinition(typeof(Brush), "OutlineDisabledLowBrush")]
+				public static ResourceValue<Brush> DisabledLow => new("OutlineDisabledLowBrush");
 			}
 		}
 	}

--- a/src/library/Uno.Themes.WinUI.Markup/Theme.Brushes.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme.Brushes.cs
@@ -10,990 +10,990 @@ namespace Uno.Themes.Markup
 			public static class Primary
 			{
 				[ResourceKeyDefinition(typeof(Brush), "PrimaryBrush")]
-				public static ResourceValue<Brush> Default => new("PrimaryBrush");
+				public static ResourceValue<Brush> Default => new("PrimaryBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "PrimaryHoverBrush")]
-				public static ResourceValue<Brush> Hover => new("PrimaryHoverBrush");
+				public static ResourceValue<Brush> Hover => new("PrimaryHoverBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "PrimaryFocusedBrush")]
-				public static ResourceValue<Brush> Focused => new("PrimaryFocusedBrush");
+				public static ResourceValue<Brush> Focused => new("PrimaryFocusedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "PrimaryPressedBrush")]
-				public static ResourceValue<Brush> Pressed => new("PrimaryPressedBrush");
+				public static ResourceValue<Brush> Pressed => new("PrimaryPressedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "PrimaryDraggedBrush")]
-				public static ResourceValue<Brush> Dragged => new("PrimaryDraggedBrush");
+				public static ResourceValue<Brush> Dragged => new("PrimaryDraggedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "PrimarySelectedBrush")]
-				public static ResourceValue<Brush> Selected => new("PrimarySelectedBrush");
+				public static ResourceValue<Brush> Selected => new("PrimarySelectedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "PrimaryMediumBrush")]
-				public static ResourceValue<Brush> Medium => new("PrimaryMediumBrush");
+				public static ResourceValue<Brush> Medium => new("PrimaryMediumBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "PrimaryLowBrush")]
-				public static ResourceValue<Brush> Low => new("PrimaryLowBrush");
+				public static ResourceValue<Brush> Low => new("PrimaryLowBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "PrimaryDisabledBrush")]
-				public static ResourceValue<Brush> Disabled => new("PrimaryDisabledBrush");
+				public static ResourceValue<Brush> Disabled => new("PrimaryDisabledBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "PrimaryDisabledLowBrush")]
-				public static ResourceValue<Brush> DisabledLow => new("PrimaryDisabledLowBrush");
+				public static ResourceValue<Brush> DisabledLow => new("PrimaryDisabledLowBrush", true);
 
 				public static class Inverse
 				{
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseBrush")]
-					public static ResourceValue<Brush> Default => new("PrimaryInverseBrush");
+					public static ResourceValue<Brush> Default => new("PrimaryInverseBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("PrimaryInverseHoverBrush");
+					public static ResourceValue<Brush> Hover => new("PrimaryInverseHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("PrimaryInverseFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("PrimaryInverseFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryInversePressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("PrimaryInversePressedBrush");
+					public static ResourceValue<Brush> Pressed => new("PrimaryInversePressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("PrimaryInverseDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("PrimaryInverseDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("PrimaryInverseSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("PrimaryInverseSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("PrimaryInverseMediumBrush");
+					public static ResourceValue<Brush> Medium => new("PrimaryInverseMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseLowBrush")]
-					public static ResourceValue<Brush> Low => new("PrimaryInverseLowBrush");
+					public static ResourceValue<Brush> Low => new("PrimaryInverseLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("PrimaryInverseDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("PrimaryInverseDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryInverseDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("PrimaryInverseDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("PrimaryInverseDisabledLowBrush", true);
 				}
 
 				public static class Container
 				{
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerBrush")]
-					public static ResourceValue<Brush> Default => new("PrimaryContainerBrush");
+					public static ResourceValue<Brush> Default => new("PrimaryContainerBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("PrimaryContainerHoverBrush");
+					public static ResourceValue<Brush> Hover => new("PrimaryContainerHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("PrimaryContainerFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("PrimaryContainerFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerPressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("PrimaryContainerPressedBrush");
+					public static ResourceValue<Brush> Pressed => new("PrimaryContainerPressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("PrimaryContainerDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("PrimaryContainerDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("PrimaryContainerSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("PrimaryContainerSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("PrimaryContainerMediumBrush");
+					public static ResourceValue<Brush> Medium => new("PrimaryContainerMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerLowBrush")]
-					public static ResourceValue<Brush> Low => new("PrimaryContainerLowBrush");
+					public static ResourceValue<Brush> Low => new("PrimaryContainerLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("PrimaryContainerDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("PrimaryContainerDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryContainerDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("PrimaryContainerDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("PrimaryContainerDisabledLowBrush", true);
 				}
 
 				public static class VariantLight
 				{
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightBrush")]
-					public static ResourceValue<Brush> Default => new("PrimaryVariantLightBrush");
+					public static ResourceValue<Brush> Default => new("PrimaryVariantLightBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("PrimaryVariantLightHoverBrush");
+					public static ResourceValue<Brush> Hover => new("PrimaryVariantLightHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("PrimaryVariantLightFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("PrimaryVariantLightFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightPressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("PrimaryVariantLightPressedBrush");
+					public static ResourceValue<Brush> Pressed => new("PrimaryVariantLightPressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("PrimaryVariantLightDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("PrimaryVariantLightDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("PrimaryVariantLightSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("PrimaryVariantLightSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("PrimaryVariantLightMediumBrush");
+					public static ResourceValue<Brush> Medium => new("PrimaryVariantLightMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightLowBrush")]
-					public static ResourceValue<Brush> Low => new("PrimaryVariantLightLowBrush");
+					public static ResourceValue<Brush> Low => new("PrimaryVariantLightLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("PrimaryVariantLightDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("PrimaryVariantLightDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantLightDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("PrimaryVariantLightDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("PrimaryVariantLightDisabledLowBrush", true);
 				}
 
 				public static class VariantDark
 				{
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkBrush")]
-					public static ResourceValue<Brush> Default => new("PrimaryVariantDarkBrush");
+					public static ResourceValue<Brush> Default => new("PrimaryVariantDarkBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("PrimaryVariantDarkHoverBrush");
+					public static ResourceValue<Brush> Hover => new("PrimaryVariantDarkHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("PrimaryVariantDarkFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("PrimaryVariantDarkFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkPressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("PrimaryVariantDarkPressedBrush");
+					public static ResourceValue<Brush> Pressed => new("PrimaryVariantDarkPressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("PrimaryVariantDarkDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("PrimaryVariantDarkDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("PrimaryVariantDarkSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("PrimaryVariantDarkSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("PrimaryVariantDarkMediumBrush");
+					public static ResourceValue<Brush> Medium => new("PrimaryVariantDarkMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkLowBrush")]
-					public static ResourceValue<Brush> Low => new("PrimaryVariantDarkLowBrush");
+					public static ResourceValue<Brush> Low => new("PrimaryVariantDarkLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("PrimaryVariantDarkDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("PrimaryVariantDarkDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "PrimaryVariantDarkDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("PrimaryVariantDarkDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("PrimaryVariantDarkDisabledLowBrush", true);
 				}
 			}
 
 			public static class OnPrimary
 			{
 				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryBrush")]
-				public static ResourceValue<Brush> Default => new("OnPrimaryBrush");
+				public static ResourceValue<Brush> Default => new("OnPrimaryBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryHoverBrush")]
-				public static ResourceValue<Brush> Hover => new("OnPrimaryHoverBrush");
+				public static ResourceValue<Brush> Hover => new("OnPrimaryHoverBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryFocusedBrush")]
-				public static ResourceValue<Brush> Focused => new("OnPrimaryFocusedBrush");
+				public static ResourceValue<Brush> Focused => new("OnPrimaryFocusedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryPressedBrush")]
-				public static ResourceValue<Brush> Pressed => new("OnPrimaryPressedBrush");
+				public static ResourceValue<Brush> Pressed => new("OnPrimaryPressedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryDraggedBrush")]
-				public static ResourceValue<Brush> Dragged => new("OnPrimaryDraggedBrush");
+				public static ResourceValue<Brush> Dragged => new("OnPrimaryDraggedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnPrimarySelectedBrush")]
-				public static ResourceValue<Brush> Selected => new("OnPrimarySelectedBrush");
+				public static ResourceValue<Brush> Selected => new("OnPrimarySelectedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryMediumBrush")]
-				public static ResourceValue<Brush> Medium => new("OnPrimaryMediumBrush");
+				public static ResourceValue<Brush> Medium => new("OnPrimaryMediumBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryLowBrush")]
-				public static ResourceValue<Brush> Low => new("OnPrimaryLowBrush");
+				public static ResourceValue<Brush> Low => new("OnPrimaryLowBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryDisabledBrush")]
-				public static ResourceValue<Brush> Disabled => new("OnPrimaryDisabledBrush");
+				public static ResourceValue<Brush> Disabled => new("OnPrimaryDisabledBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnPrimaryDisabledLowBrush")]
-				public static ResourceValue<Brush> DisabledLow => new("OnPrimaryDisabledLowBrush");
+				public static ResourceValue<Brush> DisabledLow => new("OnPrimaryDisabledLowBrush", true);
 
 				public static class Container
 				{
 					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerBrush")]
-					public static ResourceValue<Brush> Default => new("OnPrimaryContainerBrush");
+					public static ResourceValue<Brush> Default => new("OnPrimaryContainerBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("OnPrimaryContainerHoverBrush");
+					public static ResourceValue<Brush> Hover => new("OnPrimaryContainerHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("OnPrimaryContainerFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("OnPrimaryContainerFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerPressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("OnPrimaryContainerPressedBrush");
+					public static ResourceValue<Brush> Pressed => new("OnPrimaryContainerPressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("OnPrimaryContainerDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("OnPrimaryContainerDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("OnPrimaryContainerSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("OnPrimaryContainerSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("OnPrimaryContainerMediumBrush");
+					public static ResourceValue<Brush> Medium => new("OnPrimaryContainerMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerLowBrush")]
-					public static ResourceValue<Brush> Low => new("OnPrimaryContainerLowBrush");
+					public static ResourceValue<Brush> Low => new("OnPrimaryContainerLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("OnPrimaryContainerDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("OnPrimaryContainerDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnPrimaryContainerDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("OnPrimaryContainerDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("OnPrimaryContainerDisabledLowBrush", true);
 				}
 			}
 
 			public static class Secondary
 			{
 				[ResourceKeyDefinition(typeof(Brush), "SecondaryBrush")]
-				public static ResourceValue<Brush> Default => new("SecondaryBrush");
+				public static ResourceValue<Brush> Default => new("SecondaryBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SecondaryHoverBrush")]
-				public static ResourceValue<Brush> Hover => new("SecondaryHoverBrush");
+				public static ResourceValue<Brush> Hover => new("SecondaryHoverBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SecondaryFocusedBrush")]
-				public static ResourceValue<Brush> Focused => new("SecondaryFocusedBrush");
+				public static ResourceValue<Brush> Focused => new("SecondaryFocusedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SecondaryPressedBrush")]
-				public static ResourceValue<Brush> Pressed => new("SecondaryPressedBrush");
+				public static ResourceValue<Brush> Pressed => new("SecondaryPressedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SecondaryDraggedBrush")]
-				public static ResourceValue<Brush> Dragged => new("SecondaryDraggedBrush");
+				public static ResourceValue<Brush> Dragged => new("SecondaryDraggedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SecondarySelectedBrush")]
-				public static ResourceValue<Brush> Selected => new("SecondarySelectedBrush");
+				public static ResourceValue<Brush> Selected => new("SecondarySelectedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SecondaryMediumBrush")]
-				public static ResourceValue<Brush> Medium => new("SecondaryMediumBrush");
+				public static ResourceValue<Brush> Medium => new("SecondaryMediumBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SecondaryLowBrush")]
-				public static ResourceValue<Brush> Low => new("SecondaryLowBrush");
+				public static ResourceValue<Brush> Low => new("SecondaryLowBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SecondaryDisabledBrush")]
-				public static ResourceValue<Brush> Disabled => new("SecondaryDisabledBrush");
+				public static ResourceValue<Brush> Disabled => new("SecondaryDisabledBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SecondaryDisabledLowBrush")]
-				public static ResourceValue<Brush> DisabledLow => new("SecondaryDisabledLowBrush");
+				public static ResourceValue<Brush> DisabledLow => new("SecondaryDisabledLowBrush", true);
 
 				public static class Container
 				{
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerBrush")]
-					public static ResourceValue<Brush> Default => new("SecondaryContainerBrush");
+					public static ResourceValue<Brush> Default => new("SecondaryContainerBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("SecondaryContainerHoverBrush");
+					public static ResourceValue<Brush> Hover => new("SecondaryContainerHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("SecondaryContainerFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("SecondaryContainerFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerPressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("SecondaryContainerPressedBrush");
+					public static ResourceValue<Brush> Pressed => new("SecondaryContainerPressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("SecondaryContainerDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("SecondaryContainerDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("SecondaryContainerSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("SecondaryContainerSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("SecondaryContainerMediumBrush");
+					public static ResourceValue<Brush> Medium => new("SecondaryContainerMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerLowBrush")]
-					public static ResourceValue<Brush> Low => new("SecondaryContainerLowBrush");
+					public static ResourceValue<Brush> Low => new("SecondaryContainerLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("SecondaryContainerDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("SecondaryContainerDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryContainerDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("SecondaryContainerDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("SecondaryContainerDisabledLowBrush", true);
 				}
 
 				public static class VariantLight
 				{
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightBrush")]
-					public static ResourceValue<Brush> Default => new("SecondaryVariantLightBrush");
+					public static ResourceValue<Brush> Default => new("SecondaryVariantLightBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("SecondaryVariantLightHoverBrush");
+					public static ResourceValue<Brush> Hover => new("SecondaryVariantLightHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("SecondaryVariantLightFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("SecondaryVariantLightFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightPressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("SecondaryVariantLightPressedBrush");
+					public static ResourceValue<Brush> Pressed => new("SecondaryVariantLightPressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("SecondaryVariantLightDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("SecondaryVariantLightDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("SecondaryVariantLightSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("SecondaryVariantLightSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("SecondaryVariantLightMediumBrush");
+					public static ResourceValue<Brush> Medium => new("SecondaryVariantLightMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightLowBrush")]
-					public static ResourceValue<Brush> Low => new("SecondaryVariantLightLowBrush");
+					public static ResourceValue<Brush> Low => new("SecondaryVariantLightLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("SecondaryVariantLightDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("SecondaryVariantLightDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantLightDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("SecondaryVariantLightDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("SecondaryVariantLightDisabledLowBrush", true);
 				}
 
 				public static class VariantDark
 				{
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkBrush")]
-					public static ResourceValue<Brush> Default => new("SecondaryVariantDarkBrush");
+					public static ResourceValue<Brush> Default => new("SecondaryVariantDarkBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("SecondaryVariantDarkHoverBrush");
+					public static ResourceValue<Brush> Hover => new("SecondaryVariantDarkHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("SecondaryVariantDarkFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("SecondaryVariantDarkFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkPressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("SecondaryVariantDarkPressedBrush");
+					public static ResourceValue<Brush> Pressed => new("SecondaryVariantDarkPressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("SecondaryVariantDarkDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("SecondaryVariantDarkDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("SecondaryVariantDarkSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("SecondaryVariantDarkSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("SecondaryVariantDarkMediumBrush");
+					public static ResourceValue<Brush> Medium => new("SecondaryVariantDarkMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkLowBrush")]
-					public static ResourceValue<Brush> Low => new("SecondaryVariantDarkLowBrush");
+					public static ResourceValue<Brush> Low => new("SecondaryVariantDarkLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("SecondaryVariantDarkDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("SecondaryVariantDarkDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SecondaryVariantDarkDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("SecondaryVariantDarkDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("SecondaryVariantDarkDisabledLowBrush", true);
 				}
 			}
 
 			public static class OnSecondary
 			{
 				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryBrush")]
-				public static ResourceValue<Brush> Default => new("OnSecondaryBrush");
+				public static ResourceValue<Brush> Default => new("OnSecondaryBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryHoverBrush")]
-				public static ResourceValue<Brush> Hover => new("OnSecondaryHoverBrush");
+				public static ResourceValue<Brush> Hover => new("OnSecondaryHoverBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryFocusedBrush")]
-				public static ResourceValue<Brush> Focused => new("OnSecondaryFocusedBrush");
+				public static ResourceValue<Brush> Focused => new("OnSecondaryFocusedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryPressedBrush")]
-				public static ResourceValue<Brush> Pressed => new("OnSecondaryPressedBrush");
+				public static ResourceValue<Brush> Pressed => new("OnSecondaryPressedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryDraggedBrush")]
-				public static ResourceValue<Brush> Dragged => new("OnSecondaryDraggedBrush");
+				public static ResourceValue<Brush> Dragged => new("OnSecondaryDraggedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSecondarySelectedBrush")]
-				public static ResourceValue<Brush> Selected => new("OnSecondarySelectedBrush");
+				public static ResourceValue<Brush> Selected => new("OnSecondarySelectedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryMediumBrush")]
-				public static ResourceValue<Brush> Medium => new("OnSecondaryMediumBrush");
+				public static ResourceValue<Brush> Medium => new("OnSecondaryMediumBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryLowBrush")]
-				public static ResourceValue<Brush> Low => new("OnSecondaryLowBrush");
+				public static ResourceValue<Brush> Low => new("OnSecondaryLowBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryDisabledBrush")]
-				public static ResourceValue<Brush> Disabled => new("OnSecondaryDisabledBrush");
+				public static ResourceValue<Brush> Disabled => new("OnSecondaryDisabledBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSecondaryDisabledLowBrush")]
-				public static ResourceValue<Brush> DisabledLow => new("OnSecondaryDisabledLowBrush");
+				public static ResourceValue<Brush> DisabledLow => new("OnSecondaryDisabledLowBrush", true);
 
 				public static class Container
 				{
 					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerBrush")]
-					public static ResourceValue<Brush> Default => new("OnSecondaryContainerBrush");
+					public static ResourceValue<Brush> Default => new("OnSecondaryContainerBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("OnSecondaryContainerHoverBrush");
+					public static ResourceValue<Brush> Hover => new("OnSecondaryContainerHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("OnSecondaryContainerFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("OnSecondaryContainerFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerPressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("OnSecondaryContainerPressedBrush");
+					public static ResourceValue<Brush> Pressed => new("OnSecondaryContainerPressedBrush", true);
 
-					public static ResourceValue<Brush> Dragged => new("OnSecondaryContainerDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("OnSecondaryContainerDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("OnSecondaryContainerSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("OnSecondaryContainerSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("OnSecondaryContainerMediumBrush");
+					public static ResourceValue<Brush> Medium => new("OnSecondaryContainerMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerLowBrush")]
-					public static ResourceValue<Brush> Low => new("OnSecondaryContainerLowBrush");
+					public static ResourceValue<Brush> Low => new("OnSecondaryContainerLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("OnSecondaryContainerDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("OnSecondaryContainerDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSecondaryContainerDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("OnSecondaryContainerDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("OnSecondaryContainerDisabledLowBrush", true);
 				}
 			}
 
 			public static class Tertiary
 			{
 				[ResourceKeyDefinition(typeof(Brush), "TertiaryBrush")]
-				public static ResourceValue<Brush> Default => new("TertiaryBrush");
+				public static ResourceValue<Brush> Default => new("TertiaryBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "TertiaryHoverBrush")]
-				public static ResourceValue<Brush> Hover => new("TertiaryHoverBrush");
+				public static ResourceValue<Brush> Hover => new("TertiaryHoverBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "TertiaryFocusedBrush")]
-				public static ResourceValue<Brush> Focused => new("TertiaryFocusedBrush");
+				public static ResourceValue<Brush> Focused => new("TertiaryFocusedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "TertiaryPressedBrush")]
-				public static ResourceValue<Brush> Pressed => new("TertiaryPressedBrush");
+				public static ResourceValue<Brush> Pressed => new("TertiaryPressedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "TertiaryDraggedBrush")]
-				public static ResourceValue<Brush> Dragged => new("TertiaryDraggedBrush");
+				public static ResourceValue<Brush> Dragged => new("TertiaryDraggedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "TertiarySelectedBrush")]
-				public static ResourceValue<Brush> Selected => new("TertiarySelectedBrush");
+				public static ResourceValue<Brush> Selected => new("TertiarySelectedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "TertiaryMediumBrush")]
-				public static ResourceValue<Brush> Medium => new("TertiaryMediumBrush");
+				public static ResourceValue<Brush> Medium => new("TertiaryMediumBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "TertiaryLowBrush")]
-				public static ResourceValue<Brush> Low => new("TertiaryLowBrush");
+				public static ResourceValue<Brush> Low => new("TertiaryLowBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "TertiaryDisabledBrush")]
-				public static ResourceValue<Brush> Disabled => new("TertiaryDisabledBrush");
+				public static ResourceValue<Brush> Disabled => new("TertiaryDisabledBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "TertiaryDisabledLowBrush")]
-				public static ResourceValue<Brush> DisabledLow => new("TertiaryDisabledLowBrush");
+				public static ResourceValue<Brush> DisabledLow => new("TertiaryDisabledLowBrush", true);
 
 				public static class Container
 				{
 					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerBrush")]
-					public static ResourceValue<Brush> Default => new("TertiaryContainerBrush");
+					public static ResourceValue<Brush> Default => new("TertiaryContainerBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("TertiaryContainerHoverBrush");
+					public static ResourceValue<Brush> Hover => new("TertiaryContainerHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("TertiaryContainerFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("TertiaryContainerFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerPressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("TertiaryContainerPressedBrush");
+					public static ResourceValue<Brush> Pressed => new("TertiaryContainerPressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("TertiaryContainerDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("TertiaryContainerDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("TertiaryContainerSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("TertiaryContainerSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("TertiaryContainerMediumBrush");
+					public static ResourceValue<Brush> Medium => new("TertiaryContainerMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerLowBrush")]
-					public static ResourceValue<Brush> Low => new("TertiaryContainerLowBrush");
+					public static ResourceValue<Brush> Low => new("TertiaryContainerLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("TertiaryContainerDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("TertiaryContainerDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "TertiaryContainerDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("TertiaryContainerDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("TertiaryContainerDisabledLowBrush", true);
 				}
 			}
 
 			public static class OnTertiary
 			{
 				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryBrush")]
-				public static ResourceValue<Brush> Default => new("OnTertiaryBrush");
+				public static ResourceValue<Brush> Default => new("OnTertiaryBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryHoverBrush")]
-				public static ResourceValue<Brush> Hover => new("OnTertiaryHoverBrush");
+				public static ResourceValue<Brush> Hover => new("OnTertiaryHoverBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryFocusedBrush")]
-				public static ResourceValue<Brush> Focused => new("OnTertiaryFocusedBrush");
+				public static ResourceValue<Brush> Focused => new("OnTertiaryFocusedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryPressedBrush")]
-				public static ResourceValue<Brush> Pressed => new("OnTertiaryPressedBrush");
+				public static ResourceValue<Brush> Pressed => new("OnTertiaryPressedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryDraggedBrush")]
-				public static ResourceValue<Brush> Dragged => new("OnTertiaryDraggedBrush");
+				public static ResourceValue<Brush> Dragged => new("OnTertiaryDraggedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnTertiarySelectedBrush")]
-				public static ResourceValue<Brush> Selected => new("OnTertiarySelectedBrush");
+				public static ResourceValue<Brush> Selected => new("OnTertiarySelectedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryMediumBrush")]
-				public static ResourceValue<Brush> Medium => new("OnTertiaryMediumBrush");
+				public static ResourceValue<Brush> Medium => new("OnTertiaryMediumBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryLowBrush")]
-				public static ResourceValue<Brush> Low => new("OnTertiaryLowBrush");
+				public static ResourceValue<Brush> Low => new("OnTertiaryLowBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryDisabledBrush")]
-				public static ResourceValue<Brush> Disabled => new("OnTertiaryDisabledBrush");
+				public static ResourceValue<Brush> Disabled => new("OnTertiaryDisabledBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnTertiaryDisabledLowBrush")]
-				public static ResourceValue<Brush> DisabledLow => new("OnTertiaryDisabledLowBrush");
+				public static ResourceValue<Brush> DisabledLow => new("OnTertiaryDisabledLowBrush", true);
 
 				public static class Container
 				{
 					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerBrush")]
-					public static ResourceValue<Brush> Default => new("OnTertiaryContainerBrush");
+					public static ResourceValue<Brush> Default => new("OnTertiaryContainerBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("OnTertiaryContainerHoverBrush");
+					public static ResourceValue<Brush> Hover => new("OnTertiaryContainerHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("OnTertiaryContainerFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("OnTertiaryContainerFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerPressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("OnTertiaryContainerPressedBrush");
+					public static ResourceValue<Brush> Pressed => new("OnTertiaryContainerPressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("OnTertiaryContainerDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("OnTertiaryContainerDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("OnTertiaryContainerSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("OnTertiaryContainerSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("OnTertiaryContainerMediumBrush");
+					public static ResourceValue<Brush> Medium => new("OnTertiaryContainerMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerLowBrush")]
-					public static ResourceValue<Brush> Low => new("OnTertiaryContainerLowBrush");
+					public static ResourceValue<Brush> Low => new("OnTertiaryContainerLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("OnTertiaryContainerDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("OnTertiaryContainerDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnTertiaryContainerDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("OnTertiaryContainerDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("OnTertiaryContainerDisabledLowBrush", true);
 				}
 			}
 
 			public static class Error
 			{
 				[ResourceKeyDefinition(typeof(Brush), "ErrorBrush")]
-				public static ResourceValue<Brush> Default => new("ErrorBrush");
+				public static ResourceValue<Brush> Default => new("ErrorBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "ErrorHoverBrush")]
-				public static ResourceValue<Brush> Hover => new("ErrorHoverBrush");
+				public static ResourceValue<Brush> Hover => new("ErrorHoverBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "ErrorFocusedBrush")]
-				public static ResourceValue<Brush> Focused => new("ErrorFocusedBrush");
+				public static ResourceValue<Brush> Focused => new("ErrorFocusedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "ErrorPressedBrush")]
-				public static ResourceValue<Brush> Pressed => new("ErrorPressedBrush");
+				public static ResourceValue<Brush> Pressed => new("ErrorPressedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "ErrorDraggedBrush")]
-				public static ResourceValue<Brush> Dragged => new("ErrorDraggedBrush");
+				public static ResourceValue<Brush> Dragged => new("ErrorDraggedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "ErrorSelectedBrush")]
-				public static ResourceValue<Brush> Selected => new("ErrorSelectedBrush");
+				public static ResourceValue<Brush> Selected => new("ErrorSelectedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "ErrorMediumBrush")]
-				public static ResourceValue<Brush> Medium => new("ErrorMediumBrush");
+				public static ResourceValue<Brush> Medium => new("ErrorMediumBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "ErrorLowBrush")]
-				public static ResourceValue<Brush> Low => new("ErrorLowBrush");
+				public static ResourceValue<Brush> Low => new("ErrorLowBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "ErrorDisabledBrush")]
-				public static ResourceValue<Brush> Disabled => new("ErrorDisabledBrush");
+				public static ResourceValue<Brush> Disabled => new("ErrorDisabledBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "ErrorDisabledLowBrush")]
-				public static ResourceValue<Brush> DisabledLow => new("ErrorDisabledLowBrush");
+				public static ResourceValue<Brush> DisabledLow => new("ErrorDisabledLowBrush", true);
 
 				public static class Container
 				{
 					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerBrush")]
-					public static ResourceValue<Brush> Default => new("ErrorContainerBrush");
+					public static ResourceValue<Brush> Default => new("ErrorContainerBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("ErrorContainerHoverBrush");
+					public static ResourceValue<Brush> Hover => new("ErrorContainerHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("ErrorContainerFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("ErrorContainerFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerPressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("ErrorContainerPressedBrush");
+					public static ResourceValue<Brush> Pressed => new("ErrorContainerPressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("ErrorContainerDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("ErrorContainerDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("ErrorContainerSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("ErrorContainerSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("ErrorContainerMediumBrush");
+					public static ResourceValue<Brush> Medium => new("ErrorContainerMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerLowBrush")]
-					public static ResourceValue<Brush> Low => new("ErrorContainerLowBrush");
+					public static ResourceValue<Brush> Low => new("ErrorContainerLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("ErrorContainerDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("ErrorContainerDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "ErrorContainerDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("ErrorContainerDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("ErrorContainerDisabledLowBrush", true);
 				}
 			}
 
 			public static class OnError
 			{
 				[ResourceKeyDefinition(typeof(Brush), "OnErrorBrush")]
-				public static ResourceValue<Brush> Default => new("OnErrorBrush");
+				public static ResourceValue<Brush> Default => new("OnErrorBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnErrorHoverBrush")]
-				public static ResourceValue<Brush> Hover => new("OnErrorHoverBrush");
+				public static ResourceValue<Brush> Hover => new("OnErrorHoverBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnErrorFocusedBrush")]
-				public static ResourceValue<Brush> Focused => new("OnErrorFocusedBrush");
+				public static ResourceValue<Brush> Focused => new("OnErrorFocusedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnErrorPressedBrush")]
-				public static ResourceValue<Brush> Pressed => new("OnErrorPressedBrush");
+				public static ResourceValue<Brush> Pressed => new("OnErrorPressedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnErrorDraggedBrush")]
-				public static ResourceValue<Brush> Dragged => new("OnErrorDraggedBrush");
+				public static ResourceValue<Brush> Dragged => new("OnErrorDraggedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnErrorSelectedBrush")]
-				public static ResourceValue<Brush> Selected => new("OnErrorSelectedBrush");
+				public static ResourceValue<Brush> Selected => new("OnErrorSelectedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnErrorMediumBrush")]
-				public static ResourceValue<Brush> Medium => new("OnErrorMediumBrush");
+				public static ResourceValue<Brush> Medium => new("OnErrorMediumBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnErrorLowBrush")]
-				public static ResourceValue<Brush> Low => new("OnErrorLowBrush");
+				public static ResourceValue<Brush> Low => new("OnErrorLowBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnErrorDisabledBrush")]
-				public static ResourceValue<Brush> Disabled => new("OnErrorDisabledBrush");
+				public static ResourceValue<Brush> Disabled => new("OnErrorDisabledBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnErrorDisabledLowBrush")]
-				public static ResourceValue<Brush> DisabledLow => new("OnErrorDisabledLowBrush");
+				public static ResourceValue<Brush> DisabledLow => new("OnErrorDisabledLowBrush", true);
 
 				public static class Container
 				{
 					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerBrush")]
-					public static ResourceValue<Brush> Default => new("OnErrorContainerBrush");
+					public static ResourceValue<Brush> Default => new("OnErrorContainerBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("OnErrorContainerHoverBrush");
+					public static ResourceValue<Brush> Hover => new("OnErrorContainerHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("OnErrorContainerFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("OnErrorContainerFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerPressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("OnErrorContainerPressedBrush");
+					public static ResourceValue<Brush> Pressed => new("OnErrorContainerPressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("OnErrorContainerDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("OnErrorContainerDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("OnErrorContainerSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("OnErrorContainerSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("OnErrorContainerMediumBrush");
+					public static ResourceValue<Brush> Medium => new("OnErrorContainerMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerLowBrush")]
-					public static ResourceValue<Brush> Low => new("OnErrorContainerLowBrush");
+					public static ResourceValue<Brush> Low => new("OnErrorContainerLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("OnErrorContainerDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("OnErrorContainerDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnErrorContainerDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("OnErrorContainerDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("OnErrorContainerDisabledLowBrush", true);
 				}
 			}
 
 			public static class Background
 			{
 				[ResourceKeyDefinition(typeof(Brush), "BackgroundBrush")]
-				public static ResourceValue<Brush> Default => new("BackgroundBrush");
+				public static ResourceValue<Brush> Default => new("BackgroundBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "BackgroundHoverBrush")]
-				public static ResourceValue<Brush> Hover => new("BackgroundHoverBrush");
+				public static ResourceValue<Brush> Hover => new("BackgroundHoverBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "BackgroundFocusedBrush")]
-				public static ResourceValue<Brush> Focused => new("BackgroundFocusedBrush");
+				public static ResourceValue<Brush> Focused => new("BackgroundFocusedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "BackgroundPressedBrush")]
-				public static ResourceValue<Brush> Pressed => new("BackgroundPressedBrush");
+				public static ResourceValue<Brush> Pressed => new("BackgroundPressedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "BackgroundDraggedBrush")]
-				public static ResourceValue<Brush> Dragged => new("BackgroundDraggedBrush");
+				public static ResourceValue<Brush> Dragged => new("BackgroundDraggedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "BackgroundSelectedBrush")]
-				public static ResourceValue<Brush> Selected => new("BackgroundSelectedBrush");
+				public static ResourceValue<Brush> Selected => new("BackgroundSelectedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "BackgroundMediumBrush")]
-				public static ResourceValue<Brush> Medium => new("BackgroundMediumBrush");
+				public static ResourceValue<Brush> Medium => new("BackgroundMediumBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "BackgroundLowBrush")]
-				public static ResourceValue<Brush> Low => new("BackgroundLowBrush");
+				public static ResourceValue<Brush> Low => new("BackgroundLowBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "BackgroundDisabledBrush")]
-				public static ResourceValue<Brush> Disabled => new("BackgroundDisabledBrush");
+				public static ResourceValue<Brush> Disabled => new("BackgroundDisabledBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "BackgroundDisabledLowBrush")]
-				public static ResourceValue<Brush> DisabledLow => new("BackgroundDisabledLowBrush");
+				public static ResourceValue<Brush> DisabledLow => new("BackgroundDisabledLowBrush", true);
 			}
 
 			public static class OnBackground
 			{
 				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundBrush")]
-				public static ResourceValue<Brush> Default => new("OnBackgroundBrush");
+				public static ResourceValue<Brush> Default => new("OnBackgroundBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundHoverBrush")]
-				public static ResourceValue<Brush> Hover => new("OnBackgroundHoverBrush");
+				public static ResourceValue<Brush> Hover => new("OnBackgroundHoverBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundFocusedBrush")]
-				public static ResourceValue<Brush> Focused => new("OnBackgroundFocusedBrush");
+				public static ResourceValue<Brush> Focused => new("OnBackgroundFocusedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundPressedBrush")]
-				public static ResourceValue<Brush> Pressed => new("OnBackgroundPressedBrush");
+				public static ResourceValue<Brush> Pressed => new("OnBackgroundPressedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundDraggedBrush")]
-				public static ResourceValue<Brush> Dragged => new("OnBackgroundDraggedBrush");
+				public static ResourceValue<Brush> Dragged => new("OnBackgroundDraggedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundSelectedBrush")]
-				public static ResourceValue<Brush> Selected => new("OnBackgroundSelectedBrush");
+				public static ResourceValue<Brush> Selected => new("OnBackgroundSelectedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundMediumBrush")]
-				public static ResourceValue<Brush> Medium => new("OnBackgroundMediumBrush");
+				public static ResourceValue<Brush> Medium => new("OnBackgroundMediumBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundLowBrush")]
-				public static ResourceValue<Brush> Low => new("OnBackgroundLowBrush");
+				public static ResourceValue<Brush> Low => new("OnBackgroundLowBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundDisabledBrush")]
-				public static ResourceValue<Brush> Disabled => new("OnBackgroundDisabledBrush");
+				public static ResourceValue<Brush> Disabled => new("OnBackgroundDisabledBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnBackgroundDisabledLowBrush")]
-				public static ResourceValue<Brush> DisabledLow => new("OnBackgroundDisabledLowBrush");
+				public static ResourceValue<Brush> DisabledLow => new("OnBackgroundDisabledLowBrush", true);
 			}
 
 			public static class Surface
 			{
 				[ResourceKeyDefinition(typeof(Brush), "SurfaceBrush")]
-				public static ResourceValue<Brush> Default => new("SurfaceBrush");
+				public static ResourceValue<Brush> Default => new("SurfaceBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SurfaceHoverBrush")]
-				public static ResourceValue<Brush> Hover => new("SurfaceHoverBrush");
+				public static ResourceValue<Brush> Hover => new("SurfaceHoverBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SurfaceFocusedBrush")]
-				public static ResourceValue<Brush> Focused => new("SurfaceFocusedBrush");
+				public static ResourceValue<Brush> Focused => new("SurfaceFocusedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SurfacePressedBrush")]
-				public static ResourceValue<Brush> Pressed => new("SurfacePressedBrush");
+				public static ResourceValue<Brush> Pressed => new("SurfacePressedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SurfaceDraggedBrush")]
-				public static ResourceValue<Brush> Dragged => new("SurfaceDraggedBrush");
+				public static ResourceValue<Brush> Dragged => new("SurfaceDraggedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SurfaceSelectedBrush")]
-				public static ResourceValue<Brush> Selected => new("SurfaceSelectedBrush");
+				public static ResourceValue<Brush> Selected => new("SurfaceSelectedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SurfaceMediumBrush")]
-				public static ResourceValue<Brush> Medium => new("SurfaceMediumBrush");
+				public static ResourceValue<Brush> Medium => new("SurfaceMediumBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SurfaceLowBrush")]
-				public static ResourceValue<Brush> Low => new("SurfaceLowBrush");
+				public static ResourceValue<Brush> Low => new("SurfaceLowBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SurfaceDisabledBrush")]
-				public static ResourceValue<Brush> Disabled => new("SurfaceDisabledBrush");
+				public static ResourceValue<Brush> Disabled => new("SurfaceDisabledBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "SurfaceDisabledLowBrush")]
-				public static ResourceValue<Brush> DisabledLow => new("SurfaceDisabledLowBrush");
+				public static ResourceValue<Brush> DisabledLow => new("SurfaceDisabledLowBrush", true);
 
 				public static class Variant
 				{
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantBrush")]
-					public static ResourceValue<Brush> Default => new("SurfaceVariantBrush");
+					public static ResourceValue<Brush> Default => new("SurfaceVariantBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("SurfaceVariantHoverBrush");
+					public static ResourceValue<Brush> Hover => new("SurfaceVariantHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("SurfaceVariantFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("SurfaceVariantFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantPressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("SurfaceVariantPressedBrush");
+					public static ResourceValue<Brush> Pressed => new("SurfaceVariantPressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("SurfaceVariantDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("SurfaceVariantDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("SurfaceVariantSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("SurfaceVariantSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("SurfaceVariantMediumBrush");
+					public static ResourceValue<Brush> Medium => new("SurfaceVariantMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantLowBrush")]
-					public static ResourceValue<Brush> Low => new("SurfaceVariantLowBrush");
+					public static ResourceValue<Brush> Low => new("SurfaceVariantLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("SurfaceVariantDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("SurfaceVariantDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceVariantDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("SurfaceVariantDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("SurfaceVariantDisabledLowBrush", true);
 				}
 
 				public static class Inverse
 				{
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseBrush")]
-					public static ResourceValue<Brush> Default => new("SurfaceInverseBrush");
+					public static ResourceValue<Brush> Default => new("SurfaceInverseBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("SurfaceInverseHoverBrush");
+					public static ResourceValue<Brush> Hover => new("SurfaceInverseHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("SurfaceInverseFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("SurfaceInverseFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceInversePressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("SurfaceInversePressedBrush");
+					public static ResourceValue<Brush> Pressed => new("SurfaceInversePressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("SurfaceInverseDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("SurfaceInverseDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("SurfaceInverseSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("SurfaceInverseSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("SurfaceInverseMediumBrush");
+					public static ResourceValue<Brush> Medium => new("SurfaceInverseMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseLowBrush")]
-					public static ResourceValue<Brush> Low => new("SurfaceInverseLowBrush");
+					public static ResourceValue<Brush> Low => new("SurfaceInverseLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("SurfaceInverseDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("SurfaceInverseDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "SurfaceInverseDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("SurfaceInverseDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("SurfaceInverseDisabledLowBrush", true);
 				}
 			}
 
 			public static class OnSurface
 			{
 				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceBrush")]
-				public static ResourceValue<Brush> Default => new("OnSurfaceBrush");
+				public static ResourceValue<Brush> Default => new("OnSurfaceBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceHoverBrush")]
-				public static ResourceValue<Brush> Hover => new("OnSurfaceHoverBrush");
+				public static ResourceValue<Brush> Hover => new("OnSurfaceHoverBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceFocusedBrush")]
-				public static ResourceValue<Brush> Focused => new("OnSurfaceFocusedBrush");
+				public static ResourceValue<Brush> Focused => new("OnSurfaceFocusedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSurfacePressedBrush")]
-				public static ResourceValue<Brush> Pressed => new("OnSurfacePressedBrush");
+				public static ResourceValue<Brush> Pressed => new("OnSurfacePressedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceDraggedBrush")]
-				public static ResourceValue<Brush> Dragged => new("OnSurfaceDraggedBrush");
+				public static ResourceValue<Brush> Dragged => new("OnSurfaceDraggedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceSelectedBrush")]
-				public static ResourceValue<Brush> Selected => new("OnSurfaceSelectedBrush");
+				public static ResourceValue<Brush> Selected => new("OnSurfaceSelectedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceMediumBrush")]
-				public static ResourceValue<Brush> Medium => new("OnSurfaceMediumBrush");
+				public static ResourceValue<Brush> Medium => new("OnSurfaceMediumBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceLowBrush")]
-				public static ResourceValue<Brush> Low => new("OnSurfaceLowBrush");
+				public static ResourceValue<Brush> Low => new("OnSurfaceLowBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceDisabledBrush")]
-				public static ResourceValue<Brush> Disabled => new("OnSurfaceDisabledBrush");
+				public static ResourceValue<Brush> Disabled => new("OnSurfaceDisabledBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OnSurfaceDisabledLowBrush")]
-				public static ResourceValue<Brush> DisabledLow => new("OnSurfaceDisabledLowBrush");
+				public static ResourceValue<Brush> DisabledLow => new("OnSurfaceDisabledLowBrush", true);
 
 				public static class Variant
 				{
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantBrush")]
-					public static ResourceValue<Brush> Default => new("OnSurfaceVariantBrush");
+					public static ResourceValue<Brush> Default => new("OnSurfaceVariantBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("OnSurfaceVariantHoverBrush");
+					public static ResourceValue<Brush> Hover => new("OnSurfaceVariantHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("OnSurfaceVariantFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("OnSurfaceVariantFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantPressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("OnSurfaceVariantPressedBrush");
+					public static ResourceValue<Brush> Pressed => new("OnSurfaceVariantPressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("OnSurfaceVariantDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("OnSurfaceVariantDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("OnSurfaceVariantSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("OnSurfaceVariantSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("OnSurfaceVariantMediumBrush");
+					public static ResourceValue<Brush> Medium => new("OnSurfaceVariantMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantLowBrush")]
-					public static ResourceValue<Brush> Low => new("OnSurfaceVariantLowBrush");
+					public static ResourceValue<Brush> Low => new("OnSurfaceVariantLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("OnSurfaceVariantDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("OnSurfaceVariantDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceVariantDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("OnSurfaceVariantDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("OnSurfaceVariantDisabledLowBrush", true);
 				}
 
 				public static class Inverse
 				{
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseBrush")]
-					public static ResourceValue<Brush> Default => new("OnSurfaceInverseBrush");
+					public static ResourceValue<Brush> Default => new("OnSurfaceInverseBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseHoverBrush")]
-					public static ResourceValue<Brush> Hover => new("OnSurfaceInverseHoverBrush");
+					public static ResourceValue<Brush> Hover => new("OnSurfaceInverseHoverBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseFocusedBrush")]
-					public static ResourceValue<Brush> Focused => new("OnSurfaceInverseFocusedBrush");
+					public static ResourceValue<Brush> Focused => new("OnSurfaceInverseFocusedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInversePressedBrush")]
-					public static ResourceValue<Brush> Pressed => new("OnSurfaceInversePressedBrush");
+					public static ResourceValue<Brush> Pressed => new("OnSurfaceInversePressedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseDraggedBrush")]
-					public static ResourceValue<Brush> Dragged => new("OnSurfaceInverseDraggedBrush");
+					public static ResourceValue<Brush> Dragged => new("OnSurfaceInverseDraggedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseSelectedBrush")]
-					public static ResourceValue<Brush> Selected => new("OnSurfaceInverseSelectedBrush");
+					public static ResourceValue<Brush> Selected => new("OnSurfaceInverseSelectedBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseMediumBrush")]
-					public static ResourceValue<Brush> Medium => new("OnSurfaceInverseMediumBrush");
+					public static ResourceValue<Brush> Medium => new("OnSurfaceInverseMediumBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseLowBrush")]
-					public static ResourceValue<Brush> Low => new("OnSurfaceInverseLowBrush");
+					public static ResourceValue<Brush> Low => new("OnSurfaceInverseLowBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseDisabledBrush")]
-					public static ResourceValue<Brush> Disabled => new("OnSurfaceInverseDisabledBrush");
+					public static ResourceValue<Brush> Disabled => new("OnSurfaceInverseDisabledBrush", true);
 
 					[ResourceKeyDefinition(typeof(Brush), "OnSurfaceInverseDisabledLowBrush")]
-					public static ResourceValue<Brush> DisabledLow => new("OnSurfaceInverseDisabledLowBrush");
+					public static ResourceValue<Brush> DisabledLow => new("OnSurfaceInverseDisabledLowBrush", true);
 				}
 			}
 
 			public static class Outline
 			{
 				[ResourceKeyDefinition(typeof(Brush), "OutlineBrush")]
-				public static ResourceValue<Brush> Default => new("OutlineBrush");
+				public static ResourceValue<Brush> Default => new("OutlineBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OutlineHoverBrush")]
-				public static ResourceValue<Brush> Hover => new("OutlineHoverBrush");
+				public static ResourceValue<Brush> Hover => new("OutlineHoverBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OutlineFocusedBrush")]
-				public static ResourceValue<Brush> Focused => new("OutlineFocusedBrush");
+				public static ResourceValue<Brush> Focused => new("OutlineFocusedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OutlinePressedBrush")]
-				public static ResourceValue<Brush> Pressed => new("OutlinePressedBrush");
+				public static ResourceValue<Brush> Pressed => new("OutlinePressedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OutlineDraggedBrush")]
-				public static ResourceValue<Brush> Dragged => new("OutlineDraggedBrush");
+				public static ResourceValue<Brush> Dragged => new("OutlineDraggedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OutlineSelectedBrush")]
-				public static ResourceValue<Brush> Selected => new("OutlineSelectedBrush");
+				public static ResourceValue<Brush> Selected => new("OutlineSelectedBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OutlineMediumBrush")]
-				public static ResourceValue<Brush> Medium => new("OutlineMediumBrush");
+				public static ResourceValue<Brush> Medium => new("OutlineMediumBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OutlineLowBrush")]
-				public static ResourceValue<Brush> Low => new("OutlineLowBrush");
+				public static ResourceValue<Brush> Low => new("OutlineLowBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OutlineDisabledBrush")]
-				public static ResourceValue<Brush> Disabled => new("OutlineDisabledBrush");
+				public static ResourceValue<Brush> Disabled => new("OutlineDisabledBrush", true);
 
 				[ResourceKeyDefinition(typeof(Brush), "OutlineDisabledLowBrush")]
-				public static ResourceValue<Brush> DisabledLow => new("OutlineDisabledLowBrush");
+				public static ResourceValue<Brush> DisabledLow => new("OutlineDisabledLowBrush", true);
 			}
 		}
 	}

--- a/src/library/Uno.Themes.WinUI.Markup/Theme.Colors.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme.Colors.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.MarkupHelpers;
+﻿using Microsoft.UI.Xaml.MarkupHelpers.Internals;
 using Windows.UI;
 
 namespace Uno.Themes.Markup
@@ -11,84 +9,131 @@ namespace Uno.Themes.Markup
 		{
 			public static class Primary
 			{
-				public static Action<IDependencyPropertyBuilder<Color>> Default => ThemeResource.Get<Color>("PrimaryColor");
-				public static Action<IDependencyPropertyBuilder<Color>> Inverse => ThemeResource.Get<Color>("PrimaryInverseColor");
-				public static Action<IDependencyPropertyBuilder<Color>> Container => ThemeResource.Get<Color>("PrimaryContainerColor");
-				public static Action<IDependencyPropertyBuilder<Color>> VariantDark => ThemeResource.Get<Color>("PrimaryVariantDarkColor");
-				public static Action<IDependencyPropertyBuilder<Color>> VariantLight => ThemeResource.Get<Color>("PrimaryVariantLightColor");
+				[ResourceKeyDefinition(typeof(Color), "PrimaryColor")]
+				public static ResourceValue<Color> Default => new("PrimaryColor");
+
+				[ResourceKeyDefinition(typeof(Color), "PrimaryInverseColor")]
+				public static ResourceValue<Color> Inverse => new("PrimaryInverseColor");
+
+				[ResourceKeyDefinition(typeof(Color), "PrimaryContainerColor")]
+				public static ResourceValue<Color> Container => new("PrimaryContainerColor");
+
+				[ResourceKeyDefinition(typeof(Color), "PrimaryVariantDarkColor")]
+				public static ResourceValue<Color> VariantDark => new("PrimaryVariantDarkColor");
+
+				[ResourceKeyDefinition(typeof(Color), "PrimaryVariantLightColor")]
+				public static ResourceValue<Color> VariantLight => new("PrimaryVariantLightColor");
 			}
 
 			public static class OnPrimary
 			{
-				public static Action<IDependencyPropertyBuilder<Color>> Default => ThemeResource.Get<Color>("OnPrimaryColor");
-				public static Action<IDependencyPropertyBuilder<Color>> Container => ThemeResource.Get<Color>("OnPrimaryContainerColor");
+				[ResourceKeyDefinition(typeof(Color), "OnPrimaryColor")]
+				public static ResourceValue<Color> Default => new("OnPrimaryColor");
+
+				[ResourceKeyDefinition(typeof(Color), "OnPrimaryContainerColor")]
+				public static ResourceValue<Color> Container => new("OnPrimaryContainerColor");
 			}
 
 			public static class Secondary
 			{
-				public static Action<IDependencyPropertyBuilder<Color>> Default => ThemeResource.Get<Color>("SecondaryColor");
-				public static Action<IDependencyPropertyBuilder<Color>> Container => ThemeResource.Get<Color>("SecondaryContainerColor");
-				public static Action<IDependencyPropertyBuilder<Color>> VariantDark => ThemeResource.Get<Color>("SecondaryVariantDarkColor");
-				public static Action<IDependencyPropertyBuilder<Color>> VariantLight => ThemeResource.Get<Color>("SecondaryVariantLightColor");
+				[ResourceKeyDefinition(typeof(Color), "SecondaryColor")]
+				public static ResourceValue<Color> Default => new("SecondaryColor");
+
+				[ResourceKeyDefinition(typeof(Color), "SecondaryContainerColor")]
+				public static ResourceValue<Color> Container => new("SecondaryContainerColor");
+
+				[ResourceKeyDefinition(typeof(Color), "SecondaryVariantDarkColor")]
+				public static ResourceValue<Color> VariantDark => new("SecondaryVariantDarkColor");
+
+				[ResourceKeyDefinition(typeof(Color), "SecondaryVariantLightColor")]
+				public static ResourceValue<Color> VariantLight => new("SecondaryVariantLightColor");
 			}
 
 			public static class OnSecondary
 			{
-				public static Action<IDependencyPropertyBuilder<Color>> Default => ThemeResource.Get<Color>("OnSecondaryColor");
-				public static Action<IDependencyPropertyBuilder<Color>> Container => ThemeResource.Get<Color>("OnSecondaryContainerColor");
+				[ResourceKeyDefinition(typeof(Color), "OnSecondaryColor")]
+				public static ResourceValue<Color> Default => new("OnSecondaryColor");
+
+				[ResourceKeyDefinition(typeof(Color), "OnSecondaryContainerColor")]
+				public static ResourceValue<Color> Container => new("OnSecondaryContainerColor");
 			}
 
 			public static class Tertiary
 			{
-				public static Action<IDependencyPropertyBuilder<Color>> Default => ThemeResource.Get<Color>("TertiaryColor");
-				public static Action<IDependencyPropertyBuilder<Color>> Container => ThemeResource.Get<Color>("TertiaryContainerColor");
+				[ResourceKeyDefinition(typeof(Color), "TertiaryColor")]
+				public static ResourceValue<Color> Default => new("TertiaryColor");
+
+				[ResourceKeyDefinition(typeof(Color), "TertiaryContainerColor")]
+				public static ResourceValue<Color> Container => new("TertiaryContainerColor");
 			}
 
 			public static class OnTertiary
 			{
-				public static Action<IDependencyPropertyBuilder<Color>> Default => ThemeResource.Get<Color>("OnTertiaryColor");
-				public static Action<IDependencyPropertyBuilder<Color>> Container => ThemeResource.Get<Color>("OnTertiaryContainerColor");
+				[ResourceKeyDefinition(typeof(Color), "OnTertiaryColor")]
+				public static ResourceValue<Color> Default => new("OnTertiaryColor");
+
+				[ResourceKeyDefinition(typeof(Color), "OnTertiaryContainerColor")]
+				public static ResourceValue<Color> Container => new("OnTertiaryContainerColor");
 			}
 
 			public static class Error
 			{
-				public static Action<IDependencyPropertyBuilder<Color>> Default => ThemeResource.Get<Color>("ErrorColor");
-				public static Action<IDependencyPropertyBuilder<Color>> Container => ThemeResource.Get<Color>("ErrorContainerColor");
+				[ResourceKeyDefinition(typeof(Color), "ErrorColor")]
+				public static ResourceValue<Color> Default => new("ErrorColor");
+
+				[ResourceKeyDefinition(typeof(Color), "ErrorContainerColor")]
+				public static ResourceValue<Color> Container => new("ErrorContainerColor");
 			}
 
 			public static class OnError
 			{
-				public static Action<IDependencyPropertyBuilder<Color>> Default => ThemeResource.Get<Color>("OnErrorColor");
-				public static Action<IDependencyPropertyBuilder<Color>> Container => ThemeResource.Get<Color>("OnErrorContainerColor");
+				[ResourceKeyDefinition(typeof(Color), "OnErrorColor")]
+				public static ResourceValue<Color> Default => new("OnErrorColor");
+
+				[ResourceKeyDefinition(typeof(Color), "OnErrorContainerColor")]
+				public static ResourceValue<Color> Container => new("OnErrorContainerColor");
 			}
 
 			public static class Background
 			{
-				public static Action<IDependencyPropertyBuilder<Color>> Default => ThemeResource.Get<Color>("BackgroundColor");
+				[ResourceKeyDefinition(typeof(Color), "BackgroundColor")]
+				public static ResourceValue<Color> Default => new("BackgroundColor");
 			}
 
 			public static class OnBackground
 			{
-				public static Action<IDependencyPropertyBuilder<Color>> Default => ThemeResource.Get<Color>("OnBackgroundColor");
+				[ResourceKeyDefinition(typeof(Color), "OnBackgroundColor")]
+				public static ResourceValue<Color> Default => new("OnBackgroundColor");
 			}
 
 			public static class Surface
 			{
-				public static Action<IDependencyPropertyBuilder<Color>> Default => ThemeResource.Get<Color>("SurfaceColor");
-				public static Action<IDependencyPropertyBuilder<Color>> Variant => ThemeResource.Get<Color>("SurfaceVariantColor");
-				public static Action<IDependencyPropertyBuilder<Color>> Inverse => ThemeResource.Get<Color>("SurfaceInverseColor");
+				[ResourceKeyDefinition(typeof(Color), "SurfaceColor")]
+				public static ResourceValue<Color> Default => new("SurfaceColor");
+
+				[ResourceKeyDefinition(typeof(Color), "SurfaceVariantColor")]
+				public static ResourceValue<Color> Variant => new("SurfaceVariantColor");
+
+				[ResourceKeyDefinition(typeof(Color), "SurfaceInverseColor")]
+				public static ResourceValue<Color> Inverse => new("SurfaceInverseColor");
 			}
 
 			public static class OnSurface
 			{
-				public static Action<IDependencyPropertyBuilder<Color>> Default => ThemeResource.Get<Color>("OnSurfaceColor");
-				public static Action<IDependencyPropertyBuilder<Color>> Variant => ThemeResource.Get<Color>("OnSurfaceVariantColor");
-				public static Action<IDependencyPropertyBuilder<Color>> Inverse => ThemeResource.Get<Color>("OnSurfaceInverseColor");
+				[ResourceKeyDefinition(typeof(Color), "OnSurfaceColor")]
+				public static ResourceValue<Color> Default => new("OnSurfaceColor");
+
+				[ResourceKeyDefinition(typeof(Color), "OnSurfaceVariantColor")]
+				public static ResourceValue<Color> Variant => new("OnSurfaceVariantColor");
+
+				[ResourceKeyDefinition(typeof(Color), "OnSurfaceInverseColor")]
+				public static ResourceValue<Color> Inverse => new("OnSurfaceInverseColor");
 			}
 
 			public static class Outline
 			{
-				public static Action<IDependencyPropertyBuilder<Color>> Default => ThemeResource.Get<Color>("OutlineColor");
+				[ResourceKeyDefinition(typeof(Color), "OutlineColor")]
+				public static ResourceValue<Color> Default => new("OutlineColor");
 			}
 
 		}

--- a/src/library/Uno.Themes.WinUI.Markup/Theme.Colors.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme.Colors.cs
@@ -10,130 +10,130 @@ namespace Uno.Themes.Markup
 			public static class Primary
 			{
 				[ResourceKeyDefinition(typeof(Color), "PrimaryColor")]
-				public static ResourceValue<Color> Default => new("PrimaryColor");
+				public static ResourceValue<Color> Default => new("PrimaryColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "PrimaryInverseColor")]
-				public static ResourceValue<Color> Inverse => new("PrimaryInverseColor");
+				public static ResourceValue<Color> Inverse => new("PrimaryInverseColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "PrimaryContainerColor")]
-				public static ResourceValue<Color> Container => new("PrimaryContainerColor");
+				public static ResourceValue<Color> Container => new("PrimaryContainerColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "PrimaryVariantDarkColor")]
-				public static ResourceValue<Color> VariantDark => new("PrimaryVariantDarkColor");
+				public static ResourceValue<Color> VariantDark => new("PrimaryVariantDarkColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "PrimaryVariantLightColor")]
-				public static ResourceValue<Color> VariantLight => new("PrimaryVariantLightColor");
+				public static ResourceValue<Color> VariantLight => new("PrimaryVariantLightColor", true);
 			}
 
 			public static class OnPrimary
 			{
 				[ResourceKeyDefinition(typeof(Color), "OnPrimaryColor")]
-				public static ResourceValue<Color> Default => new("OnPrimaryColor");
+				public static ResourceValue<Color> Default => new("OnPrimaryColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "OnPrimaryContainerColor")]
-				public static ResourceValue<Color> Container => new("OnPrimaryContainerColor");
+				public static ResourceValue<Color> Container => new("OnPrimaryContainerColor", true);
 			}
 
 			public static class Secondary
 			{
 				[ResourceKeyDefinition(typeof(Color), "SecondaryColor")]
-				public static ResourceValue<Color> Default => new("SecondaryColor");
+				public static ResourceValue<Color> Default => new("SecondaryColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "SecondaryContainerColor")]
-				public static ResourceValue<Color> Container => new("SecondaryContainerColor");
+				public static ResourceValue<Color> Container => new("SecondaryContainerColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "SecondaryVariantDarkColor")]
-				public static ResourceValue<Color> VariantDark => new("SecondaryVariantDarkColor");
+				public static ResourceValue<Color> VariantDark => new("SecondaryVariantDarkColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "SecondaryVariantLightColor")]
-				public static ResourceValue<Color> VariantLight => new("SecondaryVariantLightColor");
+				public static ResourceValue<Color> VariantLight => new("SecondaryVariantLightColor", true);
 			}
 
 			public static class OnSecondary
 			{
 				[ResourceKeyDefinition(typeof(Color), "OnSecondaryColor")]
-				public static ResourceValue<Color> Default => new("OnSecondaryColor");
+				public static ResourceValue<Color> Default => new("OnSecondaryColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "OnSecondaryContainerColor")]
-				public static ResourceValue<Color> Container => new("OnSecondaryContainerColor");
+				public static ResourceValue<Color> Container => new("OnSecondaryContainerColor", true);
 			}
 
 			public static class Tertiary
 			{
 				[ResourceKeyDefinition(typeof(Color), "TertiaryColor")]
-				public static ResourceValue<Color> Default => new("TertiaryColor");
+				public static ResourceValue<Color> Default => new("TertiaryColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "TertiaryContainerColor")]
-				public static ResourceValue<Color> Container => new("TertiaryContainerColor");
+				public static ResourceValue<Color> Container => new("TertiaryContainerColor", true);
 			}
 
 			public static class OnTertiary
 			{
 				[ResourceKeyDefinition(typeof(Color), "OnTertiaryColor")]
-				public static ResourceValue<Color> Default => new("OnTertiaryColor");
+				public static ResourceValue<Color> Default => new("OnTertiaryColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "OnTertiaryContainerColor")]
-				public static ResourceValue<Color> Container => new("OnTertiaryContainerColor");
+				public static ResourceValue<Color> Container => new("OnTertiaryContainerColor", true);
 			}
 
 			public static class Error
 			{
 				[ResourceKeyDefinition(typeof(Color), "ErrorColor")]
-				public static ResourceValue<Color> Default => new("ErrorColor");
+				public static ResourceValue<Color> Default => new("ErrorColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "ErrorContainerColor")]
-				public static ResourceValue<Color> Container => new("ErrorContainerColor");
+				public static ResourceValue<Color> Container => new("ErrorContainerColor", true);
 			}
 
 			public static class OnError
 			{
 				[ResourceKeyDefinition(typeof(Color), "OnErrorColor")]
-				public static ResourceValue<Color> Default => new("OnErrorColor");
+				public static ResourceValue<Color> Default => new("OnErrorColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "OnErrorContainerColor")]
-				public static ResourceValue<Color> Container => new("OnErrorContainerColor");
+				public static ResourceValue<Color> Container => new("OnErrorContainerColor", true);
 			}
 
 			public static class Background
 			{
 				[ResourceKeyDefinition(typeof(Color), "BackgroundColor")]
-				public static ResourceValue<Color> Default => new("BackgroundColor");
+				public static ResourceValue<Color> Default => new("BackgroundColor", true);
 			}
 
 			public static class OnBackground
 			{
 				[ResourceKeyDefinition(typeof(Color), "OnBackgroundColor")]
-				public static ResourceValue<Color> Default => new("OnBackgroundColor");
+				public static ResourceValue<Color> Default => new("OnBackgroundColor", true);
 			}
 
 			public static class Surface
 			{
 				[ResourceKeyDefinition(typeof(Color), "SurfaceColor")]
-				public static ResourceValue<Color> Default => new("SurfaceColor");
+				public static ResourceValue<Color> Default => new("SurfaceColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "SurfaceVariantColor")]
-				public static ResourceValue<Color> Variant => new("SurfaceVariantColor");
+				public static ResourceValue<Color> Variant => new("SurfaceVariantColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "SurfaceInverseColor")]
-				public static ResourceValue<Color> Inverse => new("SurfaceInverseColor");
+				public static ResourceValue<Color> Inverse => new("SurfaceInverseColor", true);
 			}
 
 			public static class OnSurface
 			{
 				[ResourceKeyDefinition(typeof(Color), "OnSurfaceColor")]
-				public static ResourceValue<Color> Default => new("OnSurfaceColor");
+				public static ResourceValue<Color> Default => new("OnSurfaceColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "OnSurfaceVariantColor")]
-				public static ResourceValue<Color> Variant => new("OnSurfaceVariantColor");
+				public static ResourceValue<Color> Variant => new("OnSurfaceVariantColor", true);
 
 				[ResourceKeyDefinition(typeof(Color), "OnSurfaceInverseColor")]
-				public static ResourceValue<Color> Inverse => new("OnSurfaceInverseColor");
+				public static ResourceValue<Color> Inverse => new("OnSurfaceInverseColor", true);
 			}
 
 			public static class Outline
 			{
 				[ResourceKeyDefinition(typeof(Color), "OutlineColor")]
-				public static ResourceValue<Color> Default => new("OutlineColor");
+				public static ResourceValue<Color> Default => new("OutlineColor", true);
 			}
 
 		}

--- a/src/library/Uno.Themes.WinUI.Markup/Theme.Styles.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme.Styles.cs
@@ -10,274 +10,274 @@ namespace Uno.Themes.Markup
 			public static class Button
 			{
 				[ResourceKeyDefinition(typeof(Style), "ElevatedButtonStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> Elevated => new("ElevatedButtonStyle");
+				public static ResourceValue<Style> Elevated => new("ElevatedButtonStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "FilledButtonStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> Filled => new("FilledButtonStyle");
+				public static ResourceValue<Style> Filled => new("FilledButtonStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "FilledTonalButtonStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> FilledTonal => new("FilledTonalButtonStyle");
+				public static ResourceValue<Style> FilledTonal => new("FilledTonalButtonStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "OutlinedButtonStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> Outlined => new("OutlinedButtonStyle");
+				public static ResourceValue<Style> Outlined => new("OutlinedButtonStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "TextButtonStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> Text => new("TextButtonStyle");
+				public static ResourceValue<Style> Text => new("TextButtonStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "IconButtonStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> Icon => new("IconButtonStyle");
+				public static ResourceValue<Style> Icon => new("IconButtonStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "FabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> Fab => new("FabStyle");
+				public static ResourceValue<Style> Fab => new("FabStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "SurfaceFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> SurfaceFab => new("SurfaceFabStyle");
+				public static ResourceValue<Style> SurfaceFab => new("SurfaceFabStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "SecondaryFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> SecondaryFab => new("SecondaryFabStyle");
+				public static ResourceValue<Style> SecondaryFab => new("SecondaryFabStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "TertiaryFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> TertiaryFab => new("TertiaryFabStyle");
+				public static ResourceValue<Style> TertiaryFab => new("TertiaryFabStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "SmallFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> SmallFab => new("SmallFabStyle");
+				public static ResourceValue<Style> SmallFab => new("SmallFabStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "SurfaceSmallFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> SurfaceSmallFab => new("SurfaceSmallFabStyle");
+				public static ResourceValue<Style> SurfaceSmallFab => new("SurfaceSmallFabStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "SecondarySmallFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> SecondarySmallFab => new("SecondarySmallFabStyle");
+				public static ResourceValue<Style> SecondarySmallFab => new("SecondarySmallFabStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "TertiarySmallFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> TertiarySmallFab => new("TertiarySmallFabStyle");
+				public static ResourceValue<Style> TertiarySmallFab => new("TertiarySmallFabStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "LargeFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> LargeFab => new("LargeFabStyle");
+				public static ResourceValue<Style> LargeFab => new("LargeFabStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "SurfaceLargeFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> SurfaceLargeFab => new("SurfaceLargeFabStyle");
+				public static ResourceValue<Style> SurfaceLargeFab => new("SurfaceLargeFabStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "SecondaryLargeFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> SecondaryLargeFab => new("SecondaryLargeFabStyle");
+				public static ResourceValue<Style> SecondaryLargeFab => new("SecondaryLargeFabStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "TertiaryLargeFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> TertiaryLargeFab => new("TertiaryLargeFabStyle");
+				public static ResourceValue<Style> TertiaryLargeFab => new("TertiaryLargeFabStyle", false);
 			}
 
 			public static class CalendarDatePicker
 			{
 				[ResourceKeyDefinition(typeof(Style), "CalendarDatePickerStyle", TargetType = typeof(CalendarDatePicker))]
-				public static ResourceValue<Style> Default => new("CalendarDatePickerStyle");
+				public static ResourceValue<Style> Default => new("CalendarDatePickerStyle", false);
 			}
 
 			public static class CalendarView
 			{
 				[ResourceKeyDefinition(typeof(Style), "CalendarViewStyle", TargetType = typeof(CalendarView))]
-				public static ResourceValue<Style> Default => new("CalendarViewStyle");
+				public static ResourceValue<Style> Default => new("CalendarViewStyle", false);
 			}
 
 			public static class CheckBox
 			{
 				[ResourceKeyDefinition(typeof(Style), "CheckBoxStyle", TargetType = typeof(CheckBox))]
-				public static ResourceValue<Style> Default => new("CheckBoxStyle");
+				public static ResourceValue<Style> Default => new("CheckBoxStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "SecondaryCheckBoxStyle", TargetType = typeof(CheckBox))]
-				public static ResourceValue<Style> Secondary => new("SecondaryCheckBoxStyle");
+				public static ResourceValue<Style> Secondary => new("SecondaryCheckBoxStyle", false);
 			}
 
 			public static class ComboBox
 			{
 				[ResourceKeyDefinition(typeof(Style), "ComboBoxStyle", TargetType = typeof(ComboBox))]
-				public static ResourceValue<Style> Default => new("ComboBoxStyle");
+				public static ResourceValue<Style> Default => new("ComboBoxStyle", false);
 			}
 
 			public static class AppBarButton
 			{
 				[ResourceKeyDefinition(typeof(Style), "AppBarButtonStyle", TargetType = typeof(AppBarButton))]
-				public static ResourceValue<Style> Default => new("AppBarButtonStyle");
+				public static ResourceValue<Style> Default => new("AppBarButtonStyle", false);
 			}
 
 			public static class CommandBar
 			{
 				[ResourceKeyDefinition(typeof(Style), "CommandBarStyle", TargetType = typeof(CommandBar))]
-				public static ResourceValue<Style> Default => new("CommandBarStyle");
+				public static ResourceValue<Style> Default => new("CommandBarStyle", false);
 			}
 
 			public static class ContentDialog
 			{
 				[ResourceKeyDefinition(typeof(Style), "ContentDialogStyle", TargetType = typeof(ContentDialog))]
-				public static ResourceValue<Style> Default => new("ContentDialogStyle");
+				public static ResourceValue<Style> Default => new("ContentDialogStyle", false);
 			}
 
 			public static class DatePicker
 			{
 				[ResourceKeyDefinition(typeof(Style), "DatePickerStyle", TargetType = typeof(DatePicker))]
-				public static ResourceValue<Style> Default => new("DatePickerStyle");
+				public static ResourceValue<Style> Default => new("DatePickerStyle", false);
 			}
 
 			public static class FlyoutPresenter
 			{
 				[ResourceKeyDefinition(typeof(Style), "FlyoutPresenterStyle", TargetType = typeof(FlyoutPresenter))]
-				public static ResourceValue<Style> Default => new("FlyoutPresenterStyle");
+				public static ResourceValue<Style> Default => new("FlyoutPresenterStyle", false);
 			}
 
 			public static class MenuFlyoutPresenter
 			{
 				[ResourceKeyDefinition(typeof(Style), "MenuFlyoutPresenterStyle", TargetType = typeof(MenuFlyoutPresenter))]
-				public static ResourceValue<Style> Default => new("MenuFlyoutPresenterStyle");
+				public static ResourceValue<Style> Default => new("MenuFlyoutPresenterStyle", false);
 			}
 
 			public static class HyperlinkButton
 			{
 				[ResourceKeyDefinition(typeof(Style), "HyperlinkButtonStyle", TargetType = typeof(HyperlinkButton))]
-				public static ResourceValue<Style> Default => new("HyperlinkButtonStyle");
+				public static ResourceValue<Style> Default => new("HyperlinkButtonStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "SecondaryHyperlinkButtonStyle", TargetType = typeof(HyperlinkButton))]
-				public static ResourceValue<Style> Secondary => new("SecondaryHyperlinkButtonStyle");
+				public static ResourceValue<Style> Secondary => new("SecondaryHyperlinkButtonStyle", false);
 			}
 
 			public static class ListViewItem
 			{
 				[ResourceKeyDefinition(typeof(Style), "ListViewItemStyle", TargetType = typeof(ListViewItem))]
-				public static ResourceValue<Style> Default => new("ListViewItemStyle");
+				public static ResourceValue<Style> Default => new("ListViewItemStyle", false);
 			}
 
 			public static class ListView
 			{
 				[ResourceKeyDefinition(typeof(Style), "ListViewStyle", TargetType = typeof(ListView))]
-				public static ResourceValue<Style> Default => new("ListViewStyle");
+				public static ResourceValue<Style> Default => new("ListViewStyle", false);
 			}
 
 			public static class NavigationView
 			{
 				[ResourceKeyDefinition(typeof(Style), "NavigationViewStyle", TargetType = typeof(NavigationView))]
-				public static ResourceValue<Style> Default => new("NavigationViewStyle");
+				public static ResourceValue<Style> Default => new("NavigationViewStyle", false);
 			}
 
 			public static class NavigationViewItem
 			{
 				[ResourceKeyDefinition(typeof(Style), "NavigationViewItemStyle", TargetType = typeof(NavigationViewItem))]
-				public static ResourceValue<Style> Default => new("NavigationViewItemStyle");
+				public static ResourceValue<Style> Default => new("NavigationViewItemStyle", false);
 			}
 
 			public static class PasswordBox
 			{
 				[ResourceKeyDefinition(typeof(Style), "FilledPasswordBoxStyle", TargetType = typeof(PasswordBox))]
-				public static ResourceValue<Style> Filled => new("FilledPasswordBoxStyle");
+				public static ResourceValue<Style> Filled => new("FilledPasswordBoxStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "OutlinedPasswordBoxStyle", TargetType = typeof(PasswordBox))]
-				public static ResourceValue<Style> Outlined => new("OutlinedPasswordBoxStyle");
+				public static ResourceValue<Style> Outlined => new("OutlinedPasswordBoxStyle", false);
 			}
 
 			public static class ProgressBar
 			{
 				[ResourceKeyDefinition(typeof(Style), "ProgressBarStyle", TargetType = typeof(ProgressBar))]
-				public static ResourceValue<Style> Default => new("ProgressBarStyle");
+				public static ResourceValue<Style> Default => new("ProgressBarStyle", false);
 			}
 
 			public static class ProgressRing
 			{
 				[ResourceKeyDefinition(typeof(Style), "ProgressRingStyle", TargetType = typeof(ProgressRing))]
-				public static ResourceValue<Style> Default => new("ProgressRingStyle");
+				public static ResourceValue<Style> Default => new("ProgressRingStyle", false);
 			}
 
 			public static class RadioButton
 			{
 				[ResourceKeyDefinition(typeof(Style), "RadioButtonStyle", TargetType = typeof(RadioButton))]
-				public static ResourceValue<Style> Default => new("RadioButtonStyle");
+				public static ResourceValue<Style> Default => new("RadioButtonStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "SecondaryRadioButtonStyle", TargetType = typeof(RadioButton))]
-				public static ResourceValue<Style> Secondary => new("SecondaryRadioButtonStyle");
+				public static ResourceValue<Style> Secondary => new("SecondaryRadioButtonStyle", false);
 			}
 
 			public static class Slider
 			{
 				[ResourceKeyDefinition(typeof(Style), "SliderStyle", TargetType = typeof(Slider))]
-				public static ResourceValue<Style> Default => new("SliderStyle");
+				public static ResourceValue<Style> Default => new("SliderStyle", false);
 			}
 
 			public static class TextBlock
 			{
 				[ResourceKeyDefinition(typeof(Style), "DisplayLarge", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> DisplayLarge => new("DisplayLarge");
+				public static ResourceValue<Style> DisplayLarge => new("DisplayLarge", false);
 
 				[ResourceKeyDefinition(typeof(Style), "DisplayMedium", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> DisplayMedium => new("DisplayMedium");
+				public static ResourceValue<Style> DisplayMedium => new("DisplayMedium", false);
 
 				[ResourceKeyDefinition(typeof(Style), "DisplaySmall", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> DisplaySmall => new("DisplaySmall");
+				public static ResourceValue<Style> DisplaySmall => new("DisplaySmall", false);
 
 				[ResourceKeyDefinition(typeof(Style), "HeadlineLarge", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> HeadlineLarge => new("HeadlineLarge");
+				public static ResourceValue<Style> HeadlineLarge => new("HeadlineLarge", false);
 
 				[ResourceKeyDefinition(typeof(Style), "HeadlineMedium", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> HeadlineMedium => new("HeadlineMedium");
+				public static ResourceValue<Style> HeadlineMedium => new("HeadlineMedium", false);
 
 				[ResourceKeyDefinition(typeof(Style), "HeadlineSmall", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> HeadlineSmall => new("HeadlineSmall");
+				public static ResourceValue<Style> HeadlineSmall => new("HeadlineSmall", false);
 
 				[ResourceKeyDefinition(typeof(Style), "TitleLarge", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> TitleLarge => new("TitleLarge");
+				public static ResourceValue<Style> TitleLarge => new("TitleLarge", false);
 
 				[ResourceKeyDefinition(typeof(Style), "TitleMedium", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> TitleMedium => new("TitleMedium");
+				public static ResourceValue<Style> TitleMedium => new("TitleMedium", false);
 
 				[ResourceKeyDefinition(typeof(Style), "TitleSmall", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> TitleSmall => new("TitleSmall");
+				public static ResourceValue<Style> TitleSmall => new("TitleSmall", false);
 
 				[ResourceKeyDefinition(typeof(Style), "LabelLarge", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> LabelLarge => new("LabelLarge");
+				public static ResourceValue<Style> LabelLarge => new("LabelLarge", false);
 
 				[ResourceKeyDefinition(typeof(Style), "LabelMedium", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> LabelMedium => new("LabelMedium");
+				public static ResourceValue<Style> LabelMedium => new("LabelMedium", false);
 
 				[ResourceKeyDefinition(typeof(Style), "LabelSmall", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> LabelSmall => new("LabelSmall");
+				public static ResourceValue<Style> LabelSmall => new("LabelSmall", false);
 
 				[ResourceKeyDefinition(typeof(Style), "LabelExtraSmall", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> LabelExtraSmall => new("LabelExtraSmall");
+				public static ResourceValue<Style> LabelExtraSmall => new("LabelExtraSmall", false);
 
 				[ResourceKeyDefinition(typeof(Style), "BodyLarge", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> BodyLarge => new("BodyLarge");
+				public static ResourceValue<Style> BodyLarge => new("BodyLarge", false);
 
 				[ResourceKeyDefinition(typeof(Style), "BodyMedium", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> BodyMedium => new("BodyMedium");
+				public static ResourceValue<Style> BodyMedium => new("BodyMedium", false);
 
 				[ResourceKeyDefinition(typeof(Style), "BodySmall", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> BodySmall => new("BodySmall");
+				public static ResourceValue<Style> BodySmall => new("BodySmall", false);
 
 				[ResourceKeyDefinition(typeof(Style), "CaptionLarge", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> CaptionLarge => new("CaptionLarge");
+				public static ResourceValue<Style> CaptionLarge => new("CaptionLarge", false);
 
 				[ResourceKeyDefinition(typeof(Style), "CaptionMedium", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> CaptionMedium => new("CaptionMedium");
+				public static ResourceValue<Style> CaptionMedium => new("CaptionMedium", false);
 
 				[ResourceKeyDefinition(typeof(Style), "CaptionSmall", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> CaptionSmall => new("CaptionSmall");
+				public static ResourceValue<Style> CaptionSmall => new("CaptionSmall", false);
 			}
 
 			public static class TextBox
 			{
 				[ResourceKeyDefinition(typeof(Style), "FilledTextBoxStyle", TargetType = typeof(TextBox))]
-				public static ResourceValue<Style> Filled => new("FilledTextBoxStyle");
+				public static ResourceValue<Style> Filled => new("FilledTextBoxStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "OutlinedTextBoxStyle", TargetType = typeof(TextBox))]
-				public static ResourceValue<Style> Outlined => new("OutlinedTextBoxStyle");
+				public static ResourceValue<Style> Outlined => new("OutlinedTextBoxStyle", false);
 			}
 
 			public static class ToggleButton
 			{
 				[ResourceKeyDefinition(typeof(Style), "TextToggleButtonStyle", TargetType = typeof(ToggleButton))]
-				public static ResourceValue<Style> Text => new("TextToggleButtonStyle");
+				public static ResourceValue<Style> Text => new("TextToggleButtonStyle", false);
 
 				[ResourceKeyDefinition(typeof(Style), "IconToggleButtonStyle", TargetType = typeof(ToggleButton))]
-				public static ResourceValue<Style> Icon => new("IconToggleButtonStyle");
+				public static ResourceValue<Style> Icon => new("IconToggleButtonStyle", false);
 			}
 
 			public static class ToggleSwitch
 			{
 				[ResourceKeyDefinition(typeof(Style), "ToggleSwitchStyle", TargetType = typeof(ToggleSwitch))]
-				public static ResourceValue<Style> Default => new("ToggleSwitchStyle");
+				public static ResourceValue<Style> Default => new("ToggleSwitchStyle", false);
 			}
 		}
 	}

--- a/src/library/Uno.Themes.WinUI.Markup/Theme.Styles.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme.Styles.cs
@@ -10,274 +10,274 @@ namespace Uno.Themes.Markup
 			public static class Button
 			{
 				[ResourceKeyDefinition(typeof(Style), "ElevatedButtonStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> Elevated => new("ElevatedButtonStyle", false);
+				public static ResourceValue<Style> Elevated => new("ElevatedButtonStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "FilledButtonStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> Filled => new("FilledButtonStyle", false);
+				public static ResourceValue<Style> Filled => new("FilledButtonStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "FilledTonalButtonStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> FilledTonal => new("FilledTonalButtonStyle", false);
+				public static ResourceValue<Style> FilledTonal => new("FilledTonalButtonStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "OutlinedButtonStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> Outlined => new("OutlinedButtonStyle", false);
+				public static ResourceValue<Style> Outlined => new("OutlinedButtonStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "TextButtonStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> Text => new("TextButtonStyle", false);
+				public static ResourceValue<Style> Text => new("TextButtonStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "IconButtonStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> Icon => new("IconButtonStyle", false);
+				public static ResourceValue<Style> Icon => new("IconButtonStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "FabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> Fab => new("FabStyle", false);
+				public static ResourceValue<Style> Fab => new("FabStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "SurfaceFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> SurfaceFab => new("SurfaceFabStyle", false);
+				public static ResourceValue<Style> SurfaceFab => new("SurfaceFabStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "SecondaryFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> SecondaryFab => new("SecondaryFabStyle", false);
+				public static ResourceValue<Style> SecondaryFab => new("SecondaryFabStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "TertiaryFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> TertiaryFab => new("TertiaryFabStyle", false);
+				public static ResourceValue<Style> TertiaryFab => new("TertiaryFabStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "SmallFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> SmallFab => new("SmallFabStyle", false);
+				public static ResourceValue<Style> SmallFab => new("SmallFabStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "SurfaceSmallFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> SurfaceSmallFab => new("SurfaceSmallFabStyle", false);
+				public static ResourceValue<Style> SurfaceSmallFab => new("SurfaceSmallFabStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "SecondarySmallFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> SecondarySmallFab => new("SecondarySmallFabStyle", false);
+				public static ResourceValue<Style> SecondarySmallFab => new("SecondarySmallFabStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "TertiarySmallFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> TertiarySmallFab => new("TertiarySmallFabStyle", false);
+				public static ResourceValue<Style> TertiarySmallFab => new("TertiarySmallFabStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "LargeFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> LargeFab => new("LargeFabStyle", false);
+				public static ResourceValue<Style> LargeFab => new("LargeFabStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "SurfaceLargeFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> SurfaceLargeFab => new("SurfaceLargeFabStyle", false);
+				public static ResourceValue<Style> SurfaceLargeFab => new("SurfaceLargeFabStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "SecondaryLargeFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> SecondaryLargeFab => new("SecondaryLargeFabStyle", false);
+				public static ResourceValue<Style> SecondaryLargeFab => new("SecondaryLargeFabStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "TertiaryLargeFabStyle", TargetType = typeof(Button))]
-				public static ResourceValue<Style> TertiaryLargeFab => new("TertiaryLargeFabStyle", false);
+				public static ResourceValue<Style> TertiaryLargeFab => new("TertiaryLargeFabStyle");
 			}
 
 			public static class CalendarDatePicker
 			{
 				[ResourceKeyDefinition(typeof(Style), "CalendarDatePickerStyle", TargetType = typeof(CalendarDatePicker))]
-				public static ResourceValue<Style> Default => new("CalendarDatePickerStyle", false);
+				public static ResourceValue<Style> Default => new("CalendarDatePickerStyle");
 			}
 
 			public static class CalendarView
 			{
 				[ResourceKeyDefinition(typeof(Style), "CalendarViewStyle", TargetType = typeof(CalendarView))]
-				public static ResourceValue<Style> Default => new("CalendarViewStyle", false);
+				public static ResourceValue<Style> Default => new("CalendarViewStyle");
 			}
 
 			public static class CheckBox
 			{
 				[ResourceKeyDefinition(typeof(Style), "CheckBoxStyle", TargetType = typeof(CheckBox))]
-				public static ResourceValue<Style> Default => new("CheckBoxStyle", false);
+				public static ResourceValue<Style> Default => new("CheckBoxStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "SecondaryCheckBoxStyle", TargetType = typeof(CheckBox))]
-				public static ResourceValue<Style> Secondary => new("SecondaryCheckBoxStyle", false);
+				public static ResourceValue<Style> Secondary => new("SecondaryCheckBoxStyle");
 			}
 
 			public static class ComboBox
 			{
 				[ResourceKeyDefinition(typeof(Style), "ComboBoxStyle", TargetType = typeof(ComboBox))]
-				public static ResourceValue<Style> Default => new("ComboBoxStyle", false);
+				public static ResourceValue<Style> Default => new("ComboBoxStyle");
 			}
 
 			public static class AppBarButton
 			{
 				[ResourceKeyDefinition(typeof(Style), "AppBarButtonStyle", TargetType = typeof(AppBarButton))]
-				public static ResourceValue<Style> Default => new("AppBarButtonStyle", false);
+				public static ResourceValue<Style> Default => new("AppBarButtonStyle");
 			}
 
 			public static class CommandBar
 			{
 				[ResourceKeyDefinition(typeof(Style), "CommandBarStyle", TargetType = typeof(CommandBar))]
-				public static ResourceValue<Style> Default => new("CommandBarStyle", false);
+				public static ResourceValue<Style> Default => new("CommandBarStyle");
 			}
 
 			public static class ContentDialog
 			{
 				[ResourceKeyDefinition(typeof(Style), "ContentDialogStyle", TargetType = typeof(ContentDialog))]
-				public static ResourceValue<Style> Default => new("ContentDialogStyle", false);
+				public static ResourceValue<Style> Default => new("ContentDialogStyle");
 			}
 
 			public static class DatePicker
 			{
 				[ResourceKeyDefinition(typeof(Style), "DatePickerStyle", TargetType = typeof(DatePicker))]
-				public static ResourceValue<Style> Default => new("DatePickerStyle", false);
+				public static ResourceValue<Style> Default => new("DatePickerStyle");
 			}
 
 			public static class FlyoutPresenter
 			{
 				[ResourceKeyDefinition(typeof(Style), "FlyoutPresenterStyle", TargetType = typeof(FlyoutPresenter))]
-				public static ResourceValue<Style> Default => new("FlyoutPresenterStyle", false);
+				public static ResourceValue<Style> Default => new("FlyoutPresenterStyle");
 			}
 
 			public static class MenuFlyoutPresenter
 			{
 				[ResourceKeyDefinition(typeof(Style), "MenuFlyoutPresenterStyle", TargetType = typeof(MenuFlyoutPresenter))]
-				public static ResourceValue<Style> Default => new("MenuFlyoutPresenterStyle", false);
+				public static ResourceValue<Style> Default => new("MenuFlyoutPresenterStyle");
 			}
 
 			public static class HyperlinkButton
 			{
 				[ResourceKeyDefinition(typeof(Style), "HyperlinkButtonStyle", TargetType = typeof(HyperlinkButton))]
-				public static ResourceValue<Style> Default => new("HyperlinkButtonStyle", false);
+				public static ResourceValue<Style> Default => new("HyperlinkButtonStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "SecondaryHyperlinkButtonStyle", TargetType = typeof(HyperlinkButton))]
-				public static ResourceValue<Style> Secondary => new("SecondaryHyperlinkButtonStyle", false);
+				public static ResourceValue<Style> Secondary => new("SecondaryHyperlinkButtonStyle");
 			}
 
 			public static class ListViewItem
 			{
 				[ResourceKeyDefinition(typeof(Style), "ListViewItemStyle", TargetType = typeof(ListViewItem))]
-				public static ResourceValue<Style> Default => new("ListViewItemStyle", false);
+				public static ResourceValue<Style> Default => new("ListViewItemStyle");
 			}
 
 			public static class ListView
 			{
 				[ResourceKeyDefinition(typeof(Style), "ListViewStyle", TargetType = typeof(ListView))]
-				public static ResourceValue<Style> Default => new("ListViewStyle", false);
+				public static ResourceValue<Style> Default => new("ListViewStyle");
 			}
 
 			public static class NavigationView
 			{
 				[ResourceKeyDefinition(typeof(Style), "NavigationViewStyle", TargetType = typeof(NavigationView))]
-				public static ResourceValue<Style> Default => new("NavigationViewStyle", false);
+				public static ResourceValue<Style> Default => new("NavigationViewStyle");
 			}
 
 			public static class NavigationViewItem
 			{
 				[ResourceKeyDefinition(typeof(Style), "NavigationViewItemStyle", TargetType = typeof(NavigationViewItem))]
-				public static ResourceValue<Style> Default => new("NavigationViewItemStyle", false);
+				public static ResourceValue<Style> Default => new("NavigationViewItemStyle");
 			}
 
 			public static class PasswordBox
 			{
 				[ResourceKeyDefinition(typeof(Style), "FilledPasswordBoxStyle", TargetType = typeof(PasswordBox))]
-				public static ResourceValue<Style> Filled => new("FilledPasswordBoxStyle", false);
+				public static ResourceValue<Style> Filled => new("FilledPasswordBoxStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "OutlinedPasswordBoxStyle", TargetType = typeof(PasswordBox))]
-				public static ResourceValue<Style> Outlined => new("OutlinedPasswordBoxStyle", false);
+				public static ResourceValue<Style> Outlined => new("OutlinedPasswordBoxStyle");
 			}
 
 			public static class ProgressBar
 			{
 				[ResourceKeyDefinition(typeof(Style), "ProgressBarStyle", TargetType = typeof(ProgressBar))]
-				public static ResourceValue<Style> Default => new("ProgressBarStyle", false);
+				public static ResourceValue<Style> Default => new("ProgressBarStyle");
 			}
 
 			public static class ProgressRing
 			{
 				[ResourceKeyDefinition(typeof(Style), "ProgressRingStyle", TargetType = typeof(ProgressRing))]
-				public static ResourceValue<Style> Default => new("ProgressRingStyle", false);
+				public static ResourceValue<Style> Default => new("ProgressRingStyle");
 			}
 
 			public static class RadioButton
 			{
 				[ResourceKeyDefinition(typeof(Style), "RadioButtonStyle", TargetType = typeof(RadioButton))]
-				public static ResourceValue<Style> Default => new("RadioButtonStyle", false);
+				public static ResourceValue<Style> Default => new("RadioButtonStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "SecondaryRadioButtonStyle", TargetType = typeof(RadioButton))]
-				public static ResourceValue<Style> Secondary => new("SecondaryRadioButtonStyle", false);
+				public static ResourceValue<Style> Secondary => new("SecondaryRadioButtonStyle");
 			}
 
 			public static class Slider
 			{
 				[ResourceKeyDefinition(typeof(Style), "SliderStyle", TargetType = typeof(Slider))]
-				public static ResourceValue<Style> Default => new("SliderStyle", false);
+				public static ResourceValue<Style> Default => new("SliderStyle");
 			}
 
 			public static class TextBlock
 			{
 				[ResourceKeyDefinition(typeof(Style), "DisplayLarge", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> DisplayLarge => new("DisplayLarge", false);
+				public static ResourceValue<Style> DisplayLarge => new("DisplayLarge");
 
 				[ResourceKeyDefinition(typeof(Style), "DisplayMedium", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> DisplayMedium => new("DisplayMedium", false);
+				public static ResourceValue<Style> DisplayMedium => new("DisplayMedium");
 
 				[ResourceKeyDefinition(typeof(Style), "DisplaySmall", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> DisplaySmall => new("DisplaySmall", false);
+				public static ResourceValue<Style> DisplaySmall => new("DisplaySmall");
 
 				[ResourceKeyDefinition(typeof(Style), "HeadlineLarge", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> HeadlineLarge => new("HeadlineLarge", false);
+				public static ResourceValue<Style> HeadlineLarge => new("HeadlineLarge");
 
 				[ResourceKeyDefinition(typeof(Style), "HeadlineMedium", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> HeadlineMedium => new("HeadlineMedium", false);
+				public static ResourceValue<Style> HeadlineMedium => new("HeadlineMedium");
 
 				[ResourceKeyDefinition(typeof(Style), "HeadlineSmall", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> HeadlineSmall => new("HeadlineSmall", false);
+				public static ResourceValue<Style> HeadlineSmall => new("HeadlineSmall");
 
 				[ResourceKeyDefinition(typeof(Style), "TitleLarge", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> TitleLarge => new("TitleLarge", false);
+				public static ResourceValue<Style> TitleLarge => new("TitleLarge");
 
 				[ResourceKeyDefinition(typeof(Style), "TitleMedium", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> TitleMedium => new("TitleMedium", false);
+				public static ResourceValue<Style> TitleMedium => new("TitleMedium");
 
 				[ResourceKeyDefinition(typeof(Style), "TitleSmall", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> TitleSmall => new("TitleSmall", false);
+				public static ResourceValue<Style> TitleSmall => new("TitleSmall");
 
 				[ResourceKeyDefinition(typeof(Style), "LabelLarge", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> LabelLarge => new("LabelLarge", false);
+				public static ResourceValue<Style> LabelLarge => new("LabelLarge");
 
 				[ResourceKeyDefinition(typeof(Style), "LabelMedium", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> LabelMedium => new("LabelMedium", false);
+				public static ResourceValue<Style> LabelMedium => new("LabelMedium");
 
 				[ResourceKeyDefinition(typeof(Style), "LabelSmall", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> LabelSmall => new("LabelSmall", false);
+				public static ResourceValue<Style> LabelSmall => new("LabelSmall");
 
 				[ResourceKeyDefinition(typeof(Style), "LabelExtraSmall", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> LabelExtraSmall => new("LabelExtraSmall", false);
+				public static ResourceValue<Style> LabelExtraSmall => new("LabelExtraSmall");
 
 				[ResourceKeyDefinition(typeof(Style), "BodyLarge", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> BodyLarge => new("BodyLarge", false);
+				public static ResourceValue<Style> BodyLarge => new("BodyLarge");
 
 				[ResourceKeyDefinition(typeof(Style), "BodyMedium", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> BodyMedium => new("BodyMedium", false);
+				public static ResourceValue<Style> BodyMedium => new("BodyMedium");
 
 				[ResourceKeyDefinition(typeof(Style), "BodySmall", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> BodySmall => new("BodySmall", false);
+				public static ResourceValue<Style> BodySmall => new("BodySmall");
 
 				[ResourceKeyDefinition(typeof(Style), "CaptionLarge", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> CaptionLarge => new("CaptionLarge", false);
+				public static ResourceValue<Style> CaptionLarge => new("CaptionLarge");
 
 				[ResourceKeyDefinition(typeof(Style), "CaptionMedium", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> CaptionMedium => new("CaptionMedium", false);
+				public static ResourceValue<Style> CaptionMedium => new("CaptionMedium");
 
 				[ResourceKeyDefinition(typeof(Style), "CaptionSmall", TargetType = typeof(TextBlock))]
-				public static ResourceValue<Style> CaptionSmall => new("CaptionSmall", false);
+				public static ResourceValue<Style> CaptionSmall => new("CaptionSmall");
 			}
 
 			public static class TextBox
 			{
 				[ResourceKeyDefinition(typeof(Style), "FilledTextBoxStyle", TargetType = typeof(TextBox))]
-				public static ResourceValue<Style> Filled => new("FilledTextBoxStyle", false);
+				public static ResourceValue<Style> Filled => new("FilledTextBoxStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "OutlinedTextBoxStyle", TargetType = typeof(TextBox))]
-				public static ResourceValue<Style> Outlined => new("OutlinedTextBoxStyle", false);
+				public static ResourceValue<Style> Outlined => new("OutlinedTextBoxStyle");
 			}
 
 			public static class ToggleButton
 			{
 				[ResourceKeyDefinition(typeof(Style), "TextToggleButtonStyle", TargetType = typeof(ToggleButton))]
-				public static ResourceValue<Style> Text => new("TextToggleButtonStyle", false);
+				public static ResourceValue<Style> Text => new("TextToggleButtonStyle");
 
 				[ResourceKeyDefinition(typeof(Style), "IconToggleButtonStyle", TargetType = typeof(ToggleButton))]
-				public static ResourceValue<Style> Icon => new("IconToggleButtonStyle", false);
+				public static ResourceValue<Style> Icon => new("IconToggleButtonStyle");
 			}
 
 			public static class ToggleSwitch
 			{
 				[ResourceKeyDefinition(typeof(Style), "ToggleSwitchStyle", TargetType = typeof(ToggleSwitch))]
-				public static ResourceValue<Style> Default => new("ToggleSwitchStyle", false);
+				public static ResourceValue<Style> Default => new("ToggleSwitchStyle");
 			}
 		}
 	}

--- a/src/library/Uno.Themes.WinUI.Markup/Theme.Styles.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme.Styles.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.MarkupHelpers;
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.MarkupHelpers.Internals;
 
 namespace Uno.Themes.Markup
 {
@@ -10,168 +9,275 @@ namespace Uno.Themes.Markup
 		{
 			public static class Button
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Elevated => StaticResource.Get<Style>("ElevatedButtonStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> Filled => StaticResource.Get<Style>("FilledButtonStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> FilledTonal => StaticResource.Get<Style>("FilledTonalButtonStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> Outlined => StaticResource.Get<Style>("OutlinedButtonStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> Text => StaticResource.Get<Style>("TextButtonStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> Icon => StaticResource.Get<Style>("IconButtonStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> Fab => StaticResource.Get<Style>("FabStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> SurfaceFab => StaticResource.Get<Style>("SurfaceFabStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> SecondaryFab => StaticResource.Get<Style>("SecondaryFabStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> TertiaryFab => StaticResource.Get<Style>("TertiaryFabStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> SmallFab => StaticResource.Get<Style>("SmallFabStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> SurfaceSmallFab => StaticResource.Get<Style>("SurfaceSmallFabStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> SecondarySmallFab => StaticResource.Get<Style>("SecondarySmallFabStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> TertiarySmallFab => StaticResource.Get<Style>("TertiarySmallFabStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> LargeFab => StaticResource.Get<Style>("LargeFabStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> SurfaceLargeFab => StaticResource.Get<Style>("SurfaceLargeFabStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> SecondaryLargeFab => StaticResource.Get<Style>("SecondaryLargeFabStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> TertiaryLargeFab => StaticResource.Get<Style>("TertiaryLargeFabStyle");
+				[ResourceKeyDefinition(typeof(Style), "ElevatedButtonStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> Elevated => new("ElevatedButtonStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "FilledButtonStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> Filled => new("FilledButtonStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "FilledTonalButtonStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> FilledTonal => new("FilledTonalButtonStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "OutlinedButtonStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> Outlined => new("OutlinedButtonStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "TextButtonStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> Text => new("TextButtonStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "IconButtonStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> Icon => new("IconButtonStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "FabStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> Fab => new("FabStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "SurfaceFabStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> SurfaceFab => new("SurfaceFabStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "SecondaryFabStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> SecondaryFab => new("SecondaryFabStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "TertiaryFabStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> TertiaryFab => new("TertiaryFabStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "SmallFabStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> SmallFab => new("SmallFabStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "SurfaceSmallFabStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> SurfaceSmallFab => new("SurfaceSmallFabStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "SecondarySmallFabStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> SecondarySmallFab => new("SecondarySmallFabStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "TertiarySmallFabStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> TertiarySmallFab => new("TertiarySmallFabStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "LargeFabStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> LargeFab => new("LargeFabStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "SurfaceLargeFabStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> SurfaceLargeFab => new("SurfaceLargeFabStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "SecondaryLargeFabStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> SecondaryLargeFab => new("SecondaryLargeFabStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "TertiaryLargeFabStyle", TargetType = typeof(Button))]
+				public static ResourceValue<Style> TertiaryLargeFab => new("TertiaryLargeFabStyle");
 			}
 
 			public static class CalendarDatePicker
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("CalendarDatePickerStyle");
+				[ResourceKeyDefinition(typeof(Style), "CalendarDatePickerStyle", TargetType = typeof(CalendarDatePicker))]
+				public static ResourceValue<Style> Default => new("CalendarDatePickerStyle");
 			}
 
 			public static class CalendarView
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("CalendarViewStyle");
+				[ResourceKeyDefinition(typeof(Style), "CalendarViewStyle", TargetType = typeof(CalendarView))]
+				public static ResourceValue<Style> Default => new("CalendarViewStyle");
 			}
 
 			public static class CheckBox
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("CheckBoxStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> Secondary => StaticResource.Get<Style>("SecondaryCheckBoxStyle");
+				[ResourceKeyDefinition(typeof(Style), "CheckBoxStyle", TargetType = typeof(CheckBox))]
+				public static ResourceValue<Style> Default => new("CheckBoxStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "SecondaryCheckBoxStyle", TargetType = typeof(CheckBox))]
+				public static ResourceValue<Style> Secondary => new("SecondaryCheckBoxStyle");
 			}
 
 			public static class ComboBox
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("ComboBoxStyle");
+				[ResourceKeyDefinition(typeof(Style), "ComboBoxStyle", TargetType = typeof(ComboBox))]
+				public static ResourceValue<Style> Default => new("ComboBoxStyle");
 			}
 
 			public static class AppBarButton
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("AppBarButtonStyle");
+				[ResourceKeyDefinition(typeof(Style), "AppBarButtonStyle", TargetType = typeof(AppBarButton))]
+				public static ResourceValue<Style> Default => new("AppBarButtonStyle");
 			}
 
 			public static class CommandBar
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("CommandBarStyle");
+				[ResourceKeyDefinition(typeof(Style), "CommandBarStyle", TargetType = typeof(CommandBar))]
+				public static ResourceValue<Style> Default => new("CommandBarStyle");
 			}
 
 			public static class ContentDialog
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("ContentDialogStyle");
+				[ResourceKeyDefinition(typeof(Style), "ContentDialogStyle", TargetType = typeof(ContentDialog))]
+				public static ResourceValue<Style> Default => new("ContentDialogStyle");
 			}
 
 			public static class DatePicker
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("DatePickerStyle");
+				[ResourceKeyDefinition(typeof(Style), "DatePickerStyle", TargetType = typeof(DatePicker))]
+				public static ResourceValue<Style> Default => new("DatePickerStyle");
 			}
 
 			public static class FlyoutPresenter
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("FlyoutPresenterStyle");
+				[ResourceKeyDefinition(typeof(Style), "FlyoutPresenterStyle", TargetType = typeof(FlyoutPresenter))]
+				public static ResourceValue<Style> Default => new("FlyoutPresenterStyle");
 			}
 
 			public static class MenuFlyoutPresenter
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("MenuFlyoutPresenterStyle");
+				[ResourceKeyDefinition(typeof(Style), "MenuFlyoutPresenterStyle", TargetType = typeof(MenuFlyoutPresenter))]
+				public static ResourceValue<Style> Default => new("MenuFlyoutPresenterStyle");
 			}
 
 			public static class HyperlinkButton
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("HyperlinkButtonStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> Secondary => StaticResource.Get<Style>("SecondaryHyperlinkButtonStyle");
+				[ResourceKeyDefinition(typeof(Style), "HyperlinkButtonStyle", TargetType = typeof(HyperlinkButton))]
+				public static ResourceValue<Style> Default => new("HyperlinkButtonStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "SecondaryHyperlinkButtonStyle", TargetType = typeof(HyperlinkButton))]
+				public static ResourceValue<Style> Secondary => new("SecondaryHyperlinkButtonStyle");
 			}
 
 			public static class ListViewItem
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("ListViewItemStyle");
+				[ResourceKeyDefinition(typeof(Style), "ListViewItemStyle", TargetType = typeof(ListViewItem))]
+				public static ResourceValue<Style> Default => new("ListViewItemStyle");
 			}
 
 			public static class ListView
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("ListViewStyle");
+				[ResourceKeyDefinition(typeof(Style), "ListViewStyle", TargetType = typeof(ListView))]
+				public static ResourceValue<Style> Default => new("ListViewStyle");
 			}
 
 			public static class NavigationView
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("NavigationViewStyle");
+				[ResourceKeyDefinition(typeof(Style), "NavigationViewStyle", TargetType = typeof(NavigationView))]
+				public static ResourceValue<Style> Default => new("NavigationViewStyle");
 			}
 
 			public static class NavigationViewItem
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("NavigationViewItemStyle");
+				[ResourceKeyDefinition(typeof(Style), "NavigationViewItemStyle", TargetType = typeof(NavigationViewItem))]
+				public static ResourceValue<Style> Default => new("NavigationViewItemStyle");
 			}
 
 			public static class PasswordBox
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Filled => StaticResource.Get<Style>("FilledPasswordBoxStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> Outlined => StaticResource.Get<Style>("OutlinedPasswordBoxStyle");
+				[ResourceKeyDefinition(typeof(Style), "FilledPasswordBoxStyle", TargetType = typeof(PasswordBox))]
+				public static ResourceValue<Style> Filled => new("FilledPasswordBoxStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "OutlinedPasswordBoxStyle", TargetType = typeof(PasswordBox))]
+				public static ResourceValue<Style> Outlined => new("OutlinedPasswordBoxStyle");
 			}
 
 			public static class ProgressBar
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("ProgressBarStyle");
+				[ResourceKeyDefinition(typeof(Style), "ProgressBarStyle", TargetType = typeof(ProgressBar))]
+				public static ResourceValue<Style> Default => new("ProgressBarStyle");
 			}
 
 			public static class ProgressRing
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("ProgressRingStyle");
+				[ResourceKeyDefinition(typeof(Style), "ProgressRingStyle", TargetType = typeof(ProgressRing))]
+				public static ResourceValue<Style> Default => new("ProgressRingStyle");
 			}
 
 			public static class RadioButton
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("RadioButtonStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> Secondary => StaticResource.Get<Style>("SecondaryRadioButtonStyle");
+				[ResourceKeyDefinition(typeof(Style), "RadioButtonStyle", TargetType = typeof(RadioButton))]
+				public static ResourceValue<Style> Default => new("RadioButtonStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "SecondaryRadioButtonStyle", TargetType = typeof(RadioButton))]
+				public static ResourceValue<Style> Secondary => new("SecondaryRadioButtonStyle");
 			}
 
 			public static class Slider
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("SliderStyle");
+				[ResourceKeyDefinition(typeof(Style), "SliderStyle", TargetType = typeof(Slider))]
+				public static ResourceValue<Style> Default => new("SliderStyle");
 			}
 
 			public static class TextBlock
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> DisplayLarge => StaticResource.Get<Style>("DisplayLarge");
-				public static Action<IDependencyPropertyBuilder<Style>> DisplayMedium => StaticResource.Get<Style>("DisplayMedium");
-				public static Action<IDependencyPropertyBuilder<Style>> DisplaySmall => StaticResource.Get<Style>("DisplaySmall");
-				public static Action<IDependencyPropertyBuilder<Style>> HeadlineLarge => StaticResource.Get<Style>("HeadlineLarge");
-				public static Action<IDependencyPropertyBuilder<Style>> HeadlineMedium => StaticResource.Get<Style>("HeadlineMedium");
-				public static Action<IDependencyPropertyBuilder<Style>> HeadlineSmall => StaticResource.Get<Style>("HeadlineSmall");
-				public static Action<IDependencyPropertyBuilder<Style>> TitleLarge => StaticResource.Get<Style>("TitleLarge");
-				public static Action<IDependencyPropertyBuilder<Style>> TitleMedium => StaticResource.Get<Style>("TitleMedium");
-				public static Action<IDependencyPropertyBuilder<Style>> TitleSmall => StaticResource.Get<Style>("TitleSmall");
-				public static Action<IDependencyPropertyBuilder<Style>> LabelLarge => StaticResource.Get<Style>("LabelLarge");
-				public static Action<IDependencyPropertyBuilder<Style>> LabelMedium => StaticResource.Get<Style>("LabelMedium");
-				public static Action<IDependencyPropertyBuilder<Style>> LabelSmall => StaticResource.Get<Style>("LabelSmall");
-				public static Action<IDependencyPropertyBuilder<Style>> LabelExtraSmall => StaticResource.Get<Style>("LabelExtraSmall");
-				public static Action<IDependencyPropertyBuilder<Style>> BodyLarge => StaticResource.Get<Style>("BodyLarge");
-				public static Action<IDependencyPropertyBuilder<Style>> BodyMedium => StaticResource.Get<Style>("BodyMedium");
-				public static Action<IDependencyPropertyBuilder<Style>> BodySmall => StaticResource.Get<Style>("BodySmall");
-				public static Action<IDependencyPropertyBuilder<Style>> CaptionLarge => StaticResource.Get<Style>("CaptionLarge");
-				public static Action<IDependencyPropertyBuilder<Style>> CaptionMedium => StaticResource.Get<Style>("CaptionMedium");
-				public static Action<IDependencyPropertyBuilder<Style>> CaptionSmall => StaticResource.Get<Style>("CaptionSmall");
+				[ResourceKeyDefinition(typeof(Style), "DisplayLarge", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> DisplayLarge => new("DisplayLarge");
+
+				[ResourceKeyDefinition(typeof(Style), "DisplayMedium", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> DisplayMedium => new("DisplayMedium");
+
+				[ResourceKeyDefinition(typeof(Style), "DisplaySmall", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> DisplaySmall => new("DisplaySmall");
+
+				[ResourceKeyDefinition(typeof(Style), "HeadlineLarge", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> HeadlineLarge => new("HeadlineLarge");
+
+				[ResourceKeyDefinition(typeof(Style), "HeadlineMedium", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> HeadlineMedium => new("HeadlineMedium");
+
+				[ResourceKeyDefinition(typeof(Style), "HeadlineSmall", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> HeadlineSmall => new("HeadlineSmall");
+
+				[ResourceKeyDefinition(typeof(Style), "TitleLarge", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> TitleLarge => new("TitleLarge");
+
+				[ResourceKeyDefinition(typeof(Style), "TitleMedium", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> TitleMedium => new("TitleMedium");
+
+				[ResourceKeyDefinition(typeof(Style), "TitleSmall", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> TitleSmall => new("TitleSmall");
+
+				[ResourceKeyDefinition(typeof(Style), "LabelLarge", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> LabelLarge => new("LabelLarge");
+
+				[ResourceKeyDefinition(typeof(Style), "LabelMedium", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> LabelMedium => new("LabelMedium");
+
+				[ResourceKeyDefinition(typeof(Style), "LabelSmall", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> LabelSmall => new("LabelSmall");
+
+				[ResourceKeyDefinition(typeof(Style), "LabelExtraSmall", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> LabelExtraSmall => new("LabelExtraSmall");
+
+				[ResourceKeyDefinition(typeof(Style), "BodyLarge", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> BodyLarge => new("BodyLarge");
+
+				[ResourceKeyDefinition(typeof(Style), "BodyMedium", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> BodyMedium => new("BodyMedium");
+
+				[ResourceKeyDefinition(typeof(Style), "BodySmall", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> BodySmall => new("BodySmall");
+
+				[ResourceKeyDefinition(typeof(Style), "CaptionLarge", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> CaptionLarge => new("CaptionLarge");
+
+				[ResourceKeyDefinition(typeof(Style), "CaptionMedium", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> CaptionMedium => new("CaptionMedium");
+
+				[ResourceKeyDefinition(typeof(Style), "CaptionSmall", TargetType = typeof(TextBlock))]
+				public static ResourceValue<Style> CaptionSmall => new("CaptionSmall");
 			}
 
 			public static class TextBox
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Filled => StaticResource.Get<Style>("FilledTextBoxStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> Outlined => StaticResource.Get<Style>("OutlinedTextBoxStyle");
+				[ResourceKeyDefinition(typeof(Style), "FilledTextBoxStyle", TargetType = typeof(TextBox))]
+				public static ResourceValue<Style> Filled => new("FilledTextBoxStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "OutlinedTextBoxStyle", TargetType = typeof(TextBox))]
+				public static ResourceValue<Style> Outlined => new("OutlinedTextBoxStyle");
 			}
 
 			public static class ToggleButton
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Text => StaticResource.Get<Style>("TextToggleButtonStyle");
-				public static Action<IDependencyPropertyBuilder<Style>> Icon => StaticResource.Get<Style>("IconToggleButtonStyle");
+				[ResourceKeyDefinition(typeof(Style), "TextToggleButtonStyle", TargetType = typeof(ToggleButton))]
+				public static ResourceValue<Style> Text => new("TextToggleButtonStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "IconToggleButtonStyle", TargetType = typeof(ToggleButton))]
+				public static ResourceValue<Style> Icon => new("IconToggleButtonStyle");
 			}
 
 			public static class ToggleSwitch
 			{
-				public static Action<IDependencyPropertyBuilder<Style>> Default => StaticResource.Get<Style>("ToggleSwitchStyle");
+				[ResourceKeyDefinition(typeof(Style), "ToggleSwitchStyle", TargetType = typeof(ToggleSwitch))]
+				public static ResourceValue<Style> Default => new("ToggleSwitchStyle");
 			}
 		}
 	}

--- a/src/library/Uno.Themes.WinUI.Markup/Uno.Themes.WinUI.Markup.csproj
+++ b/src/library/Uno.Themes.WinUI.Markup/Uno.Themes.WinUI.Markup.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.13" />
+		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.14" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.Contains('-windows10'))">


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Feature

## Description

Provide the full resource key as a string for whichever resource we are trying to build. This could be useful in cases where we may want to make use of [StaticResource.Get<T>(string key)]


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [x] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Internal Issue (If applicable):
[Theme Markup extensions should expose the resource key ](https://github.com/unoplatform/Uno.Themes/issues/887)
