### PR TITLE
Resolved issue 1218 - FilledTonalButtonStyle Leading icon incorrect f…

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/Button.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/Button.xaml
@@ -663,7 +663,7 @@
 
 								<VisualState x:Name="Normal">
 									<VisualState.Setters>
-										<Setter Target="IconPresenter.Foreground" Value="{ThemeResource FilledTonalButtonIconForegroundDisabled}" />
+										<Setter Target="IconPresenter.Foreground" Value="{ThemeResource FilledTonalButtonIconForeground}" />
 									</VisualState.Setters>
 								</VisualState>
 


### PR DESCRIPTION

fixes #1218 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Resolved issue 1218 - FilledTonalButtonStyle Leading icon incorrect fill color for Enabled state


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [x] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
