### PR TITLE
fix(converters): refactor converters to take type of visibility instead of string

### DIFF
--- a/src/library/Uno.Material/Styles/Application/Common/Converters.xaml
+++ b/src/library/Uno.Material/Styles/Application/Common/Converters.xaml
@@ -2,15 +2,18 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:um="using:Uno.Material">
 
+	<Visibility x:Key="VisibleVal">Visible</Visibility>
+	<Visibility x:Key="CollapsedVal">Collapsed</Visibility>
+	
 	<um:FromBoolToValueConverter x:Key="MaterialTrueToVisible"
-								 TrueValue="Visible"
-								 FalseValue="Collapsed"
-								 NullValue="Collapsed" />
+								 TrueValue="{StaticResource VisibleVal}"
+								 FalseValue="{StaticResource CollapsedVal}"
+								 NullValue="{StaticResource CollapsedVal}" />
 
 	<um:FromBoolToValueConverter x:Key="MaterialTrueToCollapsed"
-								 TrueValue="Collapsed"
-								 FalseValue="Visible"
-								 NullValue="Visible" />
+								 TrueValue="{StaticResource CollapsedVal}"
+								 FalseValue="{StaticResource VisibleVal}"
+								 NullValue="{StaticResource VisibleVal}" />
 
 	<um:FromEmptyStringToValueConverter x:Key="MaterialEmptyToFalse"
 										NotNullOrEmptyValue="True"
@@ -21,32 +24,32 @@
 										NullOrEmptyValue="True" />
 
 	<um:FromEmptyStringToValueConverter x:Key="MaterialEmptyToVisible"
-										NotNullOrEmptyValue="Collapsed"
-										NullOrEmptyValue="Visible" />
+										NotNullOrEmptyValue="{StaticResource CollapsedVal}"
+										NullOrEmptyValue="{StaticResource VisibleVal}" />
 
 	<um:FromEmptyStringToValueConverter x:Key="MaterialEmptyToCollapsed"
-										NotNullOrEmptyValue="Visible"
-										NullOrEmptyValue="Collapsed" />
+										NotNullOrEmptyValue="{StaticResource VisibleVal}"
+										NullOrEmptyValue="{StaticResource CollapsedVal}" />
 
 	<um:FromNullToValueConverter x:Key="MaterialNullToCollapsedConverter"
-								 NotNullValue="Visible"
-								 NullValue="Collapsed" />
+								 NotNullValue="{StaticResource VisibleVal}"
+								 NullValue="{StaticResource CollapsedVal}" />
 
 	<um:FromNullToValueConverter x:Key="MaterialNullToVisibleConverter"
-								 NotNullValue="Visible"
-								 NullValue="Collapsed" />
+								 NotNullValue="{StaticResource VisibleVal}"
+								 NullValue="{StaticResource CollapsedVal}" />
 
 	<um:FromNullToValueConverter x:Key="MaterialNullToTransparent"
 								 NotNullValue="1"
 								 NullValue="0" />
 	
 	<um:FromEmptyStringOrNullObjectToValueConverter x:Key="MaterialEmptyOrNullToVisible"
-													NotEmptyOrNullValue="Collapsed"
-													EmptyOrNullValue="Visible" />
+													NotEmptyOrNullValue="{StaticResource CollapsedVal}"
+													EmptyOrNullValue="{StaticResource VisibleVal}" />
 
 	<um:FromEmptyStringOrNullObjectToValueConverter x:Key="MaterialEmptyOrNullToCollapsed"
-													NotEmptyOrNullValue="Visible"
-													EmptyOrNullValue="Collapsed" />
+													NotEmptyOrNullValue="{StaticResource VisibleVal}"
+													EmptyOrNullValue="{StaticResource CollapsedVal}" />
 
 	<um:StringFormatConverter x:Key="StringFormatConverter" />
 	<um:FirstCharacterConverter x:Key="FirstCharacterConverter" />

--- a/src/library/Uno.Material/Styles/Controls/v2/ComboBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ComboBox.xaml
@@ -5,6 +5,8 @@
 					xmlns:um="using:Uno.Material"
 					xmlns:xamarin="http://uno.ui/xamarin"
 					mc:Ignorable="xamarin">
+	<Visibility x:Key="VisibleVal">Visible</Visibility>
+	<Visibility x:Key="CollapsedVal">Collapsed</Visibility>
 
 	<!-- Converters -->
 	<um:FromNullToValueConverter x:Key="NullToContentTranslateYConverter"
@@ -12,12 +14,12 @@
 								 NullValue="0" />
 
 	<um:FromNullToValueConverter x:Key="NullToVisible"
-								 NotNullValue="Collapsed"
-								 NullValue="Visible" />
+								 NotNullValue="{StaticResource CollapsedVal}"
+								 NullValue="{StaticResource VisibleVal}" />
 
 	<um:FromNullToValueConverter x:Key="NullToCollapsed"
-								 NotNullValue="Visible"
-								 NullValue="Collapsed" />
+								 NotNullValue="{StaticResource VisibleVal}"
+								 NullValue="{StaticResource CollapsedVal}" />
 
 	<ResourceDictionary.ThemeDictionaries>
 

--- a/src/samples/UWP/Uno.Themes.Samples.Shared/Converters.xaml
+++ b/src/samples/UWP/Uno.Themes.Samples.Shared/Converters.xaml
@@ -1,18 +1,21 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:converters="using:Uno.Themes.Samples.Converters">
+	<Visibility x:Key="VisibleVal">Visible</Visibility>
+	<Visibility x:Key="CollapsedVal">Collapsed</Visibility>
+	
 	<converters:FromStringToValueConverter x:Key="IsNullOrEmptyToCollapsed"
 										   Check="IsNullOrEmpty"
-										   TrueValue="Collapsed"
-										   FalseValue="Visible" />
+										   TrueValue="{StaticResource CollapsedVal}"
+										   FalseValue="{StaticResource VisibleVal}" />
 
 	<converters:FromStringToValueConverter x:Key="SelectedItemToVisible"
 										   Check="IsEqualToParameterValue"
-										   TrueValue="Visible"
-										   FalseValue="Collapsed" />
+										   TrueValue="{StaticResource VisibleVal}"
+										   FalseValue="{StaticResource CollapsedVal}" />
 
 	<converters:EnumDescriptionConverter x:Key="EnumToDescription" />
 	<converters:FromBoolToValueConverter x:Key="TrueToVisible"
-										 TrueValue="Visible"
-										 NullOrFalseValue="Collapsed" />
+										 TrueValue="{StaticResource VisibleVal}"
+										 NullOrFalseValue="{StaticResource CollapsedVal}" />
 </ResourceDictionary>


### PR DESCRIPTION

﻿GitHub Issue: https://github.com/unoplatform/uno.templates/issues/361

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->
refactor converters to take type of visibility instead of string

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)


