### PR TITLE
refactor: add lightweight styling resources for radiobutton

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/RadioButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/RadioButton.xaml
@@ -1,203 +1,322 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:android="http://uno.ui/android"
-					xmlns:ios="http://uno.ui/ios"
-					xmlns:wasm="http://uno.ui/wasm"
-					mc:Ignorable="ios android wasm">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:android="http://uno.ui/android"
+                    xmlns:ios="http://uno.ui/ios"
+                    xmlns:wasm="http://uno.ui/wasm"
+                    mc:Ignorable="ios android wasm">
 
-	<GridLength x:Key="RadioStatesAreaLength">40</GridLength>
-	<x:Double x:Key="RadioStatesAreaSize">40</x:Double>
-	<x:Double x:Key="RadioCheckAreaSize">20</x:Double>
-	<x:Double x:Key="RadioBorderThickness">2</x:Double>
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
+            <!--#region Foreground-->
+            <StaticResource x:Key="RadioButtonForeground" ResourceKey="OnBackgroundMediumBrush" />
+            <StaticResource x:Key="RadioButtonForegroundPointerOver" ResourceKey="OnBackgroundMediumBrush" />
+            <StaticResource x:Key="RadioButtonForegroundPressed" ResourceKey="OnBackgroundMediumBrush" />
+            <StaticResource x:Key="RadioButtonForegroundDisabled" ResourceKey="OnBackgroundDisabledBrush" />
+            <!--#endregion-->
 
+            <!--#region Stroke-->
+            <StaticResource x:Key="RadioButtonOuterEllipseStroke" ResourceKey="OnBackgroundMediumBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseStrokePointerOver" ResourceKey="OnBackgroundMediumBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseStrokePressed" ResourceKey="OnBackgroundMediumBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseStrokeDisabled" ResourceKey="OnBackgroundDisabledBrush" />
 
-	<Style x:Key="MaterialRadioButtonStyle"
-		   TargetType="RadioButton">
-		<Setter Property="Background"
-				Value="{ThemeResource PrimaryBrush}" />
-		<Setter Property="Foreground"
-				Value="{ThemeResource OnSurfaceMediumBrush}" />
-		<Setter Property="BorderBrush"
-				Value="{ThemeResource OnSurfaceMediumBrush}" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedStroke" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedStrokePointerOver" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedStrokePressed" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedStrokeDisabled" ResourceKey="PrimaryBrush" />
+            <!--#endregion-->
 
-		<!--Start: Body Small Typo-->
-		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialRegularFontFamily}" />
-		<Setter Property="FontWeight"
-				Value="{ThemeResource BodySmallFontWeight}" />
-		<Setter Property="FontSize"
-				Value="{ThemeResource BodySmallFontSize}" />
-		<Setter Property="CharacterSpacing"
-				Value="{ThemeResource BodySmallCharacterSpacing}" />
-		<!--End: Body Small Typo-->
+            <!--#region Fill-->
+            <StaticResource x:Key="RadioButtonOuterEllipseFill" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseFillPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseFillPressed" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseFillDisabled" ResourceKey="SystemControlTransparentBrush" />
 
-		<Setter Property="Padding"
-				Value="4,0,0,0" />
-		<Setter Property="HorizontalAlignment"
-				Value="Left" />
-		<Setter Property="VerticalAlignment"
-				Value="Stretch" />
-		<Setter Property="HorizontalContentAlignment"
-				Value="Left" />
-		<Setter Property="VerticalContentAlignment"
-				Value="Center" />
-		<Setter Property="MinWidth"
-				Value="{StaticResource RadioStatesAreaSize}" />
-		<Setter Property="MinHeight"
-				Value="{StaticResource RadioStatesAreaSize}" />
-		<Setter Property="UseSystemFocusVisuals"
-				Value="False" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedFill" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedFillPointerOver" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedFillPressed" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedFillDisabled" ResourceKey="PrimaryBrush" />
+            <!--#endregion-->
 
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="RadioButton">
-					<Grid x:Name="RootGrid"
-						  Background="Transparent">
-						<VisualStateManager.VisualStateGroups>
-							<VisualStateGroup x:Name="CommonStates">
-								<VisualState x:Name="Normal">
-								</VisualState>
+            <!--#region HoverRing-->
+            <StaticResource x:Key="MaterialRadioButtonHoverRingFillPointerOver" ResourceKey="PrimaryHoverBrush" />
+            <StaticResource x:Key="MaterialRadioButtonHoverRingFillPressed" ResourceKey="PrimaryFocusedBrush" />
+            <!--#endregion-->
 
-								<VisualState x:Name="PointerOver">
-									<VisualState.Setters>
-										<Setter Target="HoverAndPressRing.Opacity"
-												Value="{StaticResource HoverOpacity}" />
-									</VisualState.Setters>
-								</VisualState>
+            <!--#region Typo-->
+            <StaticResource x:Key="RadioButtonFontFamily" ResourceKey="MaterialRegularFontFamily" />
+            <StaticResource x:Key="RadioButtonFontWeight" ResourceKey="BodySmallFontWeight" />
+            <StaticResource x:Key="RadioButtonFontSize" ResourceKey="BodySmallFontSize" />
+            <StaticResource x:Key="RadioButtonCharacterSpacing" ResourceKey="BodySmallCharacterSpacing" />
+            <!--#endregion-->
 
-								<VisualState x:Name="Pressed">
-									<VisualState.Setters>
-										<Setter Target="HoverAndPressRing.Opacity"
-												Value="{StaticResource PressedOpacity}" />
-									</VisualState.Setters>
-								</VisualState>
+        </ResourceDictionary>
 
-								<VisualState x:Name="Disabled">
-									<VisualState.Setters>
-										<Setter Target="RootGrid.Opacity"
-												Value="{StaticResource DisabledOpacity}" />
-									</VisualState.Setters>
-								</VisualState>
+        <ResourceDictionary x:Key="Light">
+            <!--#region Foreground-->
+            <StaticResource x:Key="RadioButtonForeground" ResourceKey="OnBackgroundMediumBrush" />
+            <StaticResource x:Key="RadioButtonForegroundPointerOver" ResourceKey="OnBackgroundMediumBrush" />
+            <StaticResource x:Key="RadioButtonForegroundPressed" ResourceKey="OnBackgroundMediumBrush" />
+            <StaticResource x:Key="RadioButtonForegroundDisabled" ResourceKey="OnBackgroundDisabledBrush" />
+            <!--#endregion-->
 
-								<VisualStateGroup.Transitions>
-									<VisualTransition To="PointerOver"
-													  GeneratedDuration="{StaticResource MaterialAnimationDuration}"
-													  GeneratedEasingFunction="{StaticResource MaterialEaseInOutFunction}" />
-									<VisualTransition To="Pressed"
-													  GeneratedDuration="{StaticResource MaterialAnimationDuration}"
-													  GeneratedEasingFunction="{StaticResource MaterialEaseInOutFunction}" />
-								</VisualStateGroup.Transitions>
-							</VisualStateGroup>
+            <!--#region Stroke-->
+            <StaticResource x:Key="RadioButtonOuterEllipseStroke" ResourceKey="OnBackgroundMediumBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseStrokePointerOver" ResourceKey="OnBackgroundMediumBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseStrokePressed" ResourceKey="OnBackgroundMediumBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseStrokeDisabled" ResourceKey="OnBackgroundDisabledBrush" />
 
-							<VisualStateGroup x:Name="CheckStates">
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedStroke" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedStrokePointerOver" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedStrokePressed" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedStrokeDisabled" ResourceKey="PrimaryBrush" />
+            <!--#endregion-->
 
-								<VisualState x:Name="Checked">
-									<VisualState.Setters>
-										<Setter Target="CheckEllipse.Opacity"
-												Value="1" />
-										<Setter Target="OuterEllipse_Checked.Opacity"
-												Value="1" />
-										<Setter Target="OuterEllipse_Unchecked.Opacity"
-												Value="0" />
-									</VisualState.Setters>
-								</VisualState>
+            <!--#region Fill-->
+            <StaticResource x:Key="RadioButtonOuterEllipseFill" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseFillPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseFillPressed" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseFillDisabled" ResourceKey="SystemControlTransparentBrush" />
 
-								<VisualState x:Name="Unchecked" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedFill" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedFillPointerOver" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedFillPressed" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RadioButtonOuterEllipseCheckedFillDisabled" ResourceKey="PrimaryBrush" />
+            <!--#endregion-->
 
-								<VisualState x:Name="Indeterminate" />
-							</VisualStateGroup>
+            <!--#region HoverRing-->
+            <StaticResource x:Key="MaterialRadioButtonHoverRingFillPointerOver" ResourceKey="PrimaryHoverBrush" />
+            <StaticResource x:Key="MaterialRadioButtonHoverRingFillPressed" ResourceKey="PrimaryFocusedBrush" />
+            <!--#endregion-->
 
-							<VisualStateGroup x:Name="FocusStates">
+            <!--#region Typo-->
+            <StaticResource x:Key="RadioButtonFontFamily" ResourceKey="MaterialRegularFontFamily" />
+            <StaticResource x:Key="RadioButtonFontWeight" ResourceKey="BodySmallFontWeight" />
+            <StaticResource x:Key="RadioButtonFontSize" ResourceKey="BodySmallFontSize" />
+            <StaticResource x:Key="RadioButtonCharacterSpacing" ResourceKey="BodySmallCharacterSpacing" />
+            <!--#endregion-->
 
-								<VisualState x:Name="Focused">
-									<VisualState.Setters>
-										<Setter Target="FocusRing.Opacity"
-												Value="{StaticResource FocusedOpacity}" />
-									</VisualState.Setters>
-								</VisualState>
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
 
-								<VisualState x:Name="PointerFocused" />
+    <!-- RadioButton Area -->
+    <GridLength x:Key="RadioButtonAreaLength">40</GridLength>
+    <x:Double x:Key="RadioButtonAreaSize">40</x:Double>
 
-								<VisualState x:Name="Unfocused" />
-							</VisualStateGroup>
-						</VisualStateManager.VisualStateGroups>
+    <!-- Check Area -->
+    <x:Double x:Key="RadioButtonCheckAreaSize">20</x:Double>
 
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="{StaticResource RadioStatesAreaLength}" />
-							<ColumnDefinition Width="*" />
-						</Grid.ColumnDefinitions>
+    <!-- Border -->
+    <x:Double x:Key="RadioButtonBorderThemeThickness">2</x:Double>
 
-						<Ellipse x:Name="FocusRing"
-								 HorizontalAlignment="Center"
-								 VerticalAlignment="Center"
-								 Width="{StaticResource RadioStatesAreaSize}"
-								 Height="{StaticResource RadioStatesAreaSize}"
-								 Fill="{TemplateBinding Background}"
-								 IsHitTestVisible="False"
-								 Opacity="0" />
+    <Style x:Key="MaterialRadioButtonStyle"
+           TargetType="RadioButton">
+        <Setter Property="Background" Value="{ThemeResource RadioButtonOuterEllipseCheckedStroke}" />
+        <Setter Property="Foreground" Value="{ThemeResource RadioButtonForeground}" />
 
-						<Ellipse x:Name="HoverAndPressRing"
-								 HorizontalAlignment="Center"
-								 VerticalAlignment="Center"
-								 Width="{StaticResource RadioStatesAreaSize}"
-								 Height="{StaticResource RadioStatesAreaSize}"
-								 Fill="{TemplateBinding Background}"
-								 IsHitTestVisible="False"
-								 Opacity="0" />
+        <!-- Start: Body Small Typo -->
+        <Setter Property="FontFamily" Value="{ThemeResource RadioButtonFontFamily}" />
+        <Setter Property="FontWeight" Value="{ThemeResource RadioButtonFontWeight}" />
+        <Setter Property="FontSize" Value="{ThemeResource RadioButtonFontSize}" />
+        <Setter Property="CharacterSpacing" Value="{ThemeResource RadioButtonCharacterSpacing}" />
+        <!-- End: Body Small Typo -->
 
-						<Grid Height="{StaticResource RadioCheckAreaSize}"
-							  Width="{StaticResource RadioCheckAreaSize}">
+        <Setter Property="Padding" Value="4,0,0,0" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="MinWidth" Value="{StaticResource RadioButtonAreaSize}" />
+        <Setter Property="MinHeight" Value="{StaticResource RadioButtonAreaSize}" />
+        <Setter Property="UseSystemFocusVisuals" Value="False" />
 
-							<Ellipse x:Name="OuterEllipse_Checked"
-									 HorizontalAlignment="Stretch"
-									 VerticalAlignment="Stretch"
-									 Stretch="Fill"
-									 UseLayoutRounding="False"
-									 Stroke="{TemplateBinding Background}"
-									 StrokeThickness="{StaticResource RadioBorderThickness}"
-									 Opacity="0" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RadioButton">
+                    <Grid x:Name="RootGrid"
+                          Background="Transparent">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal">
+                                    <VisualState.Setters>
+                                        <Setter Target="OuterEllipse.Stroke" Value="{ThemeResource RadioButtonOuterEllipseStroke}" />
+                                        <Setter Target="OuterEllipse_Checked.Stroke" Value="{ThemeResource RadioButtonOuterEllipseCheckedStroke}" />
+                                        <Setter Target="CheckEllipse.Fill" Value="{ThemeResource RadioButtonOuterEllipseCheckedFill}" />
+                                        <Setter Target="CheckEllipse_Unchecked.Fill" Value="{ThemeResource RadioButtonOuterEllipseFill}" />
+                                    </VisualState.Setters>
+                                </VisualState>
 
-							<Ellipse x:Name="OuterEllipse_Unchecked"
-									 HorizontalAlignment="Stretch"
-									 VerticalAlignment="Stretch"
-									 Stretch="Fill"
-									 UseLayoutRounding="False"
-									 Stroke="{TemplateBinding BorderBrush}"
-									 StrokeThickness="{StaticResource RadioBorderThickness}" />
+                                <VisualState x:Name="PointerOver">
+                                    <VisualState.Setters>
+                                        <Setter Target="HoverRing.Opacity" Value="1" />
 
-							<Ellipse x:Name="CheckEllipse"
-									 HorizontalAlignment="Stretch"
-									 VerticalAlignment="Stretch"
-									 Stretch="Fill"
-									 UseLayoutRounding="False"
-									 Fill="{TemplateBinding Background}"
-									 Opacity="0"
-									 Margin="5" />
-						</Grid>
+                                        <Setter Target="OuterEllipse.Stroke" Value="{ThemeResource RadioButtonOuterEllipseStrokePointerOver}" />
+                                        <Setter Target="OuterEllipse_Checked.Stroke" Value="{ThemeResource RadioButtonOuterEllipseCheckedStrokePointerOver}" />
+                                        <Setter Target="CheckEllipse.Fill" Value="{ThemeResource RadioButtonOuterEllipseCheckedFillPointerOver}" />
+                                        <Setter Target="CheckEllipse_Unchecked.Fill" Value="{ThemeResource RadioButtonOuterEllipseFillPointerOver}" />
 
-						<ContentPresenter x:Name="ContentPresenter"
-										  ContentTemplate="{TemplateBinding ContentTemplate}"
-										  ContentTransitions="{TemplateBinding ContentTransitions}"
-										  Content="{TemplateBinding Content}"
-										  Margin="{TemplateBinding Padding}"
-										  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-										  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-										  AutomationProperties.AccessibilityView="Raw"
-										  TextWrapping="Wrap"
-										  Grid.Column="1" />
-					</Grid>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource RadioButtonForegroundPointerOver}" />
+                                    </VisualState.Setters>
+                                </VisualState>
 
-	<Style x:Key="MaterialSecondaryRadioButtonStyle"
-		   TargetType="RadioButton"
-		   BasedOn="{StaticResource MaterialRadioButtonStyle}">
+                                <VisualState x:Name="Pressed">
+                                    <VisualState.Setters>
+                                        <Setter Target="FocusAndPressRing.Opacity" Value="1" />
 
-		<Setter Property="Background"
-				Value="{ThemeResource SecondaryBrush}" />
-	</Style>
+                                        <Setter Target="OuterEllipse.Stroke" Value="{ThemeResource RadioButtonOuterEllipseStrokePressed}" />
+                                        <Setter Target="OuterEllipse_Checked.Stroke" Value="{ThemeResource RadioButtonOuterEllipseCheckedStrokePressed}" />
+                                        <Setter Target="CheckEllipse.Fill" Value="{ThemeResource RadioButtonOuterEllipseCheckedFillPressed}" />
+                                        <Setter Target="CheckEllipse_Unchecked.Fill" Value="{ThemeResource RadioButtonOuterEllipseFillPressed}" />
+
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource RadioButtonForegroundPressed}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="RootGrid.Opacity" Value="{StaticResource DisabledOpacity}" />
+
+                                        <Setter Target="OuterEllipse.Stroke" Value="{ThemeResource RadioButtonOuterEllipseStrokeDisabled}" />
+                                        <Setter Target="OuterEllipse_Checked.Stroke" Value="{ThemeResource RadioButtonOuterEllipseCheckedStrokeDisabled}" />
+                                        <Setter Target="CheckEllipse.Fill" Value="{ThemeResource RadioButtonOuterEllipseCheckedFillDisabled}" />
+                                        <Setter Target="CheckEllipse_Unchecked.Fill" Value="{ThemeResource RadioButtonOuterEllipseFillDisabled}" />
+
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource RadioButtonForegroundDisabled}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition To="PointerOver"
+                                                      GeneratedDuration="{StaticResource MaterialAnimationDuration}"
+                                                      GeneratedEasingFunction="{StaticResource MaterialEaseInOutFunction}" />
+                                    <VisualTransition To="Pressed"
+                                                      GeneratedDuration="{StaticResource MaterialAnimationDuration}"
+                                                      GeneratedEasingFunction="{StaticResource MaterialEaseInOutFunction}" />
+                                </VisualStateGroup.Transitions>
+                            </VisualStateGroup>
+
+                            <VisualStateGroup x:Name="CheckStates">
+
+                                <VisualState x:Name="Checked">
+                                    <VisualState.Setters>
+                                        <Setter Target="CheckEllipse.Opacity" Value="1" />
+
+                                        <Setter Target="OuterEllipse_Checked.Opacity" Value="1" />
+                                        <Setter Target="OuterEllipse.Opacity" Value="0" />
+
+                                        <Setter Target="CheckEllipse.Fill" Value="{ThemeResource RadioButtonOuterEllipseCheckedFill}" />
+                                        <Setter Target="OuterEllipse.Stroke" Value="{ThemeResource RadioButtonOuterEllipseCheckedStroke}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="Unchecked">
+                                    <VisualState.Setters>
+                                        <Setter Target="CheckEllipse_Unchecked.Opacity" Value="1" />
+
+                                        <Setter Target="CheckEllipse.Fill" Value="{ThemeResource RadioButtonOuterEllipseFill}" />
+                                        <Setter Target="OuterEllipse.Stroke" Value="{ThemeResource RadioButtonOuterEllipseStroke}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="Indeterminate" />
+                            </VisualStateGroup>
+
+                            <VisualStateGroup x:Name="FocusStates">
+
+                                <VisualState x:Name="Focused">
+                                    <VisualState.Setters>
+                                        <Setter Target="FocusAndPressRing.Opacity" Value="1" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="PointerFocused" />
+                                <VisualState x:Name="Unfocused" />
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="{StaticResource RadioButtonAreaLength}" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <Ellipse x:Name="FocusAndPressRing"
+                                 HorizontalAlignment="Center"
+                                 VerticalAlignment="Center"
+                                 Width="{StaticResource RadioButtonAreaSize}"
+                                 Height="{StaticResource RadioButtonAreaSize}"
+                                 Fill="{ThemeResource MaterialRadioButtonHoverRingFillPressed}"
+                                 IsHitTestVisible="False"
+                                 Opacity="0" />
+
+                        <Ellipse x:Name="HoverRing"
+                                 HorizontalAlignment="Center"
+                                 VerticalAlignment="Center"
+                                 Width="{StaticResource RadioButtonAreaSize}"
+                                 Height="{StaticResource RadioButtonAreaSize}"
+                                 Fill="{ThemeResource MaterialRadioButtonHoverRingFillPointerOver}"
+                                 IsHitTestVisible="False"
+                                 Opacity="0" />
+
+                        <Grid Height="{StaticResource RadioButtonCheckAreaSize}"
+                              Width="{StaticResource RadioButtonCheckAreaSize}">
+
+                            <Ellipse x:Name="OuterEllipse"
+                                     HorizontalAlignment="Stretch"
+                                     VerticalAlignment="Stretch"
+                                     Stretch="Fill"
+                                     UseLayoutRounding="False"
+                                     Stroke="{TemplateBinding Background}"
+                                     StrokeThickness="{StaticResource RadioButtonBorderThemeThickness}" />
+
+                            <Ellipse x:Name="OuterEllipse_Checked"
+                                     HorizontalAlignment="Stretch"
+                                     VerticalAlignment="Stretch"
+                                     Stretch="Fill"
+                                     UseLayoutRounding="False"
+                                     Stroke="{TemplateBinding Background}"
+                                     StrokeThickness="{StaticResource RadioButtonBorderThemeThickness}"
+                                     Opacity="0" />
+
+                            <Ellipse x:Name="CheckEllipse_Unchecked"
+                                     HorizontalAlignment="Stretch"
+                                     VerticalAlignment="Stretch"
+                                     Stretch="Fill"
+                                     UseLayoutRounding="False"
+                                     Fill="{TemplateBinding Background}"
+                                     Margin="5" />
+
+                            <Ellipse x:Name="CheckEllipse"
+                                     HorizontalAlignment="Stretch"
+                                     VerticalAlignment="Stretch"
+                                     Stretch="Fill"
+                                     UseLayoutRounding="False"
+                                     Fill="{TemplateBinding Background}"
+                                     Opacity="0"
+                                     Margin="5" />
+                        </Grid>
+
+                        <ContentPresenter x:Name="ContentPresenter"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          ContentTransitions="{TemplateBinding ContentTransitions}"
+                                          Content="{TemplateBinding Content}"
+                                          Margin="{TemplateBinding Padding}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          AutomationProperties.AccessibilityView="Raw"
+                                          TextWrapping="Wrap"
+                                          Grid.Column="1" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="MaterialSecondaryRadioButtonStyle"
+           TargetType="RadioButton"
+           BasedOn="{StaticResource MaterialRadioButtonStyle}">
+
+        <Setter Property="Background" Value="{ThemeResource SecondaryBrush}" />
+    </Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
﻿GitHub Issue: closes #991 

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Refactoring (no functional changes, no api changes)

## Description

<!-- (Please describe the changes that this PR introduces.) -->
![light-radiobuttons](https://github.com/unoplatform/Uno.Themes/assets/70542961/50e1c9b9-3ee0-4df2-8365-6ac1da37e44d)
![dark-radiobuttons](https://github.com/unoplatform/Uno.Themes/assets/70542961/e5dc82e7-9516-4276-86d2-866098e415b2)
![radiobuttons_gif](https://github.com/unoplatform/Uno.Themes/assets/70542961/e4d9a705-72c0-4234-aeff-988298e2a9a3)

Locally overriden with:
```
            <!--#region Foreground-->
            <SolidColorBrush x:Key="RadioButtonForeground" Color="Red" />
            <SolidColorBrush x:Key="RadioButtonForegroundPointerOver" Color="Yellow" />
            <SolidColorBrush x:Key="RadioButtonForegroundPressed" Color="Green" />
            <SolidColorBrush x:Key="RadioButtonForegroundDisabled" Color="Orange" />
            <!--#endregion-->

            <!--#region Stroke-->
            <SolidColorBrush x:Key="RadioButtonOuterEllipseStroke" Color="Red" />
            <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePointerOver" Color="Orange" />
            <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePressed" Color="Yellow" />
            <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokeDisabled" Color="Green" />

            <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStroke" Color="Green" />
            <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStrokePointerOver" Color="Orange" />
            <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStrokePressed" Color="Red" />
            <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStrokeDisabled" Color="Yellow" />
            <!--#endregion-->

            <!--#region Fill-->
            <SolidColorBrush x:Key="RadioButtonOuterEllipseFill" Color="Transparent" />
            <SolidColorBrush x:Key="RadioButtonOuterEllipseFillPointerOver" Color="Transparent" />
            <SolidColorBrush x:Key="RadioButtonOuterEllipseFillPressed" Color="Transparent" />
            <SolidColorBrush x:Key="RadioButtonOuterEllipseFillDisabled" Color="Transparent" />

            <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedFill" Color="Orange" />
            <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedFillPointerOver" Color="Red" />
            <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedFillPressed" Color="Yellow" />
            <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedFillDisabled" Color="Green" />
            <!--#endregion-->

            <!--#region HoverRing-->
            <SolidColorBrush x:Key="MaterialRadioButtonHoverRingFillPointerOver" Color="Red" />
            <SolidColorBrush x:Key="MaterialRadioButtonHoverRingFillPressed" Color="Green" />
            <!--#endregion-->

            <!--#region Typo-->
            <StaticResource x:Key="RadioButtonFontFamily" ResourceKey="MaterialRegularFontFamily" />
            <StaticResource x:Key="RadioButtonFontWeight" ResourceKey="BodySmallFontWeight" />
            <StaticResource x:Key="RadioButtonFontSize" ResourceKey="BodySmallFontSize" />
            <StaticResource x:Key="RadioButtonCharacterSpacing" ResourceKey="BodySmallCharacterSpacing" />
            <!--#endregion-->
```

![animation](https://github.com/unoplatform/Uno.Themes/assets/70542961/6801d5c7-5d3b-4a8f-a660-4b7ebde7e54e)

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)