### PR TITLE
Add missing ResourceValues for C# Markup

### DIFF
--- a/src/library/Uno.Themes.WinUI.Markup/Theme.Colors.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme.Colors.cs
@@ -116,6 +116,9 @@ namespace Uno.Themes.Markup
 
 				[ResourceKeyDefinition(typeof(Color), "SurfaceInverseColor")]
 				public static ResourceValue<Color> Inverse => new("SurfaceInverseColor", true);
+
+				[ResourceKeyDefinition(typeof(Color), "SurfaceTintColor")]
+				public static ResourceValue<Color> Tint => new("SurfaceTintColor", true);
 			}
 
 			public static class OnSurface
@@ -134,6 +137,9 @@ namespace Uno.Themes.Markup
 			{
 				[ResourceKeyDefinition(typeof(Color), "OutlineColor")]
 				public static ResourceValue<Color> Default => new("OutlineColor", true);
+
+				[ResourceKeyDefinition(typeof(Color), "OutlineVariantColor")]
+				public static ResourceValue<Color> Variant => new ("OutlineVariantColor", true);
 			}
 
 		}


### PR DESCRIPTION
﻿GitHub Issue: #

- closes #970 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Adds missing Theme ResourceValues for Color Overrides

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
