### PR TITLE
refactor(textblock): Add the Lightweight Styling TextBlock Style

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/TextBlock.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/TextBlock.xaml
@@ -1,6 +1,280 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
+	<ResourceDictionary.ThemeDictionaries>
+		<ResourceDictionary x:Key="Default">
+			<!--#region Base Style-->
+			<StaticResource x:Key="BaseTextBlockFontFamily" ResourceKey="MaterialRegularFontFamily" />
+			<!--#endregion-->
+
+			<!--DISPLAY-->
+
+			<!--#region Display Large-->
+			<StaticResource x:Key="DisplayLargeTextBlockFontWeight" ResourceKey="DisplayLargeFontWeight" />
+			<StaticResource x:Key="DisplayLargeTextBlockFontSize" ResourceKey="DisplayLargeFontSize" />
+			<StaticResource x:Key="DisplayLargeTextBlockCharacterSpacing" ResourceKey="DisplayLargeCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Display Medium-->
+			<StaticResource x:Key="DisplayMediumTextBlockFontWeight" ResourceKey="DisplayMediumFontWeight" />
+			<StaticResource x:Key="DisplayMediumTextBlockFontSize" ResourceKey="DisplayMediumFontSize" />
+			<!--#endregion-->
+
+			<!--#region Display Small-->
+			<StaticResource x:Key="DisplaySmallTextBlockFontWeight" ResourceKey="DisplaySmallFontWeight" />
+			<StaticResource x:Key="DisplaySmallTextBlockFontSize" ResourceKey="DisplaySmallFontSize" />
+			<!--#endregion-->
+
+			<!--HEADLINE-->
+
+			<!--#region Headline Large-->
+			<StaticResource x:Key="HeadlineLargeTextBlockFontWeight" ResourceKey="HeadlineLargeFontWeight" />
+			<StaticResource x:Key="HeadlineLargeTextBlockFontSize" ResourceKey="HeadlineLargeFontSize" />
+			<!--#endregion-->
+
+			<!--#region Headline Medium-->
+			<StaticResource x:Key="HeadlineMediumTextBlockFontWeight" ResourceKey="HeadlineMediumFontWeight" />
+			<StaticResource x:Key="HeadlineMediumTextBlockFontSize" ResourceKey="HeadlineMediumFontSize" />
+			<!--#endregion-->
+
+			<!--#region Headline Small-->
+			<StaticResource x:Key="HeadlineSmallTextBlockFontWeight" ResourceKey="HeadlineSmallFontWeight" />
+			<StaticResource x:Key="HeadlineSmallTextBlockFontSize" ResourceKey="HeadlineSmallFontSize" />
+			<!--#endregion-->
+
+			<!--TITLE-->
+
+			<!--#region Title Large-->
+			<StaticResource x:Key="TitleLargeTextBlockFontWeight" ResourceKey="TitleLargeFontWeight" />
+			<StaticResource x:Key="TitleLargeTextBlockFontSize" ResourceKey="TitleLargeFontSize" />
+			<!--#endregion-->
+
+			<!--#region Title Medium-->
+			<StaticResource x:Key="TitleMediumTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="TitleMediumTextBlockFontWeight" ResourceKey="TitleMediumFontWeight" />
+			<StaticResource x:Key="TitleMediumTextBlockFontSize" ResourceKey="TitleMediumFontSize" />
+			<!--#endregion-->
+
+			<!--#region Title Small-->
+			<StaticResource x:Key="TitleSmallTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="TitleSmallTextBlockFontWeight" ResourceKey="TitleSmallFontWeight" />
+			<StaticResource x:Key="TitleSmallTextBlockFontSize" ResourceKey="TitleSmallFontSize" />
+			<!--#endregion-->
+
+			<!--LABEL-->
+
+			<!--#region Label Large-->
+			<StaticResource x:Key="LabelLargeTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="LabelLargeTextBlockFontWeight" ResourceKey="LabelLargeFontWeight" />
+			<StaticResource x:Key="LabelLargeTextBlockFontSize" ResourceKey="LabelLargeFontSize" />
+			<StaticResource x:Key="LabelLargeTextBlockCharacterSpacing" ResourceKey="LabelLargeCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Label Medium-->
+			<StaticResource x:Key="LabelMediumTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="LabelMediumTextBlockFontWeight" ResourceKey="LabelMediumFontWeight" />
+			<StaticResource x:Key="LabelMediumTextBlockFontSize" ResourceKey="LabelMediumFontSize" />
+			<StaticResource x:Key="LabelMediumTextBlockCharacterSpacing" ResourceKey="LabelMediumCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Label Small-->
+			<StaticResource x:Key="LabelSmallTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="LabelSmallTextBlockFontWeight" ResourceKey="LabelSmallFontWeight" />
+			<StaticResource x:Key="LabelSmallTextBlockFontSize" ResourceKey="LabelSmallFontSize" />
+			<StaticResource x:Key="LabelSmallTextBlockCharacterSpacing" ResourceKey="LabelSmallCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Label X-Small-->
+			<StaticResource x:Key="LabelExtraSmallTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="LabelExtraSmallTextBlockFontWeight" ResourceKey="LabelExtraSmallFontWeight" />
+			<StaticResource x:Key="LabelExtraSmallTextBlockFontSize" ResourceKey="LabelExtraSmallFontSize" />
+			<StaticResource x:Key="LabelExtraSmallTextBlockCharacterSpacing" ResourceKey="LabelExtraSmallCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--BODY-->
+
+			<!--#region Body Large-->
+			<StaticResource x:Key="BodyLargeTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="BodyLargeTextBlockFontWeight" ResourceKey="BodyLargeFontWeight" />
+			<StaticResource x:Key="BodyLargeTextBlockFontSize" ResourceKey="BodyLargeFontSize" />
+			<StaticResource x:Key="BodyLargeTextBlockCharacterSpacing" ResourceKey="BodyLargeCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Body Medium-->
+			<StaticResource x:Key="BodyMediumTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="BodyMediumTextBlockFontWeight" ResourceKey="BodyMediumFontWeight" />
+			<StaticResource x:Key="BodyMediumTextBlockFontSize" ResourceKey="BodyMediumFontSize" />
+			<StaticResource x:Key="BodyMediumTextBlockCharacterSpacing" ResourceKey="BodyMediumCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Body Small-->
+			<StaticResource x:Key="BodySmallTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="BodySmallTextBlockFontWeight" ResourceKey="BodySmallFontWeight" />
+			<StaticResource x:Key="BodySmallTextBlockFontSize" ResourceKey="BodySmallFontSize" />
+			<StaticResource x:Key="BodySmallTextBlockCharacterSpacing" ResourceKey="BodySmallCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--CAPTION-->
+
+			<!--#region Caption Large-->
+			<StaticResource x:Key="CaptionLargeTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="CaptionLargeTextBlockFontWeight" ResourceKey="CaptionLargeFontWeight" />
+			<StaticResource x:Key="CaptionLargeTextBlockFontSize" ResourceKey="CaptionLargeFontSize" />
+			<StaticResource x:Key="CaptionLargeTextBlockCharacterSpacing" ResourceKey="CaptionLargeCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Caption Medium-->
+			<StaticResource x:Key="CaptionMediumTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="CaptionMediumTextBlockFontWeight" ResourceKey="CaptionMediumFontWeight" />
+			<StaticResource x:Key="CaptionMediumTextBlockFontSize" ResourceKey="CaptionMediumFontSize" />
+			<StaticResource x:Key="CaptionMediumTextBlockCharacterSpacing" ResourceKey="CaptionMediumCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Caption Small-->
+			<StaticResource x:Key="CaptionSmallTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="CaptionSmallTextBlockFontWeight" ResourceKey="CaptionSmallFontWeight" />
+			<StaticResource x:Key="CaptionSmallTextBlockFontSize" ResourceKey="CaptionSmallFontSize" />
+			<StaticResource x:Key="CaptionSmallTextBlockCharacterSpacing" ResourceKey="CaptionSmallCharacterSpacing" />
+			<!--#endregion-->
+		</ResourceDictionary>
+
+		<ResourceDictionary x:Key="Light">
+			<!--#region Base Style-->
+			<StaticResource x:Key="BaseTextBlockFontFamily" ResourceKey="MaterialRegularFontFamily" />
+			<!--#endregion-->
+
+			<!--DISPLAY-->
+
+			<!--#region Display Large-->
+			<StaticResource x:Key="DisplayLargeTextBlockFontWeight" ResourceKey="DisplayLargeFontWeight" />
+			<StaticResource x:Key="DisplayLargeTextBlockFontSize" ResourceKey="DisplayLargeFontSize" />
+			<StaticResource x:Key="DisplayLargeTextBlockCharacterSpacing" ResourceKey="DisplayLargeCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Display Medium-->
+			<StaticResource x:Key="DisplayMediumTextBlockFontWeight" ResourceKey="DisplayMediumFontWeight" />
+			<StaticResource x:Key="DisplayMediumTextBlockFontSize" ResourceKey="DisplayMediumFontSize" />
+			<!--#endregion-->
+
+			<!--#region Display Small-->
+			<StaticResource x:Key="DisplaySmallTextBlockFontWeight" ResourceKey="DisplaySmallFontWeight" />
+			<StaticResource x:Key="DisplaySmallTextBlockFontSize" ResourceKey="DisplaySmallFontSize" />
+			<!--#endregion-->
+
+			<!--HEADLINE-->
+
+			<!--#region Headline Large-->
+			<StaticResource x:Key="HeadlineLargeTextBlockFontWeight" ResourceKey="HeadlineLargeFontWeight" />
+			<StaticResource x:Key="HeadlineLargeTextBlockFontSize" ResourceKey="HeadlineLargeFontSize" />
+			<!--#endregion-->
+
+			<!--#region Headline Medium-->
+			<StaticResource x:Key="HeadlineMediumTextBlockFontWeight" ResourceKey="HeadlineMediumFontWeight" />
+			<StaticResource x:Key="HeadlineMediumTextBlockFontSize" ResourceKey="HeadlineMediumFontSize" />
+			<!--#endregion-->
+
+			<!--#region Headline Small-->
+			<StaticResource x:Key="HeadlineSmallTextBlockFontWeight" ResourceKey="HeadlineSmallFontWeight" />
+			<StaticResource x:Key="HeadlineSmallTextBlockFontSize" ResourceKey="HeadlineSmallFontSize" />
+			<!--#endregion-->
+
+			<!--TITLE-->
+
+			<!--#region Title Large-->
+			<StaticResource x:Key="TitleLargeTextBlockFontWeight" ResourceKey="TitleLargeFontWeight" />
+			<StaticResource x:Key="TitleLargeTextBlockFontSize" ResourceKey="TitleLargeFontSize" />
+			<!--#endregion-->
+
+			<!--#region Title Medium-->
+			<StaticResource x:Key="TitleMediumTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="TitleMediumTextBlockFontWeight" ResourceKey="TitleMediumFontWeight" />
+			<StaticResource x:Key="TitleMediumTextBlockFontSize" ResourceKey="TitleMediumFontSize" />
+			<!--#endregion-->
+
+			<!--#region Title Small-->
+			<StaticResource x:Key="TitleSmallTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="TitleSmallTextBlockFontWeight" ResourceKey="TitleSmallFontWeight" />
+			<StaticResource x:Key="TitleSmallTextBlockFontSize" ResourceKey="TitleSmallFontSize" />
+			<!--#endregion-->
+
+			<!--LABEL-->
+
+			<!--#region Label Large-->
+			<StaticResource x:Key="LabelLargeTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="LabelLargeTextBlockFontWeight" ResourceKey="LabelLargeFontWeight" />
+			<StaticResource x:Key="LabelLargeTextBlockFontSize" ResourceKey="LabelLargeFontSize" />
+			<StaticResource x:Key="LabelLargeTextBlockCharacterSpacing" ResourceKey="LabelLargeCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Label Medium-->
+			<StaticResource x:Key="LabelMediumTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="LabelMediumTextBlockFontWeight" ResourceKey="LabelMediumFontWeight" />
+			<StaticResource x:Key="LabelMediumTextBlockFontSize" ResourceKey="LabelMediumFontSize" />
+			<StaticResource x:Key="LabelMediumTextBlockCharacterSpacing" ResourceKey="LabelMediumCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Label Small-->
+			<StaticResource x:Key="LabelSmallTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="LabelSmallTextBlockFontWeight" ResourceKey="LabelSmallFontWeight" />
+			<StaticResource x:Key="LabelSmallTextBlockFontSize" ResourceKey="LabelSmallFontSize" />
+			<StaticResource x:Key="LabelSmallTextBlockCharacterSpacing" ResourceKey="LabelSmallCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Label X-Small-->
+			<StaticResource x:Key="LabelExtraSmallTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="LabelExtraSmallTextBlockFontWeight" ResourceKey="LabelExtraSmallFontWeight" />
+			<StaticResource x:Key="LabelExtraSmallTextBlockFontSize" ResourceKey="LabelExtraSmallFontSize" />
+			<StaticResource x:Key="LabelExtraSmallTextBlockCharacterSpacing" ResourceKey="LabelExtraSmallCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--BODY-->
+
+			<!--#region Body Large-->
+			<StaticResource x:Key="BodyLargeTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="BodyLargeTextBlockFontWeight" ResourceKey="BodyLargeFontWeight" />
+			<StaticResource x:Key="BodyLargeTextBlockFontSize" ResourceKey="BodyLargeFontSize" />
+			<StaticResource x:Key="BodyLargeTextBlockCharacterSpacing" ResourceKey="BodyLargeCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Body Medium-->
+			<StaticResource x:Key="BodyMediumTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="BodyMediumTextBlockFontWeight" ResourceKey="BodyMediumFontWeight" />
+			<StaticResource x:Key="BodyMediumTextBlockFontSize" ResourceKey="BodyMediumFontSize" />
+			<StaticResource x:Key="BodyMediumTextBlockCharacterSpacing" ResourceKey="BodyMediumCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Body Small-->
+			<StaticResource x:Key="BodySmallTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="BodySmallTextBlockFontWeight" ResourceKey="BodySmallFontWeight" />
+			<StaticResource x:Key="BodySmallTextBlockFontSize" ResourceKey="BodySmallFontSize" />
+			<StaticResource x:Key="BodySmallTextBlockCharacterSpacing" ResourceKey="BodySmallCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--CAPTION-->
+
+			<!--#region Caption Large-->
+			<StaticResource x:Key="CaptionLargeTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="CaptionLargeTextBlockFontWeight" ResourceKey="CaptionLargeFontWeight" />
+			<StaticResource x:Key="CaptionLargeTextBlockFontSize" ResourceKey="CaptionLargeFontSize" />
+			<StaticResource x:Key="CaptionLargeTextBlockCharacterSpacing" ResourceKey="CaptionLargeCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Caption Medium-->
+			<StaticResource x:Key="CaptionMediumTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="CaptionMediumTextBlockFontWeight" ResourceKey="CaptionMediumFontWeight" />
+			<StaticResource x:Key="CaptionMediumTextBlockFontSize" ResourceKey="CaptionMediumFontSize" />
+			<StaticResource x:Key="CaptionMediumTextBlockCharacterSpacing" ResourceKey="CaptionMediumCharacterSpacing" />
+			<!--#endregion-->
+
+			<!--#region Caption Small-->
+			<StaticResource x:Key="CaptionSmallTextBlockFontFamily" ResourceKey="MaterialMediumFontFamily" />
+			<StaticResource x:Key="CaptionSmallTextBlockFontWeight" ResourceKey="CaptionSmallFontWeight" />
+			<StaticResource x:Key="CaptionSmallTextBlockFontSize" ResourceKey="CaptionSmallFontSize" />
+			<StaticResource x:Key="CaptionSmallTextBlockCharacterSpacing" ResourceKey="CaptionSmallCharacterSpacing" />
+			<!--#endregion-->
+		</ResourceDictionary>
+	</ResourceDictionary.ThemeDictionaries>
+
 	<Style x:Key="MaterialBaseTextBlockStyle"
 		   TargetType="TextBlock">
 
@@ -11,7 +285,7 @@
 		<Setter Property="FontWeight"
 				Value="Normal" />
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialRegularFontFamily}" />
+				Value="{ThemeResource BaseTextBlockFontFamily}" />
 	</Style>
 
 	<!-- IMPORTANT NOTE :
@@ -27,11 +301,11 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontWeight"
-				Value="{ThemeResource DisplayLargeFontWeight}" />
+				Value="{ThemeResource DisplayLargeTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource DisplayLargeFontSize}" />
+				Value="{ThemeResource DisplayLargeTextBlockFontSize}" />
 		<Setter Property="CharacterSpacing"
-				Value="{ThemeResource DisplayLargeCharacterSpacing}" />
+				Value="{ThemeResource DisplayLargeTextBlockCharacterSpacing}" />
 	</Style>
 
 	<!--  Display Medium  -->
@@ -39,9 +313,9 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontWeight"
-				Value="{ThemeResource DisplayMediumFontWeight}" />
+				Value="{ThemeResource DisplayMediumTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource DisplayMediumFontSize}" />
+				Value="{ThemeResource DisplayMediumTextBlockFontSize}" />
 	</Style>
 
 	<!--  Display Small  -->
@@ -49,9 +323,9 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontWeight"
-				Value="{ThemeResource DisplaySmallFontWeight}" />
+				Value="{ThemeResource DisplaySmallTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource DisplaySmallFontSize}" />
+				Value="{ThemeResource DisplaySmallTextBlockFontSize}" />
 	</Style>
 
 	<!-- HEADLINE -->
@@ -61,9 +335,9 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontWeight"
-				Value="{ThemeResource HeadlineLargeFontWeight}" />
+				Value="{ThemeResource HeadlineLargeTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource HeadlineLargeFontSize}" />
+				Value="{ThemeResource HeadlineLargeTextBlockFontSize}" />
 	</Style>
 
 	<!--  Headline Medium  -->
@@ -71,9 +345,9 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontWeight"
-				Value="{ThemeResource HeadlineMediumFontWeight}" />
+				Value="{ThemeResource HeadlineMediumTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource HeadlineMediumFontSize}" />
+				Value="{ThemeResource HeadlineMediumTextBlockFontSize}" />
 	</Style>
 
 	<!--  Headline Small  -->
@@ -81,9 +355,9 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontWeight"
-				Value="{ThemeResource HeadlineSmallFontWeight}" />
+				Value="{ThemeResource HeadlineSmallTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource HeadlineSmallFontSize}" />
+				Value="{ThemeResource HeadlineSmallTextBlockFontSize}" />
 	</Style>
 
 	<!-- TITLE -->
@@ -93,9 +367,9 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontWeight"
-				Value="{ThemeResource TitleLargeFontWeight}" />
+				Value="{ThemeResource TitleLargeTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource TitleLargeFontSize}" />
+				Value="{ThemeResource TitleLargeTextBlockFontSize}" />
 	</Style>
 
 	<!--  Title Medium  -->
@@ -103,11 +377,11 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource TitleMediumTextBlockFontFamily}" />
 		<Setter Property="FontWeight"
-				Value="{ThemeResource TitleMediumFontWeight}" />
+				Value="{ThemeResource TitleMediumTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource TitleMediumFontSize}" />
+				Value="{ThemeResource TitleMediumTextBlockFontSize}" />
 	</Style>
 
 	<!--  Title Small  -->
@@ -115,11 +389,11 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource TitleSmallTextBlockFontFamily}" />
 		<Setter Property="FontWeight"
-				Value="{ThemeResource TitleSmallFontWeight}" />
+				Value="{ThemeResource TitleSmallTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource TitleSmallFontSize}" />
+				Value="{ThemeResource TitleSmallTextBlockFontSize}" />
 	</Style>
 
 	<!-- LABEL -->
@@ -129,13 +403,13 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource LabelLargeTextBlockFontFamily}" />
 		<Setter Property="FontWeight"
-				Value="{ThemeResource LabelLargeFontWeight}" />
+				Value="{ThemeResource LabelLargeTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource LabelLargeFontSize}" />
+				Value="{ThemeResource LabelLargeTextBlockFontSize}" />
 		<Setter Property="CharacterSpacing"
-				Value="{ThemeResource LabelLargeCharacterSpacing}" />
+				Value="{ThemeResource LabelLargeTextBlockCharacterSpacing}" />
 	</Style>
 
 	<!--  Label Medium  -->
@@ -143,13 +417,13 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource LabelMediumTextBlockFontFamily}" />
 		<Setter Property="FontWeight"
-				Value="{ThemeResource LabelMediumFontWeight}" />
+				Value="{ThemeResource LabelMediumTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource LabelMediumFontSize}" />
+				Value="{ThemeResource LabelMediumTextBlockFontSize}" />
 		<Setter Property="CharacterSpacing"
-				Value="{ThemeResource LabelMediumCharacterSpacing}" />
+				Value="{ThemeResource LabelMediumTextBlockCharacterSpacing}" />
 	</Style>
 
 	<!--  Label Small  -->
@@ -157,13 +431,13 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource LabelSmallTextBlockFontFamily}" />
 		<Setter Property="FontWeight"
-				Value="{ThemeResource LabelSmallFontWeight}" />
+				Value="{ThemeResource LabelSmallTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource LabelSmallFontSize}" />
+				Value="{ThemeResource LabelSmallTextBlockFontSize}" />
 		<Setter Property="CharacterSpacing"
-				Value="{ThemeResource LabelSmallCharacterSpacing}" />
+				Value="{ThemeResource LabelSmallTextBlockCharacterSpacing}" />
 	</Style>
 
 	<!--  Label ExtraSmall  -->
@@ -173,13 +447,13 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource LabelExtraSmallTextBlockFontFamily}" />
 		<Setter Property="FontWeight"
-				Value="{ThemeResource LabelExtraSmallFontWeight}" />
+				Value="{ThemeResource LabelExtraSmallTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource LabelExtraSmallFontSize}" />
+				Value="{ThemeResource LabelExtraSmallTextBlockFontSize}" />
 		<Setter Property="CharacterSpacing"
-				Value="{ThemeResource LabelExtraSmallCharacterSpacing}" />
+				Value="{ThemeResource LabelExtraSmallTextBlockCharacterSpacing}" />
 	</Style>
 
 	<!-- BODY -->
@@ -189,13 +463,13 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource BodyLargeTextBlockFontFamily}" />
 		<Setter Property="FontWeight"
-				Value="{ThemeResource BodyLargeFontWeight}" />
+				Value="{ThemeResource BodyLargeTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource BodyLargeFontSize}" />
+				Value="{ThemeResource BodyLargeTextBlockFontSize}" />
 		<Setter Property="CharacterSpacing"
-				Value="{ThemeResource BodyLargeCharacterSpacing}" />
+				Value="{ThemeResource BodyLargeTextBlockCharacterSpacing}" />
 	</Style>
 
 	<!--  Body Medium  -->
@@ -203,13 +477,13 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource BodyMediumTextBlockFontFamily}" />
 		<Setter Property="FontWeight"
-				Value="{ThemeResource BodyMediumFontWeight}" />
+				Value="{ThemeResource BodyMediumTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource BodyMediumFontSize}" />
+				Value="{ThemeResource BodyMediumTextBlockFontSize}" />
 		<Setter Property="CharacterSpacing"
-				Value="{ThemeResource BodyMediumCharacterSpacing}" />
+				Value="{ThemeResource BodyMediumTextBlockCharacterSpacing}" />
 	</Style>
 
 	<!--  Body Small  -->
@@ -217,13 +491,13 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource BodySmallTextBlockFontFamily}" />
 		<Setter Property="FontWeight"
-				Value="{ThemeResource BodySmallFontWeight}" />
+				Value="{ThemeResource BodySmallTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource BodySmallFontSize}" />
+				Value="{ThemeResource BodySmallTextBlockFontSize}" />
 		<Setter Property="CharacterSpacing"
-				Value="{ThemeResource BodySmallCharacterSpacing}" />
+				Value="{ThemeResource BodySmallTextBlockCharacterSpacing}" />
 	</Style>
 
 	<!-- CAPTION -->
@@ -234,13 +508,13 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource CaptionLargeTextBlockFontFamily}" />
 		<Setter Property="FontWeight"
-				Value="{ThemeResource CaptionLargeFontWeight}" />
+				Value="{ThemeResource CaptionLargeTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource CaptionLargeFontSize}" />
+				Value="{ThemeResource CaptionLargeTextBlockFontSize}" />
 		<Setter Property="CharacterSpacing"
-				Value="{ThemeResource CaptionLargeCharacterSpacing}" />
+				Value="{ThemeResource CaptionLargeTextBlockCharacterSpacing}" />
 	</Style>
 
 	<!--  Caption Medium  -->
@@ -249,13 +523,13 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource CaptionMediumTextBlockFontFamily}" />
 		<Setter Property="FontWeight"
-				Value="{ThemeResource CaptionMediumFontWeight}" />
+				Value="{ThemeResource CaptionMediumTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource CaptionMediumFontSize}" />
+				Value="{ThemeResource CaptionMediumTextBlockFontSize}" />
 		<Setter Property="CharacterSpacing"
-				Value="{ThemeResource CaptionMediumCharacterSpacing}" />
+				Value="{ThemeResource CaptionMediumTextBlockCharacterSpacing}" />
 	</Style>
 
 	<!--  Caption Small  -->
@@ -264,13 +538,13 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource CaptionSmallTextBlockFontFamily}" />
 		<Setter Property="FontWeight"
-				Value="{ThemeResource CaptionSmallFontWeight}" />
+				Value="{ThemeResource CaptionSmallTextBlockFontWeight}" />
 		<Setter Property="FontSize"
-				Value="{ThemeResource CaptionSmallFontSize}" />
+				Value="{ThemeResource CaptionSmallTextBlockFontSize}" />
 		<Setter Property="CharacterSpacing"
-				Value="{ThemeResource CaptionSmallCharacterSpacing}" />
+				Value="{ThemeResource CaptionSmallTextBlockCharacterSpacing}" />
 	</Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
closes #1008 
﻿GitHub Issue: #1008 

## PR Type
- Refactoring (no functional changes, no api changes)


## Description
Default:
![image](https://github.com/unoplatform/Uno.Themes/assets/54756963/12f0a2e2-f872-463a-89d8-e14f1a99b6d7)

Overriden:
![image](https://github.com/unoplatform/Uno.Themes/assets/54756963/d89efb67-b050-4872-a268-6388a1b98aac)

Locally overriden with:

	<Page.Resources>
		<x:String x:Key="DisplayLargeTextBlockFontWeight">Medium</x:String>
		<x:Double x:Key="DisplayLargeTextBlockFontSize">32</x:Double>
		<x:Int32 x:Key="DisplayLargeTextBlockCharacterSpacing">-5</x:Int32>
	</Page.Resources>


## PR Checklist 
- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [X] Tested UWP
- [X] Tested iOS
- [X] Tested Android
- [X] Tested WASM
- [ ] Tested MacOS
- [X] Contains **No** breaking changes