### PR TITLE
ci(perf): Disable .NET native for uwp builds

### DIFF
--- a/src/samples/UWP/Uno.Themes.Samples.UWP/Uno.Themes.Samples.UWP.csproj
+++ b/src/samples/UWP/Uno.Themes.Samples.UWP/Uno.Themes.Samples.UWP.csproj
@@ -85,7 +85,8 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
-<UseDotNetNativeToolchain>true</UseDotNetNativeToolchain><UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>  </PropertyGroup>
+    <UseDotNetNativeToolchain>false</UseDotNetNativeToolchain>
+  </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>

--- a/src/samples/UWP/Uno.Themes.Samples.UWP/Uno.Themes.Samples.UWP.csproj
+++ b/src/samples/UWP/Uno.Themes.Samples.UWP/Uno.Themes.Samples.UWP.csproj
@@ -85,8 +85,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
-    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
-  </PropertyGroup>
+<UseDotNetNativeToolchain>true</UseDotNetNativeToolchain><UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>  </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>


### PR DESCRIPTION
Disables unused .NET native for UWP sample builds