### PR TITLE
feat(ratingcontrol): Add Rating Control Styles and Rating Control Sample Page

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/RatingControl.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/RatingControl.xaml
@@ -1,0 +1,273 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+                    xmlns:not_win="http://uno.ui/not_win"
+                    mc:Ignorable="not_win">
+
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
+            <x:Double x:Key="RatingControlHeight">32</x:Double>
+			<x:Double x:Key="RatingControlCaptionHeight">32</x:Double>
+			<x:Double x:Key="SecondaryRatingControlCaptionHeight">32</x:Double>
+
+			<!-- Default -->
+            <StaticResource x:Key="RatingControlForeground" ResourceKey="PrimaryBrush" />
+
+            <StaticResource x:Key="RatingControlForegroundUnselected" ResourceKey="OnSurfaceLowBrush" />
+            <StaticResource x:Key="RatingControlForegroundSelected" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RatingControlPlaceholderForeground" ResourceKey="OnSurfaceLowBrush" />
+            <StaticResource x:Key="RatingControlPlaceholderForegroundPointerOver" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RatingControlForegroundPointerOverUnselected" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RatingControlForegroundPointerOverSelected" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RatingControlForegroundDisabledSelected" ResourceKey="OnSurfaceLowBrush" />
+
+            <!-- Secondary -->
+            <StaticResource x:Key="SecondaryRatingControlForeground" ResourceKey="SecondaryBrush" />
+
+            <StaticResource x:Key="SecondaryRatingControlForegroundUnselected" ResourceKey="OnSurfaceLowBrush" />
+            <StaticResource x:Key="SecondaryRatingControlForegroundSelected" ResourceKey="SecondaryBrush" />
+            <StaticResource x:Key="SecondaryRatingControlPlaceholderForeground" ResourceKey="OnSurfaceLowBrush" />
+            <StaticResource x:Key="SecondaryRatingControlPlaceholderForegroundPointerOver" ResourceKey="SecondaryBrush" />
+            <StaticResource x:Key="SecondaryRatingControlForegroundPointerOverUnselected" ResourceKey="SecondaryBrush" />
+            <StaticResource x:Key="SecondaryRatingControlForegroundPointerOverSelected" ResourceKey="SecondaryBrush" />
+            <StaticResource x:Key="SecondaryRatingControlForegroundDisabledSelected" ResourceKey="OnSurfaceLowBrush" />
+
+            <!-- Caption and Fonts -->
+            <StaticResource x:Key="RatingControlCaptionForeground" ResourceKey="OnSurfaceBrush" />
+            <StaticResource x:Key="RatingControlCaptionFontFamily" ResourceKey="MaterialRegularFontFamily" />
+            <StaticResource x:Key="RatingControlCaptionStyle" ResourceKey="CaptionMedium" />
+            <StaticResource x:Key="RatingControlFontFamily" ResourceKey="SymbolThemeFontFamily" />
+
+            <StaticResource x:Key="SecondaryRatingControlCaptionForeground" ResourceKey="OnSurfaceBrush" />
+            <StaticResource x:Key="SecondaryRatingControlCaptionFontFamily" ResourceKey="MaterialRegularFontFamily" />
+            <StaticResource x:Key="SecondaryRatingControlCaptionStyle" ResourceKey="CaptionMedium" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="Light">
+            <x:Double x:Key="RatingControlHeight">32</x:Double>
+			<x:Double x:Key="RatingControlCaptionHeight">32</x:Double>
+			<x:Double x:Key="SecondaryRatingControlCaptionHeight">32</x:Double>
+
+			<!-- Default -->
+            <StaticResource x:Key="RatingControlForeground" ResourceKey="PrimaryBrush" />
+
+            <StaticResource x:Key="RatingControlForegroundUnselected" ResourceKey="OnSurfaceLowBrush" />
+            <StaticResource x:Key="RatingControlForegroundSelected" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RatingControlPlaceholderForeground" ResourceKey="OnSurfaceLowBrush" />
+            <StaticResource x:Key="RatingControlPlaceholderForegroundPointerOver" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RatingControlForegroundPointerOverUnselected" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RatingControlForegroundPointerOverSelected" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="RatingControlForegroundDisabledSelected" ResourceKey="OnSurfaceLowBrush" />
+
+            <!-- Secondary -->
+            <StaticResource x:Key="SecondaryRatingControlForeground" ResourceKey="SecondaryBrush" />
+
+            <StaticResource x:Key="SecondaryRatingControlForegroundUnselected" ResourceKey="OnSurfaceLowBrush" />
+            <StaticResource x:Key="SecondaryRatingControlForegroundSelected" ResourceKey="SecondaryBrush" />
+            <StaticResource x:Key="SecondaryRatingControlPlaceholderForeground" ResourceKey="OnSurfaceLowBrush" />
+            <StaticResource x:Key="SecondaryRatingControlPlaceholderForegroundPointerOver" ResourceKey="SecondaryBrush" />
+            <StaticResource x:Key="SecondaryRatingControlForegroundPointerOverUnselected" ResourceKey="SecondaryBrush" />
+            <StaticResource x:Key="SecondaryRatingControlForegroundPointerOverSelected" ResourceKey="SecondaryBrush" />
+            <StaticResource x:Key="SecondaryRatingControlForegroundDisabledSelected" ResourceKey="OnSurfaceLowBrush" />
+
+            <!-- Caption and Fonts -->
+            <StaticResource x:Key="RatingControlCaptionForeground" ResourceKey="OnSurfaceBrush" />
+            <StaticResource x:Key="RatingControlCaptionFontFamily" ResourceKey="MaterialRegularFontFamily" />
+            <StaticResource x:Key="RatingControlCaptionStyle" ResourceKey="CaptionMedium" />
+            <StaticResource x:Key="RatingControlFontFamily" ResourceKey="SymbolThemeFontFamily" />
+
+            <StaticResource x:Key="SecondaryRatingControlCaptionForeground" ResourceKey="OnSurfaceBrush" />
+            <StaticResource x:Key="SecondaryRatingControlCaptionFontFamily" ResourceKey="MaterialRegularFontFamily" />
+            <StaticResource x:Key="SecondaryRatingControlCaptionStyle" ResourceKey="CaptionMedium" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+
+    <Style x:Key="MaterialRatingControlStyle"
+           TargetType="muxc:RatingControl">
+        <Setter Property="Height" Value="{ThemeResource RatingControlHeight}" />
+        <!-- 9794813: retire these two properties as customisation points once all resource keys available -->
+        <Setter Property="Foreground" Value="{ThemeResource RatingControlForeground}" />
+        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+        <Setter Property="FontFamily" Value="{ThemeResource RatingControlFontFamily}" />
+        <not_win:Setter Property="ItemInfo"
+                        Value="{ThemeResource MUX_RatingControlDefaultFontInfo}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="muxc:RatingControl">
+                    <Grid x:Name="LayoutRoot">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="ForegroundContentPresenter.Foreground" Value="{ThemeResource RatingControlForegroundDisabledSelected}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Placeholder">
+                                    <VisualState.Setters>
+                                        <Setter Target="ForegroundContentPresenter.Foreground" Value="{ThemeResource RatingControlPlaceholderForeground}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="PointerOverPlaceholder">
+                                    <VisualState.Setters>
+                                        <Setter Target="ForegroundContentPresenter.Foreground" Value="{ThemeResource RatingControlPlaceholderForegroundPointerOver}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="PointerOverUnselected">
+                                    <VisualState.Setters>
+                                        <Setter Target="ForegroundContentPresenter.Foreground" Value="{ThemeResource RatingControlForegroundPointerOverUnselected}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Set">
+                                    <VisualState.Setters>
+                                        <Setter Target="ForegroundContentPresenter.Foreground" Value="{ThemeResource RatingControlForegroundSelected}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="PointerOverSet">
+                                    <VisualState.Setters>
+                                        <Setter Target="ForegroundContentPresenter.Foreground" Value="{ThemeResource RatingControlForegroundSelected}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+
+                        <StackPanel Grid.Row="0"
+                                    Margin="-20,-20,-20,-20"
+                                    Orientation="Horizontal">
+                            <StackPanel x:Name="RatingBackgroundStackPanel"
+                                        Margin="20,20,0,20"
+                                        Background="Transparent"
+                                        Orientation="Horizontal" />
+                            <TextBlock x:Name="Caption"
+									   Height="{ThemeResource RatingControlCaptionHeight}"
+                                       Margin="4,9,20,0"
+                                       VerticalAlignment="Center"
+                                       AutomationProperties.AccessibilityView="Raw"
+                                       AutomationProperties.Name="RatingCaption"
+                                       Foreground="{ThemeResource RatingControlCaptionForeground}"
+                                       FontFamily="{ThemeResource RatingControlCaptionFontFamily}"
+                                       IsHitTestVisible="False"
+                                       Style="{ThemeResource RatingControlCaptionStyle}"
+                                       FontWeight="Bold"
+                                       Text="{TemplateBinding Caption}"
+                                       TextLineBounds="TrimToBaseline" />
+                            <!-- 4 = 8 item spacing +4 of magic redline spacing -8 to compensate for scale of the last RatingItem -->
+                            <!--
+                                NB: The redlines say 8px, but it's really 12 px because:
+                                Designer note: The value between the last glyph and first text character is 12px.
+                                (There's 4px of whitespace accounted for in the text area in the redline)
+                            -->
+                            <!-- TODO MSFT: 9925444 Fix vertical alignment in all text scenarios -->
+                        </StackPanel>
+
+                        <ContentPresenter x:Name="ForegroundContentPresenter"
+                                          Grid.Row="0"
+                                          IsHitTestVisible="False">
+                            <!-- Margin is on the StackPanel because ContentPresenter clips differently such that moving the reverse margin up won't work -->
+                            <StackPanel Margin="-40,-40,-40,-40"
+                                        Orientation="Horizontal">
+                                <StackPanel x:Name="RatingForegroundStackPanel"
+                                            Margin="40,40,40,40"
+                                            IsHitTestVisible="False"
+                                            Orientation="Horizontal" />
+                            </StackPanel>
+                        </ContentPresenter>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="SecondaryRatingControlStyle"
+           TargetType="muxc:RatingControl"
+           BasedOn="{StaticResource MaterialRatingControlStyle}">
+        <Setter Property="Foreground" Value="{ThemeResource SecondaryRatingControlForeground}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="muxc:RatingControl">
+                    <Grid x:Name="LayoutRoot">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="ForegroundContentPresenter.Foreground" Value="{ThemeResource SecondaryRatingControlForegroundDisabledSelected}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Placeholder">
+                                    <VisualState.Setters>
+                                        <Setter Target="ForegroundContentPresenter.Foreground" Value="{ThemeResource SecondaryRatingControlPlaceholderForeground}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="PointerOverPlaceholder">
+                                    <VisualState.Setters>
+                                        <Setter Target="ForegroundContentPresenter.Foreground" Value="{ThemeResource SecondaryRatingControlPlaceholderForegroundPointerOver}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="PointerOverUnselected">
+                                    <VisualState.Setters>
+                                        <Setter Target="ForegroundContentPresenter.Foreground" Value="{ThemeResource SecondaryRatingControlForegroundPointerOverUnselected}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Set">
+                                    <VisualState.Setters>
+                                        <Setter Target="ForegroundContentPresenter.Foreground" Value="{ThemeResource SecondaryRatingControlForegroundSelected}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="PointerOverSet">
+                                    <VisualState.Setters>
+                                        <Setter Target="ForegroundContentPresenter.Foreground" Value="{ThemeResource SecondaryRatingControlForegroundSelected}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+
+                        <StackPanel Grid.Row="0"
+                                    Margin="-20,-20,-20,-20"
+                                    Orientation="Horizontal">
+                            <StackPanel x:Name="RatingBackgroundStackPanel"
+                                        Margin="20,20,0,20"
+                                        Background="Transparent"
+                                        Orientation="Horizontal" />
+                            <TextBlock x:Name="Caption"
+									   Height="{ThemeResource SecondaryRatingControlCaptionHeight}"
+                                       Margin="4,9,20,0"
+                                       VerticalAlignment="Center"
+                                       AutomationProperties.AccessibilityView="Raw"
+                                       AutomationProperties.Name="RatingCaption"
+                                       Foreground="{ThemeResource SecondaryRatingControlCaptionForeground}"
+                                       FontFamily="{ThemeResource SecondaryRatingControlCaptionFontFamily}"
+                                       IsHitTestVisible="False"
+                                       Style="{ThemeResource SecondaryRatingControlCaptionStyle}"
+                                       FontWeight="Bold"
+                                       Text="{TemplateBinding Caption}"
+                                       TextLineBounds="TrimToBaseline" />
+                            <!-- 4 = 8 item spacing +4 of magic redline spacing -8 to compensate for scale of the last RatingItem -->
+                            <!--
+                                NB: The redlines say 8px, but it's really 12 px because:
+                                Designer note: The value between the last glyph and first text character is 12px.
+                                (There's 4px of whitespace accounted for in the text area in the redline)
+                            -->
+                            <!-- TODO MSFT: 9925444 Fix vertical alignment in all text scenarios -->
+                        </StackPanel>
+
+                        <ContentPresenter x:Name="ForegroundContentPresenter"
+                                          Grid.Row="0"
+                                          IsHitTestVisible="False">
+                            <!-- Margin is on the StackPanel because ContentPresenter clips differently such that moving the reverse margin up won't work -->
+                            <StackPanel Margin="-40,-40,-40,-40"
+                                        Orientation="Horizontal">
+                                <StackPanel x:Name="RatingForegroundStackPanel"
+                                            Margin="40,40,40,40"
+                                            IsHitTestVisible="False"
+                                            Orientation="Horizontal" />
+                            </StackPanel>
+                        </ContentPresenter>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+	<Style x:Key="MaterialDefaultRatingControlStyle"
+		   TargetType="muxc:RatingControl"
+		   BasedOn="{StaticResource MaterialRatingControlStyle}" />
+</ResourceDictionary>

--- a/src/library/Uno.Material/Styles/Controls/v2/_Resources.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/_Resources.xaml
@@ -33,6 +33,7 @@
 	<Style BasedOn="{StaticResource MaterialDefaultProgressBarStyle}" TargetType="muxc:ProgressBar" />
 	<Style BasedOn="{StaticResource MaterialDefaultProgressRingStyle}" TargetType="muxc:ProgressRing" />
 	<Style BasedOn="{StaticResource MaterialDefaultRadioButtonStyle}" TargetType="RadioButton" />
+	<Style BasedOn="{StaticResource MaterialDefaultRatingControlStyle}" TargetType="RatingControl" />
 	<Style BasedOn="{StaticResource MaterialDefaultRippleStyle}" TargetType="um:Ripple" />
 	<Style BasedOn="{StaticResource MaterialDefaultSliderStyle}" TargetType="Slider" />
 	<Style BasedOn="{StaticResource MaterialDefaultTextBlockStyle}" TargetType="TextBlock" />
@@ -69,6 +70,7 @@
 	<StaticResource x:Key="ProgressBarStyle"					ResourceKey="MaterialProgressBarStyle"			/>
 	<StaticResource x:Key="ProgressRingStyle"					ResourceKey="MaterialProgressRingStyle"			/>
 	<StaticResource x:Key="RadioButtonStyle"					ResourceKey="MaterialRadioButtonStyle"			/>
+	<StaticResource x:Key="RatingControlStyle"                  ResourceKey="MaterialRatingControlStyle"        />
 	<StaticResource x:Key="RippleStyle"							ResourceKey="MaterialRippleStyle"				/>
 	<StaticResource x:Key="SliderStyle"							ResourceKey="MaterialSliderStyle"				/>
 	<StaticResource x:Key="ToggleMenuFlyoutItemStyle"			ResourceKey="MaterialToggleMenuFlyoutItemStyle"	/>

--- a/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/RatingControlSamplePage.xaml
+++ b/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/RatingControlSamplePage.xaml
@@ -1,0 +1,62 @@
+﻿<Page x:Class="Uno.Themes.Samples.Content.Controls.RatingControlSamplePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:Uno.Themes.Samples.Shared.Content"
+      xmlns:sample="using:Uno.Themes.Samples"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:android="http://uno.ui/android"
+      xmlns:ios="http://uno.ui/ios"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:smtx="using:ShowMeTheXAML"
+      mc:Ignorable="d android ios">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <sample:SamplePageLayout>
+            <sample:SamplePageLayout.MaterialTemplate>
+                <DataTemplate>
+                    <StackPanel>
+                        <!-- Default style -->
+                        <TextBlock Text="Material RatingControl style with label"
+                                   Style="{StaticResource TitleSmall}"
+                                   Margin="0,0,16,0" />
+                        <smtx:XamlDisplay UniqueKey="Material_DefaultRatingControlSamplePage">
+                            <muxc:RatingControl Style="{StaticResource MaterialRatingControlStyle}"
+                                                Caption="Label" />
+                        </smtx:XamlDisplay>
+
+                        <!-- Secondary style -->
+                        <TextBlock Text="Material Secondary RatingControl style without label"
+                                   Style="{StaticResource TitleSmall}"
+                                   Margin="0,0,16,0" />
+                        <smtx:XamlDisplay UniqueKey="Material_SecondaryRatingControlSamplePage">
+                            <muxc:RatingControl Style="{StaticResource MaterialSecondaryRatingControlStyle}" />
+                        </smtx:XamlDisplay>
+                    </StackPanel>
+                </DataTemplate>
+            </sample:SamplePageLayout.MaterialTemplate>
+            <sample:SamplePageLayout.M3MaterialTemplate>
+                <DataTemplate>
+                    <StackPanel>
+                        <!-- Default style -->
+                        <TextBlock Text="Default RatingControl style with label"
+                                   Style="{StaticResource TitleSmall}"
+                                   Margin="0,0,16,0" />
+                        <smtx:XamlDisplay UniqueKey="M3_Material_DefaultRatingControlSamplePage">
+                            <muxc:RatingControl Style="{StaticResource MaterialRatingControlStyle}"
+                                                Caption="Label" />
+                        </smtx:XamlDisplay>
+
+                        <!-- Secondary style -->
+                        <TextBlock Text="Secondary RatingControl style without label"
+                                   Style="{StaticResource TitleSmall}"
+                                   Margin="0,0,16,0" />
+                        <smtx:XamlDisplay UniqueKey="M3_Material_SecondaryRatingControlSamplePage">
+                            <muxc:RatingControl Style="{StaticResource SecondaryRatingControlStyle}" />
+                        </smtx:XamlDisplay>
+                    </StackPanel>
+                </DataTemplate>
+            </sample:SamplePageLayout.M3MaterialTemplate>
+        </sample:SamplePageLayout>
+    </Grid>
+</Page>

--- a/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/RatingControlSamplePage.xaml.cs
+++ b/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/RatingControlSamplePage.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.Themes.Samples.Entities;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.Themes.Samples.Content.Controls
+{
+	[SamplePage(SampleCategory.Controls, "RatingControl", Description = "This control allows a user to enter a star rating.", DocumentationLink = "https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.ratingcontrol")]
+	public sealed partial class RatingControlSamplePage : Page
+	{
+		public RatingControlSamplePage()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/samples/UWP/Uno.Themes.Samples.Shared/Uno.Themes.Samples.Shared.projitems
+++ b/src/samples/UWP/Uno.Themes.Samples.Shared/Uno.Themes.Samples.Shared.projitems
@@ -77,6 +77,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Content\Controls\RadioButtonSamplePage.xaml.cs">
       <DependentUpon>RadioButtonSamplePage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Content\Controls\RatingControlSamplePage.xaml.cs">
+      <DependentUpon>RatingControlSamplePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Content\Controls\SliderSamplePage.xaml.cs">
       <DependentUpon>SliderSamplePage.xaml</DependentUpon>
     </Compile>
@@ -218,6 +221,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Content\Controls\RadioButtonSamplePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Content\Controls\RatingControlSamplePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>


### PR DESCRIPTION
closes #830 

﻿GitHub Issue: #830 

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Feature


## Description
Added RatingControl styles in v2/ and RatingControl Sample Page.

Overriden:
![image](https://github.com/unoplatform/Uno.Themes/assets/54756963/c15dc134-8e29-460e-a452-b48fd703e050)

Overriden with:

	<Page.Resources>
		<SolidColorBrush x:Key="RatingControlForeground"
						Color="Red" />

		<SolidColorBrush x:Key="RatingControlForegroundUnselected"
						Color="Orange" />
		<SolidColorBrush x:Key="RatingControlForegroundSelected"
						Color="Yellow" />
		<SolidColorBrush x:Key="RatingControlPlaceholderForeground"
						Color="Green" />
		<SolidColorBrush x:Key="RatingControlPlaceholderForegroundPointerOver"
						Color="Blue" />
		<SolidColorBrush x:Key="RatingControlForegroundPointerOverUnselected"
						Color="Indigo" />
		<SolidColorBrush x:Key="RatingControlForegroundPointerOverSelected"
						Color="Pink" />
		<SolidColorBrush x:Key="RatingControlForegroundDisabledSelected"
						Color="Red" />

		<!-- Secondary -->
		<SolidColorBrush x:Key="SecondaryRatingControlForeground"
						Color="Orange" />

		<SolidColorBrush x:Key="SecondaryRatingControlForegroundUnselected"
						Color="Yellow" />
		<SolidColorBrush x:Key="SecondaryRatingControlForegroundSelected"
						Color="Green" />
		<SolidColorBrush x:Key="SecondaryRatingControlPlaceholderForeground"
						Color="Blue" />
		<SolidColorBrush x:Key="SecondaryRatingControlPlaceholderForegroundPointerOver"
						Color="Indigo" />
		<SolidColorBrush x:Key="SecondaryRatingControlForegroundPointerOverUnselected"
						Color="Pink" />
		<SolidColorBrush x:Key="SecondaryRatingControlForegroundPointerOverSelected"
						Color="Red" />
		<SolidColorBrush x:Key="SecondaryRatingControlForegroundDisabledSelected"
						Color="Orange" />
		<SolidColorBrush x:Key="RatingControlCaptionForeground"
						Color="Pink" />
		<SolidColorBrush x:Key="SecondaryRatingControlCaptionForeground"
						 Color="Green" />
	</Page.Resources>


## PR Checklist 
- [X] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [X] Tested WASM
- [ ] Tested MacOS