### PR TITLE
fix: textbox clear button flickering on first load

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v1/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/TextBox.xaml
@@ -154,8 +154,6 @@
 									<Storyboard>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="DeleteButton"
 																	   Storyboard.TargetProperty="Opacity">
-											<DiscreteObjectKeyFrame KeyTime="0"
-																	Value="1" />
 											<DiscreteObjectKeyFrame KeyTime="0:0:0.2"
 																	Value="0" />
 										</ObjectAnimationUsingKeyFrames>
@@ -367,8 +365,6 @@
 									<Storyboard>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="DeleteButton"
 																	   Storyboard.TargetProperty="Opacity">
-											<DiscreteObjectKeyFrame KeyTime="0"
-																	Value="1" />
 											<DiscreteObjectKeyFrame KeyTime="0:0:0.2"
 																	Value="0" />
 										</ObjectAnimationUsingKeyFrames>


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- [x] Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Other... Please describe:


## Description

In this pr, I removed this
![image](https://github.com/unoplatform/Uno.Themes/assets/72167772/5afd8bcf-bb29-47ff-8847-637dabfa4b5a)
Because the fact that the KeyFrame 0 starts with Opacity="1" makes the clear button appear when first loading a page with a textbox then disapears when it's opacity is set to 0 200 milliseconds after. By removing it we keep the desired behaviour of disapearing after 200 milliseconds when the focus is lost but without the flickering when first loading the page. I remove the lines from MaterialOutlinedTextBoxStyle and MaterialFilledTextBoxStyle since both had the same animation.
<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [ ] Tested iOS
- [x] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

before (delay exagerated to visualize the bug better) :
![before (2)](https://github.com/unoplatform/Uno.Themes/assets/72167772/7896774a-cd45-4102-b0b8-932d6e46d9e3)

after: 
![ezgif com-video-to-gif (2)](https://github.com/unoplatform/Uno.Themes/assets/72167772/361347ab-963f-411e-b9ba-3a9326c6af62)


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
