### PR TITLE
update markup libraries

### DIFF
--- a/src/library/Uno.Material.WinUI.Markup/AssemblyInfo.cs
+++ b/src/library/Uno.Material.WinUI.Markup/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-using Microsoft.UI.Xaml.Generator;
+using Uno.Extensions.Markup.Generator;
 
 [assembly: GenerateMarkupForAssembly(typeof(Uno.Material.MaterialResources))]
 [assembly: AssemblyMetadata("IsTrimmable", "True")]

--- a/src/library/Uno.Material.WinUI.Markup/MarkupInit.cs
+++ b/src/library/Uno.Material.WinUI.Markup/MarkupInit.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.UI.Xaml;
+using Uno.Extensions.Markup;
 
 namespace Uno.Material.WinUI.Markup
 {

--- a/src/library/Uno.Material.WinUI.Markup/MarkupInit.cs
+++ b/src/library/Uno.Material.WinUI.Markup/MarkupInit.cs
@@ -4,7 +4,7 @@ using System.Text;
 using Microsoft.UI.Xaml;
 using Uno.Extensions.Markup;
 
-namespace Uno.Material.WinUI.Markup
+namespace Uno.Material
 {
 	public static class MarkupInit
 	{

--- a/src/library/Uno.Material.WinUI.Markup/Uno.Material.WinUI.Markup.csproj
+++ b/src/library/Uno.Material.WinUI.Markup/Uno.Material.WinUI.Markup.csproj
@@ -19,7 +19,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.Extensions.Markup.Generators" PrivateAssets="All" Version="1.0.0-dev.150" />
+		<PackageReference Include="Uno.Extensions.Markup.Generators" PrivateAssets="All" Version="1.0.0-dev.166" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.Contains('-windows10'))">

--- a/src/library/Uno.Themes.WinUI.Markup/AssemblyInfo.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-using Microsoft.UI.Xaml.MarkupHelpers.Internals;
+using Uno.Extensions.Markup.Internals;
 
 [assembly: AssemblyMetadata("IsTrimmable", "True")]
 [assembly: ResourceDefinitionClass(typeof(Uno.Themes.Markup.Theme))]

--- a/src/library/Uno.Themes.WinUI.Markup/ResourceValue.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/ResourceValue.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.MarkupHelpers;
+using Uno.Extensions.Markup;
 
 
 namespace Uno.Themes.Markup

--- a/src/library/Uno.Themes.WinUI.Markup/Theme.Brushes.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme.Brushes.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.UI.Xaml.MarkupHelpers.Internals;
-using Microsoft.UI.Xaml.Media;
+﻿using Microsoft.UI.Xaml.Media;
+using Uno.Extensions.Markup.Internals;
 
 namespace Uno.Themes.Markup
 {

--- a/src/library/Uno.Themes.WinUI.Markup/Theme.Colors.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme.Colors.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml.MarkupHelpers.Internals;
+﻿using Uno.Extensions.Markup.Internals;
 using Windows.UI;
 
 namespace Uno.Themes.Markup

--- a/src/library/Uno.Themes.WinUI.Markup/Theme.Styles.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme.Styles.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.MarkupHelpers.Internals;
+using Uno.Extensions.Markup.Internals;
 
 namespace Uno.Themes.Markup
 {

--- a/src/library/Uno.Themes.WinUI.Markup/Uno.Themes.WinUI.Markup.csproj
+++ b/src/library/Uno.Themes.WinUI.Markup/Uno.Themes.WinUI.Markup.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.14" />
+		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.Contains('-windows10'))">


### PR DESCRIPTION
﻿GitHub Issue: n/a

## PR Type

What kind of change does this PR introduce?

- Other Update Markup Libraries

## Description

Updates Markup Generator and Uno.WinUI.Markup. The Markup Libraries have a breaking namespace change. This also updates the MarkupInit to be in the correct Uno.Material namespace as there should not have been an Uno.Material.WinUI.Markup namespace.