### PR TITLE
fix: foreground of ContentPresenter is templatebounded

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v1/CheckBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/CheckBox.xaml
@@ -27,7 +27,7 @@
 		<Setter Property="Background"
 				Value="{StaticResource MaterialPrimaryBrush}" />
 		<Setter Property="Foreground"
-				Value="{StaticResource MaterialOnPrimaryBrush}" />
+				Value="{StaticResource MaterialOnBackgroundBrush}" />
 		<Setter Property="BorderBrush"
 				Value="{StaticResource MaterialCheckBoxBorderBrush}" />
 		<Setter Property="BorderThickness"
@@ -489,7 +489,7 @@
 
 							<Path x:Name="HyphenGlyph"
 								  Data="{StaticResource CheckBoxHyphenGlyphPathStyle}"
-								  Fill="{TemplateBinding Foreground}"
+								  Fill="{StaticResource MaterialOnPrimaryBrush}"
 								  VerticalAlignment="Center"
 								  HorizontalAlignment="Center"
 								  Stretch="Uniform"
@@ -501,7 +501,7 @@
 
 							<Path x:Name="CheckGlyph"
 								  Data="{StaticResource CheckBoxCheckGlyphPathStyle}"
-								  Fill="{TemplateBinding Foreground}"
+								  Fill="{StaticResource MaterialOnPrimaryBrush}"
 								  VerticalAlignment="Center"
 								  HorizontalAlignment="Center"
 								  Stretch="Uniform"
@@ -516,7 +516,7 @@
 										  ContentTemplate="{TemplateBinding ContentTemplate}"
 										  ContentTransitions="{TemplateBinding ContentTransitions}"
 										  Content="{TemplateBinding Content}"
-										  Foreground="{StaticResource MaterialOnBackgroundBrush}"
+										  Foreground="{TemplateBinding Foreground}"
 										  Margin="{TemplateBinding Padding}"
 										  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 										  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"


### PR DESCRIPTION
closes #823 

﻿GitHub Issue: #823 

## PR Type
- Bugfix


## Description
The ContentPresenter foreground is now templatebound to Foreground. The brush of Foreground has been changed, and the fills of glyphs are now given a brush instead of being templatebound.


## PR Checklist 
- [ ] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes

As of this instant when this PR is created, the master branch of Uno.Themes is crashing, and this branch has been created from the master branch.
