### PR TITLE
fix(Button): fix button visibility when grid column/row is zero

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/Button.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/Button.xaml
@@ -180,16 +180,14 @@
 			<StaticResource x:Key="IconButtonEllipseFillPressed" ResourceKey="PrimaryPressedBrush" />
 			<StaticResource x:Key="IconButtonEllipseFillFocused" ResourceKey="PrimaryFocusedBrush" />
 
-			<x:Double x:Key="ButtonMinHeight">40</x:Double>
-			<x:Double x:Key="ButtonMinWidth">40</x:Double>
 			<x:Double x:Key="ButtonIconMinWidth">18</x:Double>
 			<x:Double x:Key="ElevatedButtonElevation">1</x:Double>
 			<x:Double x:Key="ElevatedButtonElevationDisabled">0</x:Double>
 			<x:Double x:Key="ButtonElevation">0</x:Double>
 			<x:Double x:Key="IconButtonOpacityVisibleState">1</x:Double>
 			<x:Double x:Key="IconButtonOpacityHiddenState">0</x:Double>
-			<Thickness x:Key="ButtonPadding">16,0</Thickness>
-			<Thickness x:Key="TextButtonPadding">12,0</Thickness>
+			<Thickness x:Key="ButtonPadding">16,10</Thickness>
+			<Thickness x:Key="TextButtonPadding">12,8</Thickness>
 			<Thickness x:Key="TextButtonIconMargin">0,0,8,0</Thickness>
 			<Thickness x:Key="ButtonBorderThickness">0</Thickness>
 			<Thickness x:Key="OutlinedButtonBorderThickness">1</Thickness>
@@ -357,16 +355,14 @@
 			<StaticResource x:Key="IconButtonEllipseFillPressed" ResourceKey="PrimaryPressedBrush" />
 			<StaticResource x:Key="IconButtonEllipseFillFocused" ResourceKey="PrimaryFocusedBrush" />
 
-			<x:Double x:Key="ButtonMinHeight">40</x:Double>
-			<x:Double x:Key="ButtonMinWidth">40</x:Double>
 			<x:Double x:Key="ButtonIconMinWidth">18</x:Double>
 			<x:Double x:Key="ElevatedButtonElevation">1</x:Double>
 			<x:Double x:Key="ElevatedButtonElevationDisabled">0</x:Double>
 			<x:Double x:Key="ButtonElevation">0</x:Double>
 			<x:Double x:Key="IconButtonOpacityVisibleState">1</x:Double>
 			<x:Double x:Key="IconButtonOpacityHiddenState">0</x:Double>
-			<Thickness x:Key="ButtonPadding">16,0</Thickness>
-			<Thickness x:Key="TextButtonPadding">12,0</Thickness>
+			<Thickness x:Key="ButtonPadding">16,10</Thickness>
+			<Thickness x:Key="TextButtonPadding">12,8</Thickness>
 			<Thickness x:Key="TextButtonIconMargin">0,0,8,0</Thickness>
 			<Thickness x:Key="ButtonBorderThickness">0</Thickness>
 			<Thickness x:Key="OutlinedButtonBorderThickness">1</Thickness>
@@ -389,8 +385,6 @@
 		<Setter Property="CharacterSpacing" Value="{ThemeResource LabelLargeCharacterSpacing}" />
 		<!-- End: Label Large Typo -->
 
-		<Setter Property="MinHeight" Value="{ThemeResource ButtonMinHeight}" />
-		<Setter Property="MinWidth" Value="{ThemeResource ButtonMinWidth}" />
 		<Setter Property="Padding" Value="{ThemeResource ButtonPadding}" />
 		<Setter Property="CornerRadius" Value="{ThemeResource ButtonCornerRadius}" />
 		<Setter Property="BorderThickness" Value="{ThemeResource ButtonBorderThickness}" />


### PR DESCRIPTION
﻿GitHub Issue: https://github.com/unoplatform/Uno.Themes/issues/1188

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->

### **Wasm**
|Before|After|
|--|--|
|<img width="151" alt="WASM-button-before" src="https://github.com/unoplatform/Uno.Themes/assets/34275909/d69c51d0-0dae-48fc-8d17-65c87b269232">|<img width="149" alt="WASM-button-after" src="https://github.com/unoplatform/Uno.Themes/assets/34275909/841a41db-71ae-43b1-a61c-328de325529e">|

### **Android**
|Before|After|
|--|--|
|<img width="297" alt="AND-button-before" src="https://github.com/unoplatform/Uno.Themes/assets/34275909/3cfd1216-699d-431b-b289-253aea974f78">|<img width="300" alt="AND-button-after" src="https://github.com/unoplatform/Uno.Themes/assets/34275909/a497d4d2-1f79-42a2-b0b7-803c7a349021">|


### **GTK**
|Before|After|
|--|--|
|<img width="152" alt="GTK-button-before" src="https://github.com/unoplatform/Uno.Themes/assets/34275909/32227038-db4c-4a1d-a333-4a68aabefc9c">|<img width="147" alt="GTK-button-after" src="https://github.com/unoplatform/Uno.Themes/assets/34275909/5bae2a63-98c2-4a2b-a138-b8fc8b6e5f27">|

### **iOS**
|Before|After|
|--|--|
|<img width="229" alt="iOS-button-before" src="https://github.com/unoplatform/Uno.Themes/assets/34275909/213a0b71-4b4a-498d-b8f5-a84781b72eec">|<img width="227" alt="iOS-button-iOS" src="https://github.com/unoplatform/Uno.Themes/assets/34275909/12a44672-3a8c-4f1b-a620-9d07c0339a93">|

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [x] iOS
	- [x] Android
	- [x] WASM
	- [x]  GTK
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

