### PR TITLE
fix: Add workaround for Material CommandBar NavigationCommand extension

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/CommandBar.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/CommandBar.xaml
@@ -139,7 +139,10 @@
 
 		<Setter Property="OverflowButtonVisibility" Value="Collapsed" />
 		<Setter Property="IsDynamicOverflowEnabled" Value="False" />
-
+		
+		<!-- Workaround for WinUI issue: https://github.com/microsoft/microsoft-ui-xaml/issues/6388 -->
+		<Setter Property="toolkit:CommandBarExtensions.NavigationCommand" Value="{x:Null}" />
+		
 		<Setter Property="Template" Value="{StaticResource MaterialXamlCommandBarTemplate}" />
 	</Style>
 	<Style x:Key="MaterialCommandBarStyle"


### PR DESCRIPTION
closes https://github.com/unoplatform/Uno.Themes/issues/914

## PR Type

What kind of change does this PR introduce?
- Bugfix


## Description

Add [this workaround](https://github.com/microsoft/microsoft-ui-xaml/issues/6388) for the `CommandBarExtensions.MainCommand` attached property. Avoids a crash on WinUI
