### PR TITLE
fix: Removing framework references

### DIFF
--- a/src/library/Uno.Cupertino/Uno.Cupertino.csproj
+++ b/src/library/Uno.Cupertino/Uno.Cupertino.csproj
@@ -57,9 +57,7 @@
 				<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.37" Condition="!$(_IsWinUI)" />
 
 				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" Condition="$(_IsWinUI)" />
-
-				<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" Condition="$(_IsWinUI)" />
-				<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" Condition="$(_IsWinUI)" />
+				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" Condition="$(_IsWinUI)"/>
 			</ItemGroup>
 
 			<ItemGroup Condition="$(_IsWinUI)">

--- a/src/library/Uno.Material.WinUI.Markup/Uno.Material.WinUI.Markup.csproj
+++ b/src/library/Uno.Material.WinUI.Markup/Uno.Material.WinUI.Markup.csproj
@@ -22,11 +22,6 @@
 		<PackageReference Include="Uno.Extensions.Markup.Generators" PrivateAssets="All" Version="1.0.0-dev.166" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(_IsWinUI)">
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" />
-	</ItemGroup>
-
 	<PropertyGroup>
 		<PackageDescription>A set of C# for Markup helpers for Uno.Material.WinUI</PackageDescription>
 	</PropertyGroup>

--- a/src/library/Uno.Material/Uno.Material.csproj
+++ b/src/library/Uno.Material/Uno.Material.csproj
@@ -62,9 +62,7 @@
 				<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.37" Condition="!$(_IsWinUI)" />
 
 				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" Condition="$(_IsWinUI)" />
-
-				<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" Condition="$(_IsWinUI)" />
-				<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" Condition="$(_IsWinUI)" />
+				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" Condition="$(_IsWinUI)"/>
 			</ItemGroup>
 
 			<ItemGroup Condition="$(_IsWinUI)">

--- a/src/library/Uno.Themes.WinUI.Markup/Uno.Themes.WinUI.Markup.csproj
+++ b/src/library/Uno.Themes.WinUI.Markup/Uno.Themes.WinUI.Markup.csproj
@@ -18,11 +18,6 @@
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(_IsWinUI)">
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" />
-	</ItemGroup>
-
 	<PropertyGroup>
 		<PackageDescription>A base set of C# for Markup helpers that can be shared between all compatible Themes from Uno.Themes</PackageDescription>
 	</PropertyGroup>


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
- Bugfix

## Description

Referencing Material from WinUI project requires updating frameworkreference - this shouldn't be required

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
