### PR TITLE
fix(fontsweight): Fix LabelExtraSmallFontWeight should be "400", not 500

### DIFF
--- a/src/library/Uno.Material/Styles/Application/v2/Typography.xaml
+++ b/src/library/Uno.Material/Styles/Application/v2/Typography.xaml
@@ -89,7 +89,7 @@
 			<!--  Label ExtraSmall  -->
 			<!-- Text style added for Badges so it will match Uno figma file -->
 			<!-- Not part of Material M3. See https://github.com/unoplatform/Uno.Figma/issues/628 -->
-			<x:String x:Key="LabelExtraSmallFontWeight">Medium</x:String>
+			<x:String x:Key="LabelExtraSmallFontWeight">Normal</x:String>
 			<x:Double x:Key="LabelExtraSmallFontSize">11</x:Double>
 			<!--  Tracking: 0.1 px  -->
 			<x:Int32 x:Key="LabelExtraSmallCharacterSpacing">7</x:Int32>


### PR DESCRIPTION
# Bugfix

Fixes https://github.com/unoplatform/Uno.Figma/issues/1312

## Description
Following design requirements

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
