### PR TITLE
MERGE Fix ToggleSwitch knob does not respect Foreground and Background property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<!--TODO restore-->
-		<UseWinUI Condition="'$(UseWinUI)'==''">true</UseWinUI>
+		<UseWinUI Condition="'$(UseWinUI)'==''">false</UseWinUI>
 
 		<!-- Required until xamarin targets are used (defined by MSBuild.SDK.Extras)-->
 		<DisableImplicitFrameworkDefines>false</DisableImplicitFrameworkDefines>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,8 @@
 		<PackageIcon>uno-logo.png</PackageIcon>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<UseWinUI Condition="'$(UseWinUI)'==''">false</UseWinUI>
+		<!--TODO restore-->
+		<UseWinUI Condition="'$(UseWinUI)'==''">true</UseWinUI>
 
 		<!-- Required until xamarin targets are used (defined by MSBuild.SDK.Extras)-->
 		<DisableImplicitFrameworkDefines>false</DisableImplicitFrameworkDefines>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,6 @@
 		<PackageIcon>uno-logo.png</PackageIcon>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<!--TODO restore-->
 		<UseWinUI Condition="'$(UseWinUI)'==''">false</UseWinUI>
 
 		<!-- Required until xamarin targets are used (defined by MSBuild.SDK.Extras)-->

--- a/src/library/Uno.Material/Styles/Controls/v2/ToggleSwitch.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ToggleSwitch.xaml
@@ -633,7 +633,7 @@
 							<BindableSwitchCompat Checked="{TemplateBinding IsOn, Mode=TwoWay}"
 												  Enabled="{TemplateBinding IsEnabled}"
 												  ThumbTint="{ThemeResource MaterialPrimaryVariantLowThumbColorBrush}"
-												  TrackTint="{ThemeResource MaterialToggleSwitchOnLowBackgroundBrush}" />
+												  TrackTint="{ThemeResource MaterialToggleSwitchOffLowBackgroundBrush}" />
 						</Grid>
 						<Grid Grid.Column="1"
 							  x:Name="SwitchGrid">

--- a/src/library/Uno.Material/Styles/Controls/v2/ToggleSwitch.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ToggleSwitch.xaml
@@ -641,7 +641,7 @@
 							<BindableSwitchCompat Checked="{TemplateBinding IsOn, Mode=TwoWay}"
 												  Enabled="{TemplateBinding IsEnabled}"
 												  ThumbTint="{ThemeResource MaterialPrimaryVariantLowThumbColorBrush}"
-												  TrackTint="{ThemeResource MaterialToggleSwitchOffLowBackgroundBrush}" />
+												  TrackTint="{ThemeResource MaterialToggleSwitchOnLowBackgroundBrush}" />
 						</Grid>
 						<Grid Grid.Column="1"
 							  x:Name="SwitchGrid">

--- a/src/library/Uno.Material/Styles/Controls/v2/ToggleSwitch.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ToggleSwitch.xaml
@@ -487,6 +487,8 @@
 				Value="Center" />
 		<Setter Property="Foreground"
 				Value="{ThemeResource MaterialToggleSwitchOnButtonBrush}" />
+		<Setter Property="Background"
+				Value="{StaticResource MaterialToggleSwitchOnBackgroundBrush}" />
 
 		<!-- microsoft/microsoft-ui-xaml#6157: reset min-width inherited from base style -->
 		<Setter Property="MinWidth"
@@ -533,6 +535,8 @@
 				Value="{ThemeResource MaterialRegularFontFamily}" />
 		<Setter Property="Foreground"
 				Value="{ThemeResource MaterialToggleSwitchOnButtonBrush}" />
+		<Setter Property="Background"
+				Value="{StaticResource MaterialToggleSwitchOnBackgroundBrush}" />
 		<Setter Property="HorizontalAlignment"
 				Value="Left" />
 		<Setter Property="HorizontalContentAlignment"
@@ -576,6 +580,8 @@
 									<VisualState.Setters>
 										<Setter Target="AndroidSwitch.TrackTint"
 												Value="{ThemeResource MaterialToggleSwitchOffBackgroundBrush}" />
+										<Setter Target="AndroidSwitch.ThumbTint"
+												Value="{ThemeResource MaterialToggleSwitchOffButtonBrush}" />
 										<Setter Target="OnDisabledGrid.Visibility"
 												Value="Collapsed" />
 										<Setter Target="OffDisabledGrid.Visibility"
@@ -586,7 +592,9 @@
 								<VisualState x:Name="On">
 									<VisualState.Setters>
 										<Setter Target="AndroidSwitch.TrackTint"
-												Value="{ThemeResource MaterialToggleSwitchOnBackgroundBrush}" />
+												Value="{TemplateBinding Background}" />
+										<Setter Target="AndroidSwitch.ThumbTint"
+												Value="{TemplateBinding Foreground}" />
 										<Setter Target="OnDisabledGrid.Visibility"
 												Value="Visible" />
 										<Setter Target="OffDisabledGrid.Visibility"

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ToggleSwitchSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ToggleSwitchSamplePage.xaml
@@ -151,31 +151,6 @@
 										  IsOn="True" />
 						</smtx:XamlDisplay>
 
-						<!-- ToggleSwitch ON change foreground -->
-						<smtx:XamlDisplay UniqueKey="M3_Material_ToggleSwitchSamplePage_OnTestForeground"
-										  Margin="12,0">
-							<ToggleSwitch Header="On change foreground"
-										  Foreground="Green"
-										  IsOn="True" />
-						</smtx:XamlDisplay>
-
-						<!-- ToggleSwitch ON test change background -->
-						<smtx:XamlDisplay UniqueKey="M3_Material_ToggleSwitchSamplePage_OnTestBackground"
-										  Margin="12,0">
-							<ToggleSwitch Header="On change Background"
-										  Background="Red"
-										  IsOn="True" />
-						</smtx:XamlDisplay>
-
-						<!-- ToggleSwitch ON test change both -->
-						<smtx:XamlDisplay UniqueKey="M3_Material_ToggleSwitchSamplePage_OnTestBoth"
-										  Margin="12,0">
-							<ToggleSwitch Header="Test change background and foreground"
-										  Background="Red"
-										  Foreground="Red"
-										  IsOn="True" />
-						</smtx:XamlDisplay>
-
 						<!-- Primary -->
 						<TextBlock Text="Others"
 								   Style="{StaticResource TitleSmall}"
@@ -194,6 +169,22 @@
 							<ToggleSwitch Header="HorizontalAlignment=Stretch"
 										  HorizontalAlignment="Stretch"
 										  Style="{StaticResource MaterialToggleSwitchStyle}" />
+
+							<!-- ToggleSwitch ON change foreground -->
+							<ToggleSwitch Header="On change foreground"
+										  Foreground="Green"
+										  IsOn="True" />
+
+							<!-- ToggleSwitch ON test change background -->
+							<ToggleSwitch Header="On change Background"
+										  Background="Red"
+										  IsOn="True" />
+
+							<!-- ToggleSwitch ON test change both -->
+							<ToggleSwitch Header="Test change background and foreground"
+										  Background="Red"
+										  Foreground="Red"
+										  IsOn="True" />
 						</StackPanel>
 					</StackPanel>
 				</DataTemplate>

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ToggleSwitchSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ToggleSwitchSamplePage.xaml
@@ -181,7 +181,7 @@
 										  IsOn="True" />
 
 							<!-- ToggleSwitch ON test change both -->
-							<ToggleSwitch Header="Test change background and foreground"
+							<ToggleSwitch Header="Change Background and Foreground"
 										  Background="Red"
 										  Foreground="Red"
 										  IsOn="True" />

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ToggleSwitchSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ToggleSwitchSamplePage.xaml
@@ -171,7 +171,7 @@
 										  Style="{StaticResource MaterialToggleSwitchStyle}" />
 
 							<!-- ToggleSwitch ON change foreground -->
-							<ToggleSwitch Header="On change foreground"
+							<ToggleSwitch Header="On change Foreground"
 										  Foreground="Green"
 										  IsOn="True" />
 

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ToggleSwitchSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/ToggleSwitchSamplePage.xaml
@@ -151,6 +151,31 @@
 										  IsOn="True" />
 						</smtx:XamlDisplay>
 
+						<!-- ToggleSwitch ON change foreground -->
+						<smtx:XamlDisplay UniqueKey="M3_Material_ToggleSwitchSamplePage_OnTestForeground"
+										  Margin="12,0">
+							<ToggleSwitch Header="On change foreground"
+										  Foreground="Green"
+										  IsOn="True" />
+						</smtx:XamlDisplay>
+
+						<!-- ToggleSwitch ON test change background -->
+						<smtx:XamlDisplay UniqueKey="M3_Material_ToggleSwitchSamplePage_OnTestBackground"
+										  Margin="12,0">
+							<ToggleSwitch Header="On change Background"
+										  Background="Red"
+										  IsOn="True" />
+						</smtx:XamlDisplay>
+
+						<!-- ToggleSwitch ON test change both -->
+						<smtx:XamlDisplay UniqueKey="M3_Material_ToggleSwitchSamplePage_OnTestBoth"
+										  Margin="12,0">
+							<ToggleSwitch Header="Test change background and foreground"
+										  Background="Red"
+										  Foreground="Red"
+										  IsOn="True" />
+						</smtx:XamlDisplay>
+
 						<!-- Primary -->
 						<TextBlock Text="Others"
 								   Style="{StaticResource TitleSmall}"


### PR DESCRIPTION
﻿GitHub Issue: 893

## PR Type

What kind of change does this PR introduce?
- Bugfix

## Description

Right now setting Foreground or Background of the ToggleSwitch should be reflected in the switch.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [x] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information

with this changes setting Background and Foreground be reflected in the switch

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
This is the [issue](https://github.com/unoplatform/Uno.Themes/issues/893 "Go to issue")