### PR TITLE
feat: add lightweight styling resources to ToggleButton

### DIFF
--- a/src/library/Uno.Themes.WinUI.Markup/Theme.Styles.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme.Styles.cs
@@ -85,21 +85,6 @@ namespace Uno.Themes.Markup
 				[ResourceKeyDefinition(typeof(Style), "PipsPagerStyle", TargetType = typeof(PipsPager))]
 				public static StaticResourceKey<Style> Default => new("PipsPagerStyle");
 			}
-
-			public static class Slider
-			{
-				[ResourceKeyDefinition(typeof(Style), "SliderStyle", TargetType = typeof(Slider))]
-				public static StaticResourceKey<Style> Default => new("SliderStyle");
-			}
-
-			public static class ToggleButton
-			{
-				[ResourceKeyDefinition(typeof(Style), "TextToggleButtonStyle", TargetType = typeof(ToggleButton))]
-				public static StaticResourceKey<Style> Text => new("TextToggleButtonStyle");
-
-				[ResourceKeyDefinition(typeof(Style), "IconToggleButtonStyle", TargetType = typeof(ToggleButton))]
-				public static StaticResourceKey<Style> Icon => new("IconToggleButtonStyle");
-			}
 		}
 	}
 }

--- a/src/library/Uno.Themes.WinUI.Markup/Theme/Slider.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme/Slider.cs
@@ -74,14 +74,8 @@ namespace Uno.Themes.Markup
 
 			public static class Styles
 			{
-				[ResourceKeyDefinition(typeof(Style), "MaterialSliderStyle", TargetType = typeof(Slider))]
-				public static StaticResourceKey<Style> Default => new("MaterialSliderStyle");
-
-				public static class Thumb
-				{
-					[ResourceKeyDefinition(typeof(Style), "MaterialSliderThumbStyle", TargetType = typeof(Microsoft.UI.Xaml.Controls.Primitives.Thumb))]
-					public static ThemeResourceKey<Style> Default => new("MaterialSliderThumbStyle");
-				}
+				[ResourceKeyDefinition(typeof(Style), "SliderStyle", TargetType = typeof(Slider))]
+				public static StaticResourceKey<Style> Default => new("SliderStyle");
 			}
 		}
 	}

--- a/src/library/Uno.Themes.WinUI.Markup/Theme/ToggleButton.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme/ToggleButton.cs
@@ -1,0 +1,344 @@
+﻿using Microsoft.UI.Text;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using Uno.Extensions.Markup;
+using Uno.Extensions.Markup.Internals;
+
+namespace Uno.Themes.Markup
+{
+	public static partial class Theme
+	{
+		public static class ToggleButton
+		{
+			public static class Resources
+			{
+				public static class Text
+				{
+					public static class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBackground")]
+						public static ThemeResourceKey<Brush> Default => new("TextToggleButtonBackground");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBackgroundPointerOver")]
+						public static ThemeResourceKey<Brush> PointerOver => new("TextToggleButtonBackgroundPointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBackgroundPressed")]
+						public static ThemeResourceKey<Brush> Pressed => new("TextToggleButtonBackgroundPressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBackgroundDisabled")]
+						public static ThemeResourceKey<Brush> Disabled => new("TextToggleButtonBackgroundDisabled");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBackgroundChecked")]
+						public static ThemeResourceKey<Brush> Checked => new("TextToggleButtonBackgroundChecked");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBackgroundCheckedPointerOver")]
+						public static ThemeResourceKey<Brush> CheckedPointerOver => new("TextToggleButtonBackgroundCheckedPointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBackgroundCheckedPressed")]
+						public static ThemeResourceKey<Brush> CheckedPressed => new("TextToggleButtonBackgroundCheckedPressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBackgroundCheckedDisabled")]
+						public static ThemeResourceKey<Brush> CheckedDisabled => new("TextToggleButtonBackgroundCheckedDisabled");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBackgroundIndeterminate")]
+						public static ThemeResourceKey<Brush> Indeterminate => new("TextToggleButtonBackgroundIndeterminate");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBackgroundIndeterminatePointerOver")]
+						public static ThemeResourceKey<Brush> IndeterminatePointerOver => new("TextToggleButtonBackgroundIndeterminatePointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBackgroundIndeterminatePressed")]
+						public static ThemeResourceKey<Brush> IndeterminatePressed => new("TextToggleButtonBackgroundIndeterminatePressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBackgroundIndeterminateDisabled")]
+						public static ThemeResourceKey<Brush> IndeterminateDisabled => new("TextToggleButtonBackgroundIndeterminateDisabled");
+					}
+
+					public static class Foreground
+					{
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonForeground")]
+						public static ThemeResourceKey<Brush> Default => new("TextToggleButtonForeground");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonForegroundPointerOver")]
+						public static ThemeResourceKey<Brush> PointerOver => new("TextToggleButtonForegroundPointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonForegroundPressed")]
+						public static ThemeResourceKey<Brush> Pressed => new("TextToggleButtonForegroundPressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonForegroundDisabled")]
+						public static ThemeResourceKey<Brush> Disabled => new("TextToggleButtonForegroundDisabled");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonForegroundChecked")]
+						public static ThemeResourceKey<Brush> Checked => new("TextToggleButtonForegroundChecked");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonForegroundCheckedPointerOver")]
+						public static ThemeResourceKey<Brush> CheckedPointerOver => new("TextToggleButtonForegroundCheckedPointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonForegroundCheckedPressed")]
+						public static ThemeResourceKey<Brush> CheckedPressed => new("TextToggleButtonForegroundCheckedPressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonForegroundCheckedDisabled")]
+						public static ThemeResourceKey<Brush> CheckedDisabled => new("TextToggleButtonForegroundCheckedDisabled");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonForegroundIndeterminate")]
+						public static ThemeResourceKey<Brush> Indeterminate => new("TextToggleButtonForegroundIndeterminate");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonForegroundIndeterminatePointerOver")]
+						public static ThemeResourceKey<Brush> IndeterminatePointerOver => new("TextToggleButtonForegroundIndeterminatePointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonForegroundIndeterminatePressed")]
+						public static ThemeResourceKey<Brush> IndeterminatePressed => new("TextToggleButtonForegroundIndeterminatePressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonForegroundIndeterminateDisabled")]
+						public static ThemeResourceKey<Brush> IndeterminateDisabled => new("TextToggleButtonForegroundIndeterminateDisabled");
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrush")]
+						public static ThemeResourceKey<Brush> Default => new("TextToggleButtonBorderBrush");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrushPointerOver")]
+						public static ThemeResourceKey<Brush> PointerOver => new("TextToggleButtonBorderBrushPointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrushPressed")]
+						public static ThemeResourceKey<Brush> Pressed => new("TextToggleButtonBorderBrushPressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrushDisabled")]
+						public static ThemeResourceKey<Brush> Disabled => new("TextToggleButtonBorderBrushDisabled");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrushChecked")]
+						public static ThemeResourceKey<Brush> Checked => new("TextToggleButtonBorderBrushChecked");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrushCheckedPointerOver")]
+						public static ThemeResourceKey<Brush> CheckedPointerOver => new("TextToggleButtonBorderBrushCheckedPointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrushCheckedPressed")]
+						public static ThemeResourceKey<Brush> CheckedPressed => new("TextToggleButtonBorderBrushCheckedPressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrushCheckedDisabled")]
+						public static ThemeResourceKey<Brush> CheckedDisabled => new("TextToggleButtonBorderBrushCheckedDisabled");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrushIndeterminate")]
+						public static ThemeResourceKey<Brush> Indeterminate => new("TextToggleButtonBorderBrushIndeterminate");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrushIndeterminatePointerOver")]
+						public static ThemeResourceKey<Brush> IndeterminatePointerOver => new("TextToggleButtonBorderBrushIndeterminatePointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrushIndeterminatePressed")]
+						public static ThemeResourceKey<Brush> IndeterminatePressed => new("TextToggleButtonBorderBrushIndeterminatePressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrushIndeterminateDisabled")]
+						public static ThemeResourceKey<Brush> IndeterminateDisabled => new("TextToggleButtonBorderBrushIndeterminateDisabled");
+					}
+
+					public static class BorderBrushOverlay
+					{
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrushHoverOverlay")]
+						public static ThemeResourceKey<Brush> Hover => new("TextToggleButtonBorderBrushHoverOverlay");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrushFocusedOverlay")]
+						public static ThemeResourceKey<Brush> Focused => new("TextToggleButtonBorderBrushFocusedOverlay");
+
+						[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonBorderBrushSelectedOverlay")]
+						public static ThemeResourceKey<Brush> Selected => new("TextToggleButtonBorderBrushSelectedOverlay");
+					}
+
+					public static class Typography
+					{
+						[ResourceKeyDefinition(typeof(FontFamily), "TextToggleButtonFontFamily")]
+						public static ThemeResourceKey<FontFamily> FontFamily => new("TextToggleButtonFontFamily");
+
+						[ResourceKeyDefinition(typeof(double), "TextToggleButtonFontSize")]
+						public static ThemeResourceKey<double> FontSize => new("TextToggleButtonFontSize");
+					}
+
+					[ResourceKeyDefinition(typeof(Brush), "TextToggleButtonFeedbackFocused")]
+					public static ThemeResourceKey<Brush> FeedbackFocused => new("TextToggleButtonFeedbackFocused");
+
+					[ResourceKeyDefinition(typeof(Thickness), "TextToggleButtonBorderThickness")]
+					public static ThemeResourceKey<Thickness> BorderThickness => new("TextToggleButtonBorderThickness");
+
+					[ResourceKeyDefinition(typeof(CornerRadius), "TextToggleButtonCornerRadius")]
+					public static ThemeResourceKey<CornerRadius> CornerRadius => new("TextToggleButtonCornerRadius");
+
+					[ResourceKeyDefinition(typeof(Thickness), "TextToggleButtonPadding")]
+					public static ThemeResourceKey<Thickness> Padding => new("TextToggleButtonPadding");
+
+					[ResourceKeyDefinition(typeof(double), "TextToggleButtonMinHeight")]
+					public static ThemeResourceKey<double> MinHeight => new("TextToggleButtonMinHeight");
+				}
+
+				public static class Icon
+				{
+					public static class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBackground")]
+						public static ThemeResourceKey<Brush> Default => new("IconToggleButtonBackground");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBackgroundPointerOver")]
+						public static ThemeResourceKey<Brush> PointerOver => new("IconToggleButtonBackgroundPointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBackgroundPressed")]
+						public static ThemeResourceKey<Brush> Pressed => new("IconToggleButtonBackgroundPressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBackgroundDisabled")]
+						public static ThemeResourceKey<Brush> Disabled => new("IconToggleButtonBackgroundDisabled");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBackgroundChecked")]
+						public static ThemeResourceKey<Brush> Checked => new("IconToggleButtonBackgroundChecked");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBackgroundCheckedPointerOver")]
+						public static ThemeResourceKey<Brush> CheckedPointerOver => new("IconToggleButtonBackgroundCheckedPointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBackgroundCheckedPressed")]
+						public static ThemeResourceKey<Brush> CheckedPressed => new("IconToggleButtonBackgroundCheckedPressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBackgroundCheckedDisabled")]
+						public static ThemeResourceKey<Brush> CheckedDisabled => new("IconToggleButtonBackgroundCheckedDisabled");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBackgroundIndeterminate")]
+						public static ThemeResourceKey<Brush> Indeterminate => new("IconToggleButtonBackgroundIndeterminate");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBackgroundIndeterminatePointerOver")]
+						public static ThemeResourceKey<Brush> IndeterminatePointerOver => new("IconToggleButtonBackgroundIndeterminatePointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBackgroundIndeterminatePressed")]
+						public static ThemeResourceKey<Brush> IndeterminatePressed => new("IconToggleButtonBackgroundIndeterminatePressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBackgroundIndeterminateDisabled")]
+						public static ThemeResourceKey<Brush> IndeterminateDisabled => new("IconToggleButtonBackgroundIndeterminateDisabled");
+					}
+
+					public static class Foreground
+					{
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonForeground")]
+						public static ThemeResourceKey<Brush> Default => new("IconToggleButtonForeground");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonForegroundPointerOver")]
+						public static ThemeResourceKey<Brush> PointerOver => new("IconToggleButtonForegroundPointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonForegroundPressed")]
+						public static ThemeResourceKey<Brush> Pressed => new("IconToggleButtonForegroundPressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonForegroundDisabled")]
+						public static ThemeResourceKey<Brush> Disabled => new("IconToggleButtonForegroundDisabled");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonForegroundChecked")]
+						public static ThemeResourceKey<Brush> Checked => new("IconToggleButtonForegroundChecked");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonForegroundCheckedPointerOver")]
+						public static ThemeResourceKey<Brush> CheckedPointerOver => new("IconToggleButtonForegroundCheckedPointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonForegroundCheckedPressed")]
+						public static ThemeResourceKey<Brush> CheckedPressed => new("IconToggleButtonForegroundCheckedPressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonForegroundCheckedDisabled")]
+						public static ThemeResourceKey<Brush> CheckedDisabled => new("IconToggleButtonForegroundCheckedDisabled");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonForegroundIndeterminate")]
+						public static ThemeResourceKey<Brush> Indeterminate => new("IconToggleButtonForegroundIndeterminate");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonForegroundIndeterminatePointerOver")]
+						public static ThemeResourceKey<Brush> IndeterminatePointerOver => new("IconToggleButtonForegroundIndeterminatePointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonForegroundIndeterminatePressed")]
+						public static ThemeResourceKey<Brush> IndeterminatePressed => new("IconToggleButtonForegroundIndeterminatePressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonForegroundIndeterminateDisabled")]
+						public static ThemeResourceKey<Brush> IndeterminateDisabled => new("IconToggleButtonForegroundIndeterminateDisabled");
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrush")]
+						public static ThemeResourceKey<Brush> Default => new("IconToggleButtonBorderBrush");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrushPointerOver")]
+						public static ThemeResourceKey<Brush> PointerOver => new("IconToggleButtonBorderBrushPointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrushPressed")]
+						public static ThemeResourceKey<Brush> Pressed => new("IconToggleButtonBorderBrushPressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrushDisabled")]
+						public static ThemeResourceKey<Brush> Disabled => new("IconToggleButtonBorderBrushDisabled");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrushChecked")]
+						public static ThemeResourceKey<Brush> Checked => new("IconToggleButtonBorderBrushChecked");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrushCheckedPointerOver")]
+						public static ThemeResourceKey<Brush> CheckedPointerOver => new("IconToggleButtonBorderBrushCheckedPointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrushCheckedPressed")]
+						public static ThemeResourceKey<Brush> CheckedPressed => new("IconToggleButtonBorderBrushCheckedPressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrushCheckedDisabled")]
+						public static ThemeResourceKey<Brush> CheckedDisabled => new("IconToggleButtonBorderBrushCheckedDisabled");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrushIndeterminate")]
+						public static ThemeResourceKey<Brush> Indeterminate => new("IconToggleButtonBorderBrushIndeterminate");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrushIndeterminatePointerOver")]
+						public static ThemeResourceKey<Brush> IndeterminatePointerOver => new("IconToggleButtonBorderBrushIndeterminatePointerOver");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrushIndeterminatePressed")]
+						public static ThemeResourceKey<Brush> IndeterminatePressed => new("IconToggleButtonBorderBrushIndeterminatePressed");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrushIndeterminateDisabled")]
+						public static ThemeResourceKey<Brush> IndeterminateDisabled => new("IconToggleButtonBorderBrushIndeterminateDisabled");
+
+						[ResourceKeyDefinition(typeof(Thickness), "IconToggleButtonBorderThickness")]
+						public static ThemeResourceKey<Thickness> BorderThickness => new("IconToggleButtonBorderThickness");
+					}
+
+					public static class BorderBrushOverlay
+					{
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrushHoverOverlay")]
+						public static ThemeResourceKey<Brush> Hover => new("IconToggleButtonBorderBrushHoverOverlay");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrushFocusedOverlay")]
+						public static ThemeResourceKey<Brush> Focused => new("IconToggleButtonBorderBrushFocusedOverlay");
+
+						[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonBorderBrushSelectedOverlay")]
+						public static ThemeResourceKey<Brush> Selected => new("IconToggleButtonBorderBrushSelectedOverlay");
+					}
+
+					public static class StateCircle
+					{
+						public static class Fill
+						{
+							[ResourceKeyDefinition(typeof(Brush), "IconToggleButtonStateCircleFill")]
+							public static ThemeResourceKey<Brush> Default => new("IconToggleButtonStateCircleFill");
+						}
+
+						public static class Opacity
+						{ 
+							[ResourceKeyDefinition(typeof(double), "IconToggleButtonStateCircleOpacityPointerOver")]
+							public static ThemeResourceKey<double> PointerOver => new("IconToggleButtonStateCircleOpacityPointerOver");
+
+							[ResourceKeyDefinition(typeof(double), "IconToggleButtonStateCircleOpacityPressed")]
+							public static ThemeResourceKey<double> Pressed => new("IconToggleButtonStateCircleOpacityPressed");
+
+							[ResourceKeyDefinition(typeof(double), "IconToggleButtonStateCircleOpacityFocused")]
+							public static ThemeResourceKey<double> Focused => new("IconToggleButtonStateCircleOpacityFocused");
+						}
+					}
+
+					[ResourceKeyDefinition(typeof(double), "IconToggleButtonMinWidth")]
+					public static ThemeResourceKey<double> MinWidth => new("IconToggleButtonMinWidth");
+
+					[ResourceKeyDefinition(typeof(double), "IconToggleButtonMinHeight")]
+					public static ThemeResourceKey<double> MinHeight => new("IconToggleButtonMinHeight");
+				}
+			}
+
+			public static class Styles
+			{
+				[ResourceKeyDefinition(typeof(Style), "TextToggleButtonStyle", TargetType = typeof(ToggleButton))]
+				public static StaticResourceKey<Style> Text => new("TextToggleButtonStyle");
+
+				[ResourceKeyDefinition(typeof(Style), "IconToggleButtonStyle", TargetType = typeof(ToggleButton))]
+				public static ThemeResourceKey<Style> Icon => new("IconToggleButtonStyle");
+			}
+		}
+	}
+}


### PR DESCRIPTION
﻿GitHub Issue: https://github.com/unoplatform/uno.themes-private/issues/3

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

