### PR TITLE
fix: flyout textBlock wrapping with long text

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/Flyout.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/Flyout.xaml
@@ -245,6 +245,7 @@
 						<TextBlock x:Name="TextBlock"
 						           Grid.Column="1"
 						           Margin="12,0,0,0"
+								   TextWrapping="NoWrap"
 						           VerticalAlignment="Center"
 						           Foreground="{TemplateBinding Foreground}"
 						           Style="{StaticResource MaterialLabelLarge}"


### PR DESCRIPTION
﻿GitHub Issue:  [[Gallery][Skia.GTK] 'Help' `Flyout` 'Send Feedback' text is not displaying correctly, and the word 'Colors' is missing](https://github.com/unoplatform/uno/issues/8930)  


## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description

<!-- (Please describe the changes that this PR introduces.) -->
flyout textBlock wrapping with long text

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested Skia GTK
- [ ] Tested iOS
- [ ] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->
![image](https://github.com/unoplatform/Uno.Themes/assets/34275909/0d0936ba-f09c-4d6a-ba70-c380a8203661)

