### PR TITLE
feat: Add new MaterialTheme for simpler init

### DIFF
--- a/src/library/Uno.Material.WinUI.Markup/MarkupInit.cs
+++ b/src/library/Uno.Material.WinUI.Markup/MarkupInit.cs
@@ -11,14 +11,12 @@ namespace Uno.Material
 		public static T UseMaterial<T>(this T app,
 			ResourceDictionary colorOverride = null,
 			ResourceDictionary fontOverride = null) where T : Application
-		{
-			app.Resources(r => r.Merged(
-				colorOverride is { } ? new MaterialColors().OverrideDictionary(colorOverride) : new MaterialColors(),
-				fontOverride is { } ? new MaterialFonts().OverrideDictionary(fontOverride) : new MaterialFonts(),
-				new MaterialResources())
-			);
-
-			return app;
-		}
+			=> app.Resources(
+				r => r.Merged(
+					new MaterialTheme()
+						.ColorOverrideDictionary(colorOverride)
+						.FontOverrideDictionary(fontOverride)
+					)
+				);
 	}
 }

--- a/src/library/Uno.Material/MaterialColors.cs
+++ b/src/library/Uno.Material/MaterialColors.cs
@@ -1,4 +1,7 @@
-﻿namespace Uno.Material
+﻿using System;
+using Windows.Foundation.Metadata;
+
+namespace Uno.Material
 {
 	/// <summary>
 	/// Material resources for colors.
@@ -7,6 +10,7 @@
 	/// This class is like an alias for the latest version of MaterialColors,
 	/// which is currently pointing to <see cref="MaterialColorsV2"/>.
 	/// </remarks>
+	[Deprecated("Resource initialization for the Uno.Material theme should now be done using the MaterialTheme class instead.", DeprecationType.Deprecate, 3)]
 	public sealed partial class MaterialColors : MaterialColorsV2
 	{
 	}

--- a/src/library/Uno.Material/MaterialColorsV2.cs
+++ b/src/library/Uno.Material/MaterialColorsV2.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Windows.Foundation.Metadata;
 
 #if WinUI
 using Microsoft.UI.Xaml;
@@ -8,6 +9,7 @@ using Windows.UI.Xaml;
 
 namespace Uno.Material
 {
+	[Deprecated("Resource initialization for the Uno.Material theme should now be done using the MaterialTheme class instead.", DeprecationType.Deprecate, 3)]
 	public partial class MaterialColorsV2 : ResourceDictionary
 	{
 		private static ResourceDictionary ColorPaletteOverride;

--- a/src/library/Uno.Material/MaterialFonts.cs
+++ b/src/library/Uno.Material/MaterialFonts.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Windows.Foundation.Metadata;
 
 #if WinUI
 using Microsoft.UI.Xaml;
@@ -8,6 +9,7 @@ using Windows.UI.Xaml;
 
 namespace Uno.Material
 {
+	[Deprecated("Resource initialization for the Uno.Material theme should now be done using the MaterialTheme class instead.", DeprecationType.Deprecate, 3)]
 	public sealed partial class MaterialFonts : ResourceDictionary
 	{
 		private static ResourceDictionary FontOverride;

--- a/src/library/Uno.Material/MaterialResources.cs
+++ b/src/library/Uno.Material/MaterialResources.cs
@@ -1,4 +1,7 @@
-﻿namespace Uno.Material
+﻿using System;
+using Windows.Foundation.Metadata;
+
+namespace Uno.Material
 {
 	/// <summary>
 	/// Material resources including colors, layout values and styles
@@ -7,6 +10,7 @@
 	/// This class is like an alias for the latest version of MaterialResources,
 	/// which is currently pointing to <see cref="MaterialResourcesV2"/>.
 	/// </remarks>
+	[Deprecated("Resource initialization for the Uno.Material theme should now be done using the MaterialTheme class instead.", DeprecationType.Deprecate, 3)]
 	public sealed class MaterialResources : MaterialResourcesV2
 	{
 	}

--- a/src/library/Uno.Material/MaterialResourcesV2.cs
+++ b/src/library/Uno.Material/MaterialResourcesV2.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Uno.Material.Helpers;
+using Windows.Foundation.Metadata;
 
 #if WinUI
 using Microsoft.UI.Xaml;
@@ -18,11 +19,15 @@ namespace Uno.Material
 	/// <summary>
 	/// Material resources including colors, layout values and styles
 	/// </summary>
+	[Deprecated("Resource initialization for the Uno.Material theme should now be done using the MaterialTheme class instead.", DeprecationType.Deprecate, 3)]
 	public class MaterialResourcesV2 : ResourceDictionary
 	{
 		public MaterialResourcesV2()
 		{
 			Source = new Uri("ms-appx:///Uno.Material/Generated/mergedpages.v2.xaml");
+
+			MergedDictionaries.Add(new MaterialFonts());
+			MergedDictionaries.Add(new MaterialColorsV2());
 		}
 	}
 }

--- a/src/library/Uno.Material/MaterialTheme.cs
+++ b/src/library/Uno.Material/MaterialTheme.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Uno.Material.Helpers;
+
+#if WinUI
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Media;
+#else
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
+#endif
+
+namespace Uno.Material
+{
+	/// <summary>
+	/// Material Theme resources including colors, fonts, layout values, and styles
+	/// </summary>
+	public class MaterialTheme : ResourceDictionary
+	{
+		#region FontOverrideSource (DP)
+		/// <summary>
+		/// (Optional) Gets or sets a Uniform Resource Identifier (<see cref="Uri"/>) that provides the source location
+		/// of a <see cref="ResourceDictionary"/> containing overrides for the default Uno.Material <see cref="FontFamily"/> resources
+		/// </summary>
+		public string FontOverrideSource
+		{
+			get => (string)GetValue(FontOverrideSourceProperty);
+			set => SetValue(FontOverrideSourceProperty, value);
+		}
+
+		public static DependencyProperty FontOverrideSourceProperty { get; } =
+			DependencyProperty.Register(
+				nameof(FontOverrideSource),
+				typeof(string),
+				typeof(MaterialTheme),
+				new PropertyMetadata(null, OnFontOverrideSourceChanged));
+
+		private static void OnFontOverrideSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			if (d is MaterialTheme theme && e.NewValue is string sourceUri)
+			{
+				theme.FontOverrideDictionary = new ResourceDictionary() { Source = new Uri(sourceUri) };
+			}
+		}
+		#endregion
+
+		#region ColorOverrideSource (DP)
+		/// <summary>
+		/// (Optional) Gets or sets a Uniform Resource Identifier (<see cref="Uri"/>) that provides the source location
+		/// of a <see cref="ResourceDictionary"/> containing overrides for the default Uno.Material <see cref="Color"/> resources
+		/// </summary>
+		/// <remarks>The overrides set here should be re-defining the <see cref="Color"/> resources used by Uno.Material, not the <see cref="SolidColorBrush"/> resources</remarks>
+		public string ColorOverrideSource
+		{
+			get => (string)GetValue(ColorOverrideSourceProperty);
+			set => SetValue(ColorOverrideSourceProperty, value);
+		}
+
+		public static DependencyProperty ColorOverrideSourceProperty { get; } =
+			DependencyProperty.Register(
+				nameof(ColorOverrideSource),
+				typeof(string),
+				typeof(MaterialTheme),
+				new PropertyMetadata(null, OnColorOverrideSourceChanged));
+
+		private static void OnColorOverrideSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			if (d is MaterialTheme theme && e.NewValue is string sourceUri)
+			{
+				theme.ColorOverrideDictionary = new ResourceDictionary() { Source = new Uri(sourceUri) };
+			}
+		}
+		#endregion
+
+		#region FontOverrideDictionary (DP)
+		/// <summary>
+		/// (Optional) Gets or sets a <see cref="ResourceDictionary"/> containing overrides for the default Uno.Material <see cref="FontFamily"/> resources
+		/// </summary>
+		public ResourceDictionary FontOverrideDictionary
+		{
+			get => (ResourceDictionary)GetValue(FontOverrideDictionaryProperty);
+			set => SetValue(FontOverrideDictionaryProperty, value);
+		}
+
+		public static DependencyProperty FontOverrideDictionaryProperty { get; } =
+			DependencyProperty.Register(
+				nameof(FontOverrideDictionary),
+				typeof(ResourceDictionary),
+				typeof(MaterialTheme),
+				new PropertyMetadata(null, OnFontOverrideChanged));
+
+		private static void OnFontOverrideChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			if (d is MaterialTheme theme)
+			{
+				theme.UpdateSource();
+			}
+		}
+		#endregion
+
+		#region ColorOverrideDictionary (DP)
+		/// <summary>
+		/// (Optional) Gets or sets a <see cref="ResourceDictionary"/> containing overrides for the default Uno.Material <see cref="Color"/> resources
+		/// </summary>
+		/// <remarks>The overrides set here should be re-defining the <see cref="Color"/> resources used by Uno.Material, not the <see cref="SolidColorBrush"/> resources</remarks>
+		public ResourceDictionary ColorOverrideDictionary
+		{
+			get => (ResourceDictionary)GetValue(ColorOverrideDictionaryProperty);
+			set => SetValue(ColorOverrideDictionaryProperty, value);
+		}
+
+		public static DependencyProperty ColorOverrideDictionaryProperty { get; } =
+			DependencyProperty.Register(
+				nameof(ColorOverrideDictionary),
+				typeof(ResourceDictionary),
+				typeof(MaterialTheme),
+				new PropertyMetadata(null, OnColorOverrideChanged));
+
+		private static void OnColorOverrideChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			if (d is MaterialTheme theme)
+			{
+				theme.UpdateSource();
+			}
+		}
+		#endregion
+
+		public MaterialTheme()
+		{
+			UpdateSource();
+		}
+
+		private void UpdateSource()
+		{
+#if !HAS_UNO
+			Source = null;
+#endif
+			ThemeDictionaries.Clear();
+			MergedDictionaries.Clear();
+			this.Clear();
+
+			var colors = new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Material/Styles/Application/v2/SharedColors.xaml") };
+
+			colors.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Material/Styles/Application/v2/SharedColorPalette.xaml") });
+
+			if (ColorOverrideDictionary is { } colorOverride)
+			{
+				colors.SafeMerge(colorOverride);
+			}
+
+			var mergedPages = new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Material/Generated/mergedpages.v2.xaml") };
+
+			var fonts = new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Material/Styles/Application/Common/Fonts.xaml") };
+
+			if (FontOverrideDictionary is { } fontOverride)
+			{
+				fonts.SafeMerge(fontOverride);
+			}
+
+			mergedPages.MergedDictionaries.Add(colors);
+			mergedPages.MergedDictionaries.Add(fonts);
+
+			MergedDictionaries.Add(mergedPages);
+		}
+	}
+}

--- a/src/library/Uno.Material/MaterialTheme.cs
+++ b/src/library/Uno.Material/MaterialTheme.cs
@@ -25,6 +25,9 @@ namespace Uno.Material
 	/// </summary>
 	public class MaterialTheme : ResourceDictionary
 	{
+		private bool _isColorOverrideMuted;
+		private bool _isFontOverrideMuted;
+
 		#region FontOverrideSource (DP)
 		/// <summary>
 		/// (Optional) Gets or sets a Uniform Resource Identifier (<see cref="Uri"/>) that provides the source location
@@ -99,7 +102,7 @@ namespace Uno.Material
 
 		private static void OnFontOverrideChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
-			if (d is MaterialTheme theme)
+			if (d is MaterialTheme { _isFontOverrideMuted: false } theme)
 			{
 				theme.UpdateSource();
 			}
@@ -126,16 +129,57 @@ namespace Uno.Material
 
 		private static void OnColorOverrideChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
-			if (d is MaterialTheme theme)
+			if (d is MaterialTheme { _isColorOverrideMuted: false } theme)
 			{
 				theme.UpdateSource();
 			}
 		}
 		#endregion
 
-		public MaterialTheme()
+		public MaterialTheme() : this(colorOverride: null, fontOverride: null)
 		{
+			
+		}
+
+		public MaterialTheme(ResourceDictionary colorOverride = null, ResourceDictionary fontOverride = null)
+		{
+			if (colorOverride is { })
+			{
+				SetColorOverrideSilently(colorOverride);
+			}
+
+			if (fontOverride is { })
+			{
+				SetFontOverrideSilently(fontOverride);
+			}
+
 			UpdateSource();
+		}
+
+		private void SetColorOverrideSilently(ResourceDictionary colorOverride)
+		{
+			try
+			{
+				_isColorOverrideMuted = true;
+				ColorOverrideDictionary = colorOverride;
+			}
+			finally
+			{
+				_isColorOverrideMuted = false;
+			}
+		}
+
+		private void SetFontOverrideSilently(ResourceDictionary fontOverride)
+		{
+			try
+			{
+				_isFontOverrideMuted = true;
+				FontOverrideDictionary = fontOverride;
+			}
+			finally
+			{
+				_isFontOverrideMuted = false;
+			}
 		}
 
 		private void UpdateSource()

--- a/src/library/Uno.Material/Styles/Controls/v2/_Resources.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/_Resources.xaml
@@ -8,11 +8,6 @@
 					xmlns:not_win="http://uno.ui/not_win"
 					mc:Ignorable="d not_win">
 
-	<ResourceDictionary.MergedDictionaries>
-		<um:MaterialFonts />
-		<um:MaterialColorsV2 />
-	</ResourceDictionary.MergedDictionaries>
-
 	<!-- Implicit styles -->
 	<Style BasedOn="{StaticResource MaterialAppBarButtonStyle}" TargetType="AppBarButton" />
 	<Style BasedOn="{StaticResource MaterialBodyMedium}" TargetType="TextBlock" />

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/App.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/App.xaml
@@ -12,11 +12,11 @@
 				<MaterialFonts xmlns="using:Uno.Material" OverrideSource="ms-appx:///MaterialFontsOverride.xaml" />
 				<MaterialResourcesV1 xmlns="using:Uno.Material" />
 
-				<MaterialColorsV2 xmlns="using:Uno.Material" OverrideSource="ms-appx:///ColorPaletteOverride.xaml" />
-				<MaterialFonts xmlns="using:Uno.Material" OverrideSource="ms-appx:///MaterialFontsOverride.xaml" />
-				<MaterialResourcesV2 xmlns="using:Uno.Material" />
+				<MaterialTheme xmlns="using:Uno.Material"
+							   ColorOverrideSource="ms-appx:///ColorPaletteOverride.xaml"
+							   FontOverrideSource="ms-appx:///MaterialFontsOverride.xaml" />
 
-				<CupertinoColors xmlns="using:Uno.Cupertino" OverrideSource="ms-appx:///ColorPaletteOverride.xaml" />
+				<CupertinoColors xmlns="using:Uno.Cupertino"/>
 				<CupertinoFonts xmlns="using:Uno.Cupertino" OverrideSource="ms-appx:///CupertinoFontsOverride.xaml" />
 				<CupertinoResources xmlns="using:Uno.Cupertino" />
 


### PR DESCRIPTION
closes https://github.com/unoplatform/Uno.Themes/issues/822

## PR Type

What kind of change does this PR introduce?
- Feature


## Description

We can now init the Material resources, including the fonts and colors by doing this:

```xml
 <Application ...>
 	<Application.Resources>
 		<ResourceDictionary>
 			<ResourceDictionary.MergedDictionaries>

 				<!-- Load WinUI resources -->
 				<XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />

 				<!-- Load Uno.Material resources -->
				<MaterialTheme xmlns="using:Uno.Material"
							   ColorOverrideSource="ms-appx:///ColorPaletteOverride.xaml"
							   FontOverrideSource="ms-appx:///MaterialFontsOverride.xaml" />

 				<!-- Load custom application resources -->
 				<!-- ... -->

 			</ResourceDictionary.MergedDictionaries>
 		</ResourceDictionary>
 	</Application.Resources>
 </Application>
```

And for C# Markup:
```cs
		public static T UseMaterial<T>(this T app,
			ResourceDictionary colorOverride = null,
			ResourceDictionary fontOverride = null) where T : Application
			=> app.Resources(
				r => r.Merged(
					new MaterialTheme()
					.ColorOverrideDictionary(colorOverride)
					.FontOverrideDictionary(fontOverride)
					)
				);
```
