### PR TITLE
fix: Reverting winappsdk version

### DIFF
--- a/src/library/Uno.Cupertino/Uno.Cupertino.csproj
+++ b/src/library/Uno.Cupertino/Uno.Cupertino.csproj
@@ -56,7 +56,7 @@
 
 				<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.37" Condition="!$(_IsWinUI)" />
 
-				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" Condition="$(_IsWinUI)" />
+				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.0" Condition="$(_IsWinUI)" />
 				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" Condition="$(_IsWinUI)"/>
 			</ItemGroup>
 

--- a/src/library/Uno.Material/Uno.Material.csproj
+++ b/src/library/Uno.Material/Uno.Material.csproj
@@ -61,7 +61,7 @@
 
 				<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.37" Condition="!$(_IsWinUI)" />
 
-				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" Condition="$(_IsWinUI)" />
+				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.0" Condition="$(_IsWinUI)" />
 				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" Condition="$(_IsWinUI)"/>
 			</ItemGroup>
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## Description

Unnecessary forcing to v1.2 of winappsdk. This PR reverts back to 1.1.0 whilst keeping latest build tools version

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
