### PR TITLE
docs: Updating OutlinedTextBoxStyle as default

### DIFF
--- a/doc/material-controls-styles.md
+++ b/doc/material-controls-styles.md
@@ -64,8 +64,8 @@ TextBlock|BodySmall|
 TextBlock|CaptionLarge|
 TextBlock|CaptionMedium|
 TextBlock|CaptionSmall|
-TextBox|FilledTextBoxStyle|True
-TextBox|OutlinedTextBoxStyle|
+TextBox|FilledTextBoxStyle|
+TextBox|OutlinedTextBoxStyle|True
 ToggleButton|TextToggleButtonStyle|True
 ToggleButton|IconToggleButtonStyle|
 ToggleSwitch|ToggleSwitchStyle|True

--- a/doc/styles/TextBox.md
+++ b/doc/styles/TextBox.md
@@ -3,8 +3,8 @@
 
 Style Key|IsDefaultStyle*
 -|-
-FilledTextBoxStyle|True
-OutlinedTextBoxStyle|
+FilledTextBoxStyle|
+OutlinedTextBoxStyle|True
 
 IsDefaultStyle*: Styles in this column will be set as the default implicit style for the matching control
 


### PR DESCRIPTION
Setting `OutlinedTextBoxStyle` as default instead of `FilledTextBoxStyle` in the docs.