### PR TITLE
fix: OnSecondaryContainerColor for Light Theme to match default Material colors and Figma file

### DIFF
--- a/doc/material-colors.md
+++ b/doc/material-colors.md
@@ -17,7 +17,7 @@ uid: uno.themes.material.colors
 | SecondaryColor             | #6B4EA2    | #CDC2DC   |
 | OnSecondaryColor           | #FFFFFF    | #332D41   |
 | SecondaryContainerColor    | #EBDDFF    | #433C52   |
-| OnSecondaryContainerColor  | #1F182B    | #EDDFFF   |
+| OnSecondaryContainerColor  | #220555    | #EDDFFF   |
 | SecondaryVariantDarkColor  | #3B2574    | #441F8A   |
 | SecondaryVariantLightColor | #9B7BD5    | #EBE6F1   |
 | TertiaryColor              | #0061A4    | #9FCAFF   |

--- a/src/library/Uno.Material/Styles/Application/v2/SharedColorPalette.xaml
+++ b/src/library/Uno.Material/Styles/Application/v2/SharedColorPalette.xaml
@@ -1,18 +1,18 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <!--
-        This palette contains the default colors and opacity levels for the different state overlays
-        All of them can be overriden by the application consuming this library
+	<!--
+		This palette contains the default colors and opacity levels for the different state overlays
+		All of them can be overriden by the application consuming this library
+		
+		All variations of this palette are offered as brushes in Colors.xaml.
+	-->
 
-        All variations of this palette are offered as brushes in Colors.xaml.
-    -->
+	<ResourceDictionary.ThemeDictionaries>
 
-    <ResourceDictionary.ThemeDictionaries>
-
-        <!--  Light Theme  -->
-        <ResourceDictionary x:Key="Light">
-            <!--  Primary  -->
+		<!-- Light Theme -->
+		<ResourceDictionary x:Key="Light">
+			<!-- Primary -->
 			<Color x:Key="PrimaryColor">#5946D2</Color>
 			<Color x:Key="PrimaryInverseColor">#C8BFFF</Color>
 			<Color x:Key="OnPrimaryColor">#FFFFFF</Color>
@@ -23,33 +23,33 @@
 			<Color x:Key="PrimaryVariantDarkColor">#0021C1</Color>
 			<Color x:Key="PrimaryVariantLightColor">#9679FF</Color>
 
-			<!--  Secondary  -->
+			<!-- Secondary -->
 			<Color x:Key="SecondaryColor">#6B4EA2</Color>
 			<Color x:Key="OnSecondaryColor">#FFFFFF</Color>
 			<Color x:Key="SecondaryContainerColor">#EBDDFF</Color>
-			<Color x:Key="OnSecondaryContainerColor">#1F182B</Color>
+			<Color x:Key="OnSecondaryContainerColor">#220555</Color>
 
 			<!-- Secondary Variant Legacy Colors -->
 			<Color x:Key="SecondaryVariantDarkColor">#3B2574</Color>
 			<Color x:Key="SecondaryVariantLightColor">#9B7BD5</Color>
 
-			<!--  Tertiary  -->
+			<!-- Tertiary -->
 			<Color x:Key="TertiaryColor">#0061A4</Color>
 			<Color x:Key="OnTertiaryColor">#FFFFFF</Color>
 			<Color x:Key="TertiaryContainerColor">#CFE4FF</Color>
 			<Color x:Key="OnTertiaryContainerColor">#001D36</Color>
 
-            <!--  Error  -->
+			<!-- Error -->
 			<Color x:Key="ErrorColor">#B3261E</Color>
 			<Color x:Key="OnErrorColor">#FFFFFF</Color>
 			<Color x:Key="ErrorContainerColor">#F9DEDC</Color>
 			<Color x:Key="OnErrorContainerColor">#410E0B</Color>
 
-            <!--  Background  -->
+			<!-- Background -->
 			<Color x:Key="BackgroundColor">#FCFBFF</Color>
 			<Color x:Key="OnBackgroundColor">#1C1B1F</Color>
 
-            <!--  Surface  -->
+			<!-- Surface -->
 			<Color x:Key="SurfaceColor">#FFFFFF</Color>
 			<Color x:Key="OnSurfaceColor">#1C1B1F</Color>
 			<Color x:Key="SurfaceVariantColor">#F2EFF5</Color>
@@ -58,14 +58,14 @@
 			<Color x:Key="OnSurfaceInverseColor">#F4EFF4</Color>
 			<Color x:Key="SurfaceTintColor">#5946D2</Color>
 
-			<!--  Outline  -->
+			<!-- Outline -->
 			<Color x:Key="OutlineColor">#79747E</Color>
 			<Color x:Key="OutlineVariantColor">#C9C5D0</Color>
-        </ResourceDictionary>
+		</ResourceDictionary>
 
-        <!--  Dark Theme  -->
-        <ResourceDictionary x:Key="Default">
-            <!--  Primary  -->
+		<!-- Dark Theme -->
+		<ResourceDictionary x:Key="Default">
+			<!-- Primary -->
 			<Color x:Key="PrimaryColor">#C7BFFF</Color>
 			<Color x:Key="OnPrimaryColor">#2A009F</Color>
 			<Color x:Key="PrimaryContainerColor">#4129BA</Color>
@@ -76,7 +76,7 @@
 			<Color x:Key="PrimaryVariantDarkColor">#4128BA</Color>
 			<Color x:Key="PrimaryVariantLightColor">#C8BFFF</Color>
 
-			<!--  Secondary  -->
+			<!-- Secondary -->
 			<Color x:Key="SecondaryColor">#CDC2DC</Color>
 			<Color x:Key="OnSecondaryColor">#332D41</Color>
 			<Color x:Key="SecondaryContainerColor">#433C52</Color>
@@ -86,23 +86,23 @@
 			<Color x:Key="SecondaryVariantDarkColor">#441F8A</Color>
 			<Color x:Key="SecondaryVariantLightColor">#EBE6F1</Color>
 
-			<!--  Tertiary  -->
+			<!-- Tertiary -->
 			<Color x:Key="TertiaryColor">#9FCAFF</Color>
 			<Color x:Key="OnTertiaryColor">#003258</Color>
 			<Color x:Key="TertiaryContainerColor">#00497D</Color>
 			<Color x:Key="OnTertiaryContainerColor">#D1E4FF</Color>
 
-			<!--  Error  -->
+			<!-- Error -->
 			<Color x:Key="ErrorColor">#FFB4AB</Color>
 			<Color x:Key="OnErrorColor">#690005</Color>
 			<Color x:Key="ErrorContainerColor">#93000A</Color>
 			<Color x:Key="OnErrorContainerColor">#FFDAD6</Color>
 
-			<!--  Background  -->
+			<!-- Background -->
 			<Color x:Key="BackgroundColor">#1C1B1F</Color>
 			<Color x:Key="OnBackgroundColor">#E5E1E6</Color>
 
-			<!--  Surface  -->
+			<!-- Surface -->
 			<Color x:Key="SurfaceColor">#302D37</Color>
 			<Color x:Key="OnSurfaceColor">#E6E1E5</Color>
 			<Color x:Key="SurfaceVariantColor">#47464F</Color>
@@ -111,16 +111,16 @@
 			<Color x:Key="OnSurfaceInverseColor">#1C1B1F</Color>
 			<Color x:Key="SurfaceTintColor">#C7BFFF</Color>
 
-			<!--  Outline  -->
+			<!-- Outline -->
 			<Color x:Key="OutlineColor">#928F99</Color>
 			<Color x:Key="OutlineVariantColor">#57545D</Color>
 		</ResourceDictionary>
-    </ResourceDictionary.ThemeDictionaries>
+	</ResourceDictionary.ThemeDictionaries>
 
-    <!--  Opacity for control state overlays  -->
-    <x:Double x:Key="HoverOpacity">0.08</x:Double>
-    <x:Double x:Key="FocusedOpacity">0.12</x:Double>
-    <x:Double x:Key="PressedOpacity">0.12</x:Double>
+	<!-- Opacity for control state overlays -->
+	<x:Double x:Key="HoverOpacity">0.08</x:Double>
+	<x:Double x:Key="FocusedOpacity">0.12</x:Double>
+	<x:Double x:Key="PressedOpacity">0.12</x:Double>
 	<x:Double x:Key="DraggedOpacity">0.16</x:Double>
 	<x:Double x:Key="SelectedOpacity">0.16</x:Double>
 	<x:Double x:Key="MediumOpacity">0.54</x:Double>


### PR DESCRIPTION
GitHub Issue: fixes #1143

## PR Type

What kind of change does this PR introduce?

- Bugfix


## Description

Fix OnSecondaryContainerColor for Light Theme to match default Material colors and Figma file
(cf. https://github.com/unoplatform/Uno.Themes/issues/1143#issuecomment-1777892347)


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [X] Tested the changes where applicable:
	- [X] UWP
	- [X] iOS
	- [X] Android
	- [X] WASM
	- [ ] MacOS
- [X] Updated the documentation as needed
- [X] Contains **No** breaking changes
