### PR TITLE
feat: add material markup helper and docs

### DIFF
--- a/doc/material-getting-started.md
+++ b/doc/material-getting-started.md
@@ -264,7 +264,8 @@ If you would like Uno.Material to use a different font, you can override the def
 
 Uno Material also has support for C# Markup through a [Uno.Material.WinUI.Markup](https://www.nuget.org/packages/Uno.Material.WinUI.Markup) NuGet Package. 
 
-To get started with Uno Material in your C# Markup application, install the `Uno.Material.WinUI.Markup` NuGet package in your **App Code Library** project and your platform heads and add the following code to your `AppResources.cs`:
+To get started with Uno Material in your C# Markup application, add the `Uno.Material.WinUI.Markup` NuGet package to your **App Code Library** project and your platform heads.
+Then, add the following code to your `AppResources.cs`:
 
 ```csharp
 using Uno.Material.Markup;

--- a/doc/material-getting-started.md
+++ b/doc/material-getting-started.md
@@ -260,6 +260,22 @@ If you would like Uno.Material to use a different font, you can override the def
                    FontOverrideSource="ms-appx:///PROJECT_NAME/Styles/Application/MaterialFontsOverride.xaml" />
     ```
 
+## Using C# Markup
+
+Uno Material also has support for C# Markup through a [Uno.Material.WinUI.Markup](https://www.nuget.org/packages/Uno.Material.WinUI.Markup) NuGet Package. 
+
+To get started with Uno Material in your C# Markup application, install the `Uno.Material.WinUI.Markup` NuGet package in your **App Code Library** project and your platform heads and add the following code to your `AppResources.cs`:
+
+```csharp
+using Uno.Material.Markup;
+
+this.Build(r => r.UseMaterial(
+    //optional
+     new Styles.ColorPaletteOverride(),
+     //optional
+     new Styles.MaterialFontsOverride()));
+```
+
 ## Additional Resources
 
 - [Uno Platform Material Sample App](https://github.com/unoplatform/Uno.Samples/tree/master/UI/UnoMaterialSample)

--- a/doc/material-getting-started.md
+++ b/doc/material-getting-started.md
@@ -271,7 +271,7 @@ Then, add the following code to your `AppResources.cs`:
 using Uno.Material.Markup;
 
 this.Build(r => r.UseMaterial(
-    //optional
+     //optional
      new Styles.ColorPaletteOverride(),
      //optional
      new Styles.MaterialFontsOverride()));

--- a/src/library/Uno.Material.WinUI.Markup/MarkupInit.cs
+++ b/src/library/Uno.Material.WinUI.Markup/MarkupInit.cs
@@ -1,17 +1,17 @@
 ﻿using Microsoft.UI.Xaml;
+using Uno.Extensions.Markup;
 
 namespace Uno.Material.Markup;
 
 public static class MarkupInit
 {
-	public static T UseMaterial<T>(this T app,
+	public static ResourceDictionaryBuilder UseMaterial(
+		this ResourceDictionaryBuilder builder,
 		ResourceDictionary colorOverride = null,
-		ResourceDictionary fontOverride = null) where T : Application
-		=> app.Resources(
-			r => r.Merged(
-				new MaterialTheme()
-					.ColorOverrideDictionary(colorOverride)
-					.FontOverrideDictionary(fontOverride)
-				)
+		ResourceDictionary fontOverride = null)
+		=> builder.Merged(
+			new MaterialTheme()
+				.ColorOverrideDictionary(colorOverride)
+				.FontOverrideDictionary(fontOverride)
 			);
 }


### PR DESCRIPTION
Refactor MarkupInit helper class to use with ResourceDictionaryBuilder, new syntax is:

```cs
this.Build(r => r.UseMaterial(
	new Styles.ColorPaletteOverride(),
	new Styles.MaterialFontsOverride()));
```