### PR TITLE
fix: use valid winappsdk version

### DIFF
--- a/src/library/Uno.Cupertino/Uno.Cupertino.csproj
+++ b/src/library/Uno.Cupertino/Uno.Cupertino.csproj
@@ -55,7 +55,7 @@
 
 				<PackageReference Include="Uno.WinUI.Lottie" Version="5.0.0-dev.2572" Condition="!$(_IsWinUI)" />
 
-				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.0" Condition="$(_IsWinUI)" />
+				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" Condition="$(_IsWinUI)" />
 				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" Condition="$(_IsWinUI)" />
 			</ItemGroup>
 

--- a/src/library/Uno.Material/Uno.Material.csproj
+++ b/src/library/Uno.Material/Uno.Material.csproj
@@ -60,7 +60,7 @@
 
 				<PackageReference Include="Uno.WinUI.Lottie" Version="5.0.0-dev.2572" Condition="!$(_IsWinUI)" />
 
-				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.0" Condition="$(_IsWinUI)" />
+				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" Condition="$(_IsWinUI)" />
 				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" Condition="$(_IsWinUI)" />
 			</ItemGroup>
 


### PR DESCRIPTION
1.2.0 generates this warning:
`##[warning]src\library\Uno.Material\Uno.Material.csproj(0,0): Warning NU1603: Uno.Material.WinUI depends on Microsoft.WindowsAppSDK (>= 1.2.0) but Microsoft.WindowsAppSDK 1.2.0 was not found. An approximate best match of Microsoft.WindowsAppSDK 1.2.221109.1 was resolved.`