### PR TITLE
fix(Cupertino): add CupertinoTheme class

### DIFF
--- a/src/library/Uno.Cupertino/CupertinoTheme.cs
+++ b/src/library/Uno.Cupertino/CupertinoTheme.cs
@@ -1,0 +1,224 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+#if WinUI
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Media;
+#else
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
+#endif
+
+namespace Uno.Cupertino
+{
+	public class CupertinoTheme : ResourceDictionary
+	{
+		private bool _isColorOverrideMuted;
+		private bool _isFontOverrideMuted;
+
+		#region FontOverrideSource (DP)
+		/// <summary>
+		/// (Optional) Gets or sets a Uniform Resource Identifier (<see cref="Uri"/>) that provides the source location
+		/// of a <see cref="ResourceDictionary"/> containing overrides for the default Uno.Cupertino <see cref="FontFamily"/> resources
+		/// </summary>
+		public string FontOverrideSource
+		{
+			get => (string)GetValue(FontOverrideSourceProperty);
+			set => SetValue(FontOverrideSourceProperty, value);
+		}
+
+		public static DependencyProperty FontOverrideSourceProperty { get; } =
+			DependencyProperty.Register(
+				nameof(FontOverrideSource),
+				typeof(string),
+				typeof(CupertinoTheme),
+				new PropertyMetadata(null, OnFontOverrideSourceChanged));
+
+		private static void OnFontOverrideSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			if (d is CupertinoTheme theme && e.NewValue is string sourceUri)
+			{
+				theme.FontOverrideDictionary = new ResourceDictionary() { Source = new Uri(sourceUri) };
+			}
+		}
+		#endregion
+
+		#region ColorOverrideSource (DP)
+		/// <summary>
+		/// (Optional) Gets or sets a Uniform Resource Identifier (<see cref="Uri"/>) that provides the source location
+		/// of a <see cref="ResourceDictionary"/> containing overrides for the default Uno.Cupertino <see cref="Color"/> resources
+		/// </summary>
+		/// <remarks>The overrides set here should be re-defining the <see cref="Color"/> resources used by Uno.Cupertino, not the <see cref="SolidColorBrush"/> resources</remarks>
+		public string ColorOverrideSource
+		{
+			get => (string)GetValue(ColorOverrideSourceProperty);
+			set => SetValue(ColorOverrideSourceProperty, value);
+		}
+
+		public static DependencyProperty ColorOverrideSourceProperty { get; } =
+			DependencyProperty.Register(
+				nameof(ColorOverrideSource),
+				typeof(string),
+				typeof(CupertinoTheme),
+				new PropertyMetadata(null, OnColorOverrideSourceChanged));
+
+		private static void OnColorOverrideSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			if (d is CupertinoTheme theme && e.NewValue is string sourceUri)
+			{
+				theme.ColorOverrideDictionary = new ResourceDictionary() { Source = new Uri(sourceUri) };
+			}
+		}
+		#endregion
+
+		#region FontOverrideDictionary (DP)
+		/// <summary>
+		/// (Optional) Gets or sets a <see cref="ResourceDictionary"/> containing overrides for the default Uno.Cupertino <see cref="FontFamily"/> resources
+		/// </summary>
+		public ResourceDictionary FontOverrideDictionary
+		{
+			get => (ResourceDictionary)GetValue(FontOverrideDictionaryProperty);
+			set => SetValue(FontOverrideDictionaryProperty, value);
+		}
+
+		public static DependencyProperty FontOverrideDictionaryProperty { get; } =
+			DependencyProperty.Register(
+				nameof(FontOverrideDictionary),
+				typeof(ResourceDictionary),
+				typeof(CupertinoTheme),
+				new PropertyMetadata(null, OnFontOverrideChanged));
+
+		private static void OnFontOverrideChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			if (d is CupertinoTheme { _isFontOverrideMuted: false } theme)
+			{
+				theme.UpdateSource();
+			}
+		}
+		#endregion
+
+		#region ColorOverrideDictionary (DP)
+		/// <summary>
+		/// (Optional) Gets or sets a <see cref="ResourceDictionary"/> containing overrides for the default Uno.Cupertino <see cref="Color"/> resources
+		/// </summary>
+		/// <remarks>The overrides set here should be re-defining the <see cref="Color"/> resources used by Uno.Cupertino, not the <see cref="SolidColorBrush"/> resources</remarks>
+		public ResourceDictionary ColorOverrideDictionary
+		{
+			get => (ResourceDictionary)GetValue(ColorOverrideDictionaryProperty);
+			set => SetValue(ColorOverrideDictionaryProperty, value);
+		}
+
+		public static DependencyProperty ColorOverrideDictionaryProperty { get; } =
+			DependencyProperty.Register(
+				nameof(ColorOverrideDictionary),
+				typeof(ResourceDictionary),
+				typeof(CupertinoTheme),
+				new PropertyMetadata(null, OnColorOverrideChanged));
+
+		private static void OnColorOverrideChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			if (d is CupertinoTheme { _isColorOverrideMuted: false } theme)
+			{
+				theme.UpdateSource();
+			}
+		}
+		#endregion
+
+		public CupertinoTheme() : this(colorOverride: null, fontOverride: null)
+		{
+
+		}
+
+		public CupertinoTheme(ResourceDictionary colorOverride = null, ResourceDictionary fontOverride = null)
+		{
+			if (colorOverride is { })
+			{
+				SetColorOverrideSilently(colorOverride);
+			}
+
+			if (fontOverride is { })
+			{
+				SetFontOverrideSilently(fontOverride);
+			}
+
+			UpdateSource();
+		}
+
+		private void SetColorOverrideSilently(ResourceDictionary colorOverride)
+		{
+			try
+			{
+				_isColorOverrideMuted = true;
+				ColorOverrideDictionary = colorOverride;
+			}
+			finally
+			{
+				_isColorOverrideMuted = false;
+			}
+		}
+
+		private void SetFontOverrideSilently(ResourceDictionary fontOverride)
+		{
+			try
+			{
+				_isFontOverrideMuted = true;
+				FontOverrideDictionary = fontOverride;
+			}
+			finally
+			{
+				_isFontOverrideMuted = false;
+			}
+		}
+
+		private void UpdateSource()
+		{
+#if !HAS_UNO
+			Source = null;
+#endif
+			ThemeDictionaries.Clear();
+			MergedDictionaries.Clear();
+			this.Clear();
+
+			var colors = new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Cupertino/Styles/Application/ColorPalette.xaml") };
+
+			colors.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Cupertino/Styles/Application/CupertinoColors.xaml") });
+
+			if (ColorOverrideDictionary is { } colorOverride)
+			{
+				colors.MergedDictionaries
+#if !HAS_UNO
+				.Add(colorOverride.Duplicate());
+#else
+				.Add(colorOverride);
+#endif
+			}
+
+			var mergedPages = new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Cupertino/Generated/mergedpages.xaml") };
+
+			var fonts = new ResourceDictionary { Source = new Uri("ms-appx:///Uno.Cupertino/Styles/Application/Fonts.xaml") };
+
+			if (FontOverrideDictionary is { } fontOverride)
+			{
+				fonts.MergedDictionaries
+#if !HAS_UNO
+				.Add(fontOverride.Duplicate());
+#else
+				.Add(fontOverride);
+#endif
+			}
+
+			mergedPages.MergedDictionaries.Add(colors);
+			mergedPages.MergedDictionaries.Add(fonts);
+
+			MergedDictionaries.Add(mergedPages);
+		}
+	}
+}


### PR DESCRIPTION
﻿GitHub Issue: https://github.com/unoplatform/Uno.Themes/issues/1185

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->

add CupertinoTheme class
## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



