### PR TITLE
refactor: Add lightweight styling resources for Material PasswordBox

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/PasswordBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/PasswordBox.xaml
@@ -7,7 +7,140 @@
 					xmlns:um="using:Uno.Material"
 					mc:Ignorable="ios macos">
 
-	<x:String x:Key="MaterialRevealGlyphPathData">M11 0.5C6 0.5 1.73 3.61 0 8C1.73 12.39 6 15.5 11 15.5C16 15.5 20.27 12.39 22 8C20.27 3.61 16 0.5 11 0.5ZM11 13C8.24 13 6 10.76 6 8C6 5.24 8.24 3 11 3C13.76 3 16 5.24 16 8C16 10.76 13.76 13 11 13ZM11 5C9.34 5 8 6.34 8 8C8 9.66 9.34 11 11 11C12.66 11 14 9.66 14 8C14 6.34 12.66 5 11 5Z</x:String>
+	<ResourceDictionary.ThemeDictionaries>
+		<ResourceDictionary x:Key="Default">
+			<!--#region MaterialRevealButtonStyle-->
+			<StaticResource x:Key="PasswordBoxRevealButtonForeground" ResourceKey="OnSurfaceVariantBrush" />
+			<!--#endregion-->
+
+			<!--#region MaterialFilledPasswordBoxStyle-->
+			<StaticResource x:Key="FilledPasswordBoxBackground" ResourceKey="SurfaceVariantBrush" />
+			<StaticResource x:Key="FilledPasswordBoxBackgroundPointerOver" ResourceKey="OnSurfaceVariantHoverBrush" />
+			<StaticResource x:Key="FilledPasswordBoxBackgroundFocused" ResourceKey="SurfaceVariantBrush" />
+			<StaticResource x:Key="FilledPasswordBoxBackgroundDisabled" ResourceKey="BackgroundDisabledLowBrush" />
+
+			<StaticResource x:Key="FilledPasswordBoxBorderBrush" ResourceKey="OnSurfaceVariantBrush" />
+			<StaticResource x:Key="FilledPasswordBoxBorderBrushPointerOver" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="FilledPasswordBoxBorderBrushFocused" ResourceKey="PrimaryBrush" />
+			<StaticResource x:Key="FilledPasswordBoxBorderBrushDisabled" ResourceKey="OnSurfaceDisabledLowBrush" />
+
+			<StaticResource x:Key="FilledPasswordBoxForeground" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="FilledPasswordBoxForegroundPointerOver" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="FilledPasswordBoxForegroundFocused" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="FilledPasswordBoxForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+
+			<StaticResource x:Key="FilledPasswordBoxPlaceholderForeground" ResourceKey="OnSurfaceVariantBrush" />
+			<StaticResource x:Key="FilledPasswordBoxPlaceholderForegroundPointerOver" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="FilledPasswordBoxPlaceholderForegroundFocused" ResourceKey="PrimaryBrush" />
+			<StaticResource x:Key="FilledPasswordBoxPlaceholderForegroundDisabled" ResourceKey="OnSurfaceLowBrush" />
+
+			<StaticResource x:Key="FilledPasswordBoxRevealButtonForeground" ResourceKey="OnSurfaceVariantBrush" />
+			<!--#endregion-->
+
+			<!--#region FilledPasswordBoxTypo-->
+			<StaticResource x:Key="FilledPasswordBoxFontFamily" ResourceKey="MaterialRegularFontFamily" />
+			<StaticResource x:Key="FilledPasswordBoxFontWeight" ResourceKey="BodyLargeFontWeight" />
+			<StaticResource x:Key="FilledPasswordBoxFontSize" ResourceKey="BodyLargeFontSize" />
+			<StaticResource x:Key="FilledPasswordBoxCharacterSpacing" ResourceKey="BodyLargeCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region MaterialOutlinedPasswordBoxStyle-->
+			<StaticResource x:Key="OutlinedPasswordBoxBackground" ResourceKey="TransparentBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxBackgroundPointerOver" ResourceKey="TransparentBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxBackgroundFocused" ResourceKey="TransparentBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxBackgroundDisabled" ResourceKey="TransparentBrush" />
+
+			<StaticResource x:Key="OutlinedPasswordBoxBorderBrush" ResourceKey="OutlineBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxBorderBrushPointerOver" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxBorderBrushFocused" ResourceKey="PrimaryBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxBorderBrushDisabled" ResourceKey="OnSurfaceDisabledLowBrush" />
+
+			<StaticResource x:Key="OutlinedPasswordBoxForeground" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxForegroundPointerOver" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxForegroundFocused" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+
+			<StaticResource x:Key="OutlinedPasswordBoxPlaceholderForeground" ResourceKey="OnSurfaceVariantBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxPlaceholderForegroundPointerOver" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxPlaceholderForegroundFocused" ResourceKey="PrimaryBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxPlaceholderForegroundDisabled" ResourceKey="OnSurfaceLowBrush" />
+			<!--#endregion-->
+
+			<!--#region OutlinedPasswordBoxTypo-->
+			<StaticResource x:Key="OutlinedPasswordBoxFontFamily" ResourceKey="MaterialRegularFontFamily" />
+			<StaticResource x:Key="OutlinedPasswordBoxFontWeight" ResourceKey="BodyLargeFontWeight" />
+			<StaticResource x:Key="OutlinedPasswordBoxFontSize" ResourceKey="BodyLargeFontSize" />
+			<StaticResource x:Key="OutlinedPasswordBoxCharacterSpacing" ResourceKey="BodyLargeCharacterSpacing" />
+			<!--#endregion-->
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Light">
+			<!--#region MaterialRevealButtonStyle-->
+			<StaticResource x:Key="PasswordBoxRevealButtonForeground" ResourceKey="OnSurfaceVariantBrush" />
+			<!--#endregion-->
+
+			<!--#region MaterialFilledPasswordBoxStyle-->
+			<StaticResource x:Key="FilledPasswordBoxBackground" ResourceKey="SurfaceVariantBrush" />
+			<StaticResource x:Key="FilledPasswordBoxBackgroundPointerOver" ResourceKey="OnSurfaceVariantHoverBrush" />
+			<StaticResource x:Key="FilledPasswordBoxBackgroundFocused" ResourceKey="SurfaceVariantBrush" />
+			<StaticResource x:Key="FilledPasswordBoxBackgroundDisabled" ResourceKey="BackgroundDisabledLowBrush" />
+
+			<StaticResource x:Key="FilledPasswordBoxBorderBrush" ResourceKey="OnSurfaceVariantBrush" />
+			<StaticResource x:Key="FilledPasswordBoxBorderBrushPointerOver" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="FilledPasswordBoxBorderBrushFocused" ResourceKey="PrimaryBrush" />
+			<StaticResource x:Key="FilledPasswordBoxBorderBrushDisabled" ResourceKey="OnSurfaceDisabledLowBrush" />
+
+			<StaticResource x:Key="FilledPasswordBoxForeground" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="FilledPasswordBoxForegroundPointerOver" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="FilledPasswordBoxForegroundFocused" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="FilledPasswordBoxForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+
+			<StaticResource x:Key="FilledPasswordBoxPlaceholderForeground" ResourceKey="OnSurfaceVariantBrush" />
+			<StaticResource x:Key="FilledPasswordBoxPlaceholderForegroundPointerOver" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="FilledPasswordBoxPlaceholderForegroundFocused" ResourceKey="PrimaryBrush" />
+			<StaticResource x:Key="FilledPasswordBoxPlaceholderForegroundDisabled" ResourceKey="OnSurfaceLowBrush" />
+
+			<StaticResource x:Key="FilledPasswordBoxRevealButtonForeground" ResourceKey="OnSurfaceVariantBrush" />
+			<!--#endregion-->
+
+			<!--#region FilledPasswordBoxTypo-->
+			<StaticResource x:Key="FilledPasswordBoxFontFamily" ResourceKey="MaterialRegularFontFamily" />
+			<StaticResource x:Key="FilledPasswordBoxFontWeight" ResourceKey="BodyLargeFontWeight" />
+			<StaticResource x:Key="FilledPasswordBoxFontSize" ResourceKey="BodyLargeFontSize" />
+			<StaticResource x:Key="FilledPasswordBoxCharacterSpacing" ResourceKey="BodyLargeCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region MaterialOutlinedPasswordBoxStyle-->
+			<StaticResource x:Key="OutlinedPasswordBoxBackground" ResourceKey="TransparentBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxBackgroundPointerOver" ResourceKey="TransparentBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxBackgroundFocused" ResourceKey="TransparentBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxBackgroundDisabled" ResourceKey="TransparentBrush" />
+
+			<StaticResource x:Key="OutlinedPasswordBoxBorderBrush" ResourceKey="OutlineBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxBorderBrushPointerOver" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxBorderBrushFocused" ResourceKey="PrimaryBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxBorderBrushDisabled" ResourceKey="OnSurfaceDisabledLowBrush" />
+
+			<StaticResource x:Key="OutlinedPasswordBoxForeground" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxForegroundPointerOver" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxForegroundFocused" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+
+			<StaticResource x:Key="OutlinedPasswordBoxPlaceholderForeground" ResourceKey="OnSurfaceVariantBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxPlaceholderForegroundPointerOver" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxPlaceholderForegroundFocused" ResourceKey="PrimaryBrush" />
+			<StaticResource x:Key="OutlinedPasswordBoxPlaceholderForegroundDisabled" ResourceKey="OnSurfaceLowBrush" />
+			<!--#endregion-->
+
+			<!--#region OutlinedPasswordBoxTypo-->
+			<StaticResource x:Key="OutlinedPasswordBoxFontFamily" ResourceKey="MaterialRegularFontFamily" />
+			<StaticResource x:Key="OutlinedPasswordBoxFontWeight" ResourceKey="BodyLargeFontWeight" />
+			<StaticResource x:Key="OutlinedPasswordBoxFontSize" ResourceKey="BodyLargeFontSize" />
+			<StaticResource x:Key="OutlinedPasswordBoxCharacterSpacing" ResourceKey="BodyLargeCharacterSpacing" />
+			<!--#endregion-->
+		</ResourceDictionary>
+	</ResourceDictionary.ThemeDictionaries>
+
+	<x:String x:Key="PasswordBoxRevealGlyphPathData">M11 0.5C6 0.5 1.73 3.61 0 8C1.73 12.39 6 15.5 11 15.5C16 15.5 20.27 12.39 22 8C20.27 3.61 16 0.5 11 0.5ZM11 13C8.24 13 6 10.76 6 8C6 5.24 8.24 3 11 3C13.76 3 16 5.24 16 8C16 10.76 13.76 13 11 13ZM11 5C9.34 5 8 6.34 8 8C8 9.66 9.34 11 11 11C12.66 11 14 9.66 14 8C14 6.34 12.66 5 11 5Z</x:String>
 
 	<SolidColorBrush x:Key="MaterialDisabledOutlinedPasswordBoxBorderBrush"
 					 Opacity="0.12"
@@ -15,8 +148,7 @@
 
 	<Style x:Key="MaterialRevealButtonStyle"
 		   TargetType="Button">
-		<Setter Property="Foreground"
-				Value="{ThemeResource OnSurfaceBrush}" />
+		<Setter Property="Foreground" Value="{ThemeResource PasswordBoxRevealButtonForeground}" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="Button">
@@ -30,8 +162,7 @@
 								<VisualState x:Name="Pressed" />
 								<VisualState x:Name="Disabled">
 									<VisualState.Setters>
-										<Setter Target="ButtonLayoutGrid.Opacity"
-												Value="0" />
+										<Setter Target="ButtonLayoutGrid.Opacity" Value="0" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -43,7 +174,7 @@
 							  VerticalAlignment="Center"
 							  ios:Margin="0,2,0,0"
 							  AutomationProperties.AccessibilityView="Raw"
-							  Data="{StaticResource MaterialRevealGlyphPathData}"
+							  Data="{StaticResource PasswordBoxRevealGlyphPathData}"
 							  Fill="{TemplateBinding Foreground}"
 							  Stretch="Uniform" />
 					</Grid>
@@ -54,27 +185,24 @@
 
 	<Style x:Key="MaterialFilledPasswordBoxStyle"
 		   TargetType="PasswordBox">
-		<Setter Property="Foreground"
-				Value="{ThemeResource OnSurfaceBrush}" />
-		<Setter Property="Background"
-				Value="{ThemeResource SurfaceVariantBrush}" />
-		<Setter Property="BorderBrush"
-				Value="{ThemeResource OnSurfaceLowBrush}" />
-		<Setter Property="HorizontalContentAlignment"
-				Value="Left" />
-		<Setter Property="VerticalContentAlignment"
-				Value="Center" />
-		<Setter Property="CornerRadius"
-				Value="4,4,0,0" />
+		<Setter Property="Foreground" Value="{ThemeResource FilledPasswordBoxForeground}" />
+		<Setter Property="Background" Value="{ThemeResource FilledPasswordBoxBackground}" />
+		<Setter Property="BorderBrush" Value="{ThemeResource FilledPasswordBoxBorderBrush}" />
+		<Setter Property="HorizontalContentAlignment" Value="Left" />
+		<Setter Property="VerticalContentAlignment" Value="Center" />
+		<Setter Property="CornerRadius" Value="4,4,0,0" />
+		<Setter Property="Padding" Value="16,4,8,4" />
+		<Setter Property="MinHeight" Value="58" />
 
-		<Setter Property="Padding"
-				Value="16,4,8,4" />
-		<Setter Property="MinHeight"
-				Value="58" />
+		<!-- Start: Body Large Typo -->
+		<Setter Property="FontFamily" Value="{ThemeResource FilledPasswordBoxFontFamily}" />
+		<Setter Property="FontWeight" Value="{ThemeResource FilledPasswordBoxFontWeight}" />
+		<Setter Property="FontSize" Value="{ThemeResource FilledPasswordBoxFontSize}" />
+		<Setter Property="CharacterSpacing" Value="{ThemeResource FilledPasswordBoxCharacterSpacing}" />
+		<!-- End: Body Large Typo -->
 
-		<!--  Workaround for WinUI issue: https://github.com/microsoft/microsoft-ui-xaml/issues/6388  -->
-		<Setter Property="um:ControlExtensions.Icon"
-				Value="{x:Null}" />
+		<!-- Workaround for WinUI issue: https://github.com/microsoft/microsoft-ui-xaml/issues/6388 -->
+		<Setter Property="um:ControlExtensions.Icon" Value="{x:Null}" />
 
 		<Setter Property="Template">
 			<Setter.Value>
@@ -89,10 +217,11 @@
 
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="NormalBorder.Fill"
-												Value="{ThemeResource OnSurfaceBrush}" />
-										<Setter Target="NormalBorder.Height"
-												Value="2" />
+										<Setter Target="NormalBorder.Fill" Value="{ThemeResource FilledPasswordBoxBorderBrushPointerOver}" />
+										<Setter Target="ContentElement.Foreground" Value="{ThemeResource FilledPasswordBoxForegroundPointerOver}" />
+										<Setter Target="PlaceholderElement.Foreground" Value="{ThemeResource FilledPasswordBoxPlaceholderForegroundPointerOver}" />
+										<Setter Target="Root.Background" Value="{ThemeResource FilledPasswordBoxBackgroundPointerOver}" />
+										<Setter Target="NormalBorder.Height" Value="2" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -100,25 +229,20 @@
 
 								<VisualState x:Name="Disabled">
 									<VisualState.Setters>
-										<Setter Target="NormalBorder.Fill"
-												Value="{ThemeResource OnSurfaceLowBrush}" />
-										<Setter Target="ContentElement.Opacity"
-												Value="{StaticResource DisabledOpacity}" />
-										<Setter Target="PlaceholderElement.Foreground"
-												Value="{ThemeResource OnSurfaceLowBrush}" />
-										<Setter Target="Root.Background"
-												Value="{ThemeResource OnSurfaceDisabledLowBrush}" />
+										<Setter Target="NormalBorder.Fill" Value="{ThemeResource FilledPasswordBoxBorderBrushDisabled}" />
+										<Setter Target="ContentElement.Foreground" Value="{ThemeResource FilledPasswordBoxForegroundDisabled}" />
+										<Setter Target="PlaceholderElement.Foreground" Value="{ThemeResource FilledPasswordBoxPlaceholderForegroundDisabled}" />
+										<Setter Target="Root.Background" Value="{ThemeResource FilledPasswordBoxBackgroundDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
 
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
-										<Setter Target="PlaceholderElement.Foreground"
-												Value="{ThemeResource PrimaryBrush}" />
-										<Setter Target="NormalBorder.Fill"
-												Value="{ThemeResource PrimaryBrush}" />
-										<Setter Target="NormalBorder.Height"
-												Value="2" />
+										<Setter Target="NormalBorder.Fill" Value="{ThemeResource FilledPasswordBoxBorderBrushFocused}" />
+										<Setter Target="ContentElement.Foreground" Value="{ThemeResource FilledPasswordBoxForegroundFocused}" />
+										<Setter Target="PlaceholderElement.Foreground" Value="{ThemeResource FilledPasswordBoxPlaceholderForegroundFocused}" />
+										<Setter Target="Root.Background" Value="{ThemeResource FilledPasswordBoxBackgroundFocused}" />
+										<Setter Target="NormalBorder.Height" Value="2" />
 									</VisualState.Setters>
 
 									<Storyboard>
@@ -135,8 +259,7 @@
 
 								<VisualState x:Name="ButtonVisible">
 									<VisualState.Setters>
-										<Setter Target="RevealButton.Visibility"
-												Value="Visible" />
+										<Setter Target="RevealButton.Visibility" Value="Visible" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -221,7 +344,7 @@
 									   Grid.Column="1"
 									   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 									   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-									   Foreground="{ThemeResource OnSurfaceVariantBrush}"
+									   Foreground="{ThemeResource FilledPasswordBoxPlaceholderForeground}"
 									   IsHitTestVisible="False"
 									   RenderTransformOrigin="0,0.5"
 									   Text="{TemplateBinding PlaceholderText}">
@@ -237,7 +360,7 @@
 									VerticalAlignment="Stretch"
 									AutomationProperties.AccessibilityView="Raw"
 									IsTabStop="False"
-									Foreground="{ThemeResource OnSurfaceVariantBrush}"
+									Foreground="{ThemeResource FilledPasswordBoxRevealButtonForeground}"
 									Style="{StaticResource MaterialRevealButtonStyle}"
 									Visibility="Collapsed" />
 						</Grid>
@@ -254,10 +377,9 @@
 								   VerticalAlignment="Bottom"
 								   macos:RenderTransformOrigin="0.0,0.5"
 								   not_macos:RenderTransformOrigin="0.5,0.5"
-								   Fill="{ThemeResource PrimaryBrush}">
+								   Fill="{ThemeResource FilledPasswordBoxBorderBrushFocused}">
 							<Rectangle.RenderTransform>
-								<ScaleTransform x:Name="Scale"
-												ScaleX="0" />
+								<ScaleTransform x:Name="Scale" ScaleX="0" />
 							</Rectangle.RenderTransform>
 						</Rectangle>
 					</Grid>
@@ -268,40 +390,25 @@
 
 	<Style x:Key="MaterialOutlinedPasswordBoxStyle"
 		   TargetType="PasswordBox">
-		<Setter Property="Background"
-				Value="Transparent" />
-		<Setter Property="Foreground"
-				Value="{ThemeResource OnSurfaceBrush}" />
-		<Setter Property="BorderBrush"
-				Value="{ThemeResource OnSurfaceLowBrush}" />
-		<Setter Property="BorderThickness"
-				Value="1" />
-		<Setter Property="CornerRadius"
-				Value="4" />
+		<Setter Property="Background" Value="{ThemeResource OutlinedPasswordBoxBackground}" />
+		<Setter Property="Foreground" Value="{ThemeResource OutlinedPasswordBoxForeground}" />
+		<Setter Property="BorderBrush" Value="{ThemeResource OutlinedPasswordBoxBorderBrush}" />
+		<Setter Property="BorderThickness" Value="1" />
+		<Setter Property="CornerRadius" Value="4" />
+		<Setter Property="HorizontalContentAlignment" Value="Left" />
+		<Setter Property="VerticalContentAlignment" Value="Center" />
+		<Setter Property="Padding" Value="16,4,8,4" />
+		<Setter Property="MinHeight" Value="56" />
 
 		<!-- Start: Body Large Typo -->
-		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialRegularFontFamily}" />
-		<Setter Property="FontWeight"
-				Value="{ThemeResource BodyLargeFontWeight}" />
-		<Setter Property="FontSize"
-				Value="{ThemeResource BodyLargeFontSize}" />
-		<Setter Property="CharacterSpacing"
-				Value="{ThemeResource BodyLargeCharacterSpacing}" />
+		<Setter Property="FontFamily" Value="{ThemeResource OutlinedPasswordBoxFontFamily}" />
+		<Setter Property="FontWeight" Value="{ThemeResource OutlinedPasswordBoxFontWeight}" />
+		<Setter Property="FontSize" Value="{ThemeResource OutlinedPasswordBoxFontSize}" />
+		<Setter Property="CharacterSpacing" Value="{ThemeResource OutlinedPasswordBoxCharacterSpacing}" />
 		<!-- End: Body Large Typo -->
 
-		<Setter Property="HorizontalContentAlignment"
-				Value="Left" />
-		<Setter Property="VerticalContentAlignment"
-				Value="Center" />
-		<Setter Property="Padding"
-				Value="16,4,8,4" />
-		<Setter Property="MinHeight"
-				Value="56" />
-
-		<!--  Workaround for WinUI issue: https://github.com/microsoft/microsoft-ui-xaml/issues/6388  -->
-		<Setter Property="um:ControlExtensions.Icon"
-				Value="{x:Null}" />
+		<!-- Workaround for WinUI issue: https://github.com/microsoft/microsoft-ui-xaml/issues/6388 -->
+		<Setter Property="um:ControlExtensions.Icon" Value="{x:Null}" />
 
 		<Setter Property="Template">
 			<Setter.Value>
@@ -318,12 +425,12 @@
 
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="RootBorder.BorderBrush"
-												Value="{ThemeResource OnSurfaceBrush}" />
-										<Setter Target="RootBorder.BorderThickness"
-												Value="2" />
-										<Setter Target="RootBorder.Padding"
-												Value="0" />
+										<Setter Target="RootBorder.BorderBrush" Value="{ThemeResource OutlinedPasswordBoxBorderBrushPointerOver}" />
+										<Setter Target="ContentElement.Foreground" Value="{ThemeResource OutlinedPasswordBoxForegroundPointerOver}" />
+										<Setter Target="PlaceholderElement.Foreground" Value="{ThemeResource OutlinedPasswordBoxPlaceholderForegroundPointerOver}" />
+										<Setter Target="Root.Background" Value="{ThemeResource OutlinedPasswordBoxBackgroundPointerOver}" />
+										<Setter Target="RootBorder.BorderThickness" Value="2" />
+										<Setter Target="RootBorder.Padding" Value="0" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -331,25 +438,21 @@
 
 								<VisualState x:Name="Disabled">
 									<VisualState.Setters>
-										<Setter Target="RootBorder.BorderBrush"
-												Value="{ThemeResource OnSurfaceDisabledLowBrush}" />
-										<Setter Target="ContentElement.Opacity"
-												Value="{StaticResource DisabledOpacity}" />
-										<Setter Target="PlaceholderElement.Foreground"
-												Value="{ThemeResource OnSurfaceLowBrush}" />
+										<Setter Target="RootBorder.BorderBrush" Value="{ThemeResource OutlinedPasswordBoxBorderBrushDisabled}" />
+										<Setter Target="ContentElement.Foreground" Value="{ThemeResource OutlinedPasswordBoxForegroundDisabled}" />
+										<Setter Target="PlaceholderElement.Foreground" Value="{ThemeResource OutlinedPasswordBoxPlaceholderForegroundDisabled}" />
+										<Setter Target="Root.Background" Value="{ThemeResource OutlinedPasswordBoxBackgroundDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
 
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
-										<Setter Target="RootBorder.BorderBrush"
-												Value="{ThemeResource PrimaryBrush}" />
-										<Setter Target="PlaceholderElement.Foreground"
-												Value="{ThemeResource PrimaryBrush}" />
-										<Setter Target="RootBorder.BorderThickness"
-												Value="2" />
-										<Setter Target="RootBorder.Padding"
-												Value="0" />
+										<Setter Target="RootBorder.BorderBrush" Value="{ThemeResource OutlinedPasswordBoxBorderBrushFocused}" />
+										<Setter Target="ContentElement.Foreground" Value="{ThemeResource OutlinedPasswordBoxForegroundFocused}" />
+										<Setter Target="PlaceholderElement.Foreground" Value="{ThemeResource OutlinedPasswordBoxPlaceholderForegroundFocused}" />
+										<Setter Target="Root.Background" Value="{ThemeResource OutlinedPasswordBoxBackgroundFocused}" />
+										<Setter Target="RootBorder.BorderThickness" Value="2" />
+										<Setter Target="RootBorder.Padding" Value="0" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -358,8 +461,7 @@
 
 								<VisualState x:Name="ButtonVisible">
 									<VisualState.Setters>
-										<Setter Target="RevealButton.Visibility"
-												Value="Visible" />
+										<Setter Target="RevealButton.Visibility" Value="Visible" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -446,7 +548,7 @@
 									   Grid.Column="1"
 									   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 									   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-									   Foreground="{ThemeResource OnSurfaceVariantBrush}"
+									   Foreground="{ThemeResource OutlinedPasswordBoxPlaceholderForeground}"
 									   IsHitTestVisible="False"
 									   RenderTransformOrigin="0,0.5"
 									   Text="{TemplateBinding PlaceholderText}">

--- a/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/PasswordBoxSamplePage.xaml
+++ b/src/samples/Uno.Themes.Samples/Uno.Themes.Samples.Shared/Content/Controls/PasswordBoxSamplePage.xaml
@@ -71,7 +71,7 @@
 						<smtx:XamlDisplay UniqueKey="Material_PasswordBoxSamplePage_7"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<PasswordBox PlaceholderText="Filled with Icon"
-									 Style="{StaticResource MaterialFilledPasswordBoxStyle}">
+										 Style="{StaticResource MaterialFilledPasswordBoxStyle}">
 								<um:ControlExtensions.Icon>
 									<SymbolIcon Symbol="Favorite" />
 								</um:ControlExtensions.Icon>
@@ -82,7 +82,7 @@
 						<smtx:XamlDisplay UniqueKey="Material_PasswordBoxSamplePage_8"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<PasswordBox PlaceholderText="Filled with Icon"
-									 Style="{StaticResource MaterialOutlinedPasswordBoxStyle}">
+										 Style="{StaticResource MaterialOutlinedPasswordBoxStyle}">
 								<um:ControlExtensions.Icon>
 									<SymbolIcon Symbol="Favorite" />
 								</um:ControlExtensions.Icon>
@@ -96,39 +96,30 @@
 				<DataTemplate>
 					<StackPanel>
 
-						<!-- Default -->
+						<!-- PasswordBox Filled -->
 						<smtx:XamlDisplay UniqueKey="Material_M3_PasswordBoxSamplePage_1"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<PasswordBox PlaceholderText="Filled"
 										 Style="{StaticResource MaterialFilledPasswordBoxStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- PasswordBox With Header -->
+						<!-- PasswordBox Filled Disabled -->
 						<smtx:XamlDisplay UniqueKey="Material_M3_PasswordBoxSamplePage_2"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<PasswordBox PlaceholderText="Filled"
-										 Header="Header"
-										 Style="{StaticResource MaterialFilledPasswordBoxStyle}" />
-						</smtx:XamlDisplay>
-
-						<!-- PasswordBox Disabled -->
-						<smtx:XamlDisplay UniqueKey="Material_M3_PasswordBoxSamplePage_3"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<PasswordBox PlaceholderText="Disabled"
+							<PasswordBox PlaceholderText="Filled Disabled"
 										 Style="{StaticResource MaterialFilledPasswordBoxStyle}"
 										 IsEnabled="False" />
 						</smtx:XamlDisplay>
 
 						<!-- PasswordBox Outline -->
-						<smtx:XamlDisplay UniqueKey="Material_M3_PasswordBoxSamplePage_4"
+						<smtx:XamlDisplay UniqueKey="Material_M3_PasswordBoxSamplePage_3"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<PasswordBox PlaceholderText="Outlined"
-										 Header="Header"
 										 Style="{StaticResource MaterialOutlinedPasswordBoxStyle}" />
 						</smtx:XamlDisplay>
 
 						<!-- PasswordBox Outline Disabled -->
-						<smtx:XamlDisplay UniqueKey="Material_M3_PasswordBoxSamplePage_5"
+						<smtx:XamlDisplay UniqueKey="Material_M3_PasswordBoxSamplePage_4"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<PasswordBox PlaceholderText="Outlined Disabled"
 										 Style="{StaticResource MaterialOutlinedPasswordBoxStyle}"


### PR DESCRIPTION
﻿GitHub Issue: #

closes #989 

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Refactoring (no functional changes, no api changes)

## Description

<!-- (Please describe the changes that this PR introduces.) -->

Applies lightweight styling to the PasswordBox control.
![image](https://github.com/unoplatform/Uno.Themes/assets/10283398/756a608a-6038-4adc-9762-68151eb675fa)
![image](https://github.com/unoplatform/Uno.Themes/assets/10283398/b8249ace-3081-4f7b-8e98-e83763e3db01)

Locally overridden with
![image](https://github.com/unoplatform/Uno.Themes/assets/10283398/ae2c7715-75fe-4012-a498-e535e112cd78)
![image](https://github.com/unoplatform/Uno.Themes/assets/10283398/b6aee067-09bd-45c9-8652-e259fbdbfb6b)


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [ ] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
