### PR TITLE
fix: Disable trimming on osx+mono combination

### DIFF
--- a/src/library/Uno.Cupertino/Uno.Cupertino.csproj
+++ b/src/library/Uno.Cupertino/Uno.Cupertino.csproj
@@ -9,7 +9,7 @@
 		<DebugType>portable</DebugType>
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 
-		<UnoXamlResourcesTrimming Condition="'$(Configuration)'=='Release'">true</UnoXamlResourcesTrimming>
+		<UnoXamlResourcesTrimming Condition="'$(Configuration)'=='Release' and !('$(MSBuildRuntimeType)'!='Core' and $([MSBuild]::IsOSPlatform('osx')))">true</UnoXamlResourcesTrimming>
 	</PropertyGroup>
 	
 	<PropertyGroup>


### PR DESCRIPTION
Disables trimming on OSX+Mono combination for test apps only to avoid:

```
/Users/runner/.nuget/packages/uno.ui/4.7.0-dev.900/buildTransitive/Uno.UI.Tasks.targets(156,3): error MSB4216: Could not run the "LinkerDefinitionMergerTask_v6233eb01169e7267991cb814d9262815cb867772" task because MSBuild could not create or connect to a task host with runtime "CLR4" and architecture "x64".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "/Applications/Visual Studio.app/Contents/MonoBundle/MSBuild/Current/bin/MSBuild.exe" exists and can be run. [/Users/runner/work/1/s/src/library/Uno.Cupertino/Uno.Cupertino.csproj]
```