### PR TITLE
fix: FontFamilyOverride

### DIFF
--- a/src/library/Uno.Material/Styles/Application/v2/Typography.xaml
+++ b/src/library/Uno.Material/Styles/Application/v2/Typography.xaml
@@ -15,6 +15,7 @@
 			<!-- DISPLAY -->
 
 			<!--  Display Large  -->
+			<x:String x:Key="DisplayLargeFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="DisplayLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="DisplayLargeFontSize">57</x:Double>
 			<!--  Tracking: -0.25 px -->
@@ -23,34 +24,41 @@
 			<x:Int32 x:Key="DisplayLargeCharacterSpacing">-17</x:Int32>
 
 			<!--  Display Medium  -->
+			<x:String x:Key="DisplayMediumFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="DisplayMediumFontWeight">Normal</x:String>
 			<x:Double x:Key="DisplayMediumFontSize">45</x:Double>
 
 			<!--  Display Small  -->
+			<x:String x:Key="DisplaySmallFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="DisplaySmallFontWeight">Normal</x:String>
 			<x:Double x:Key="DisplaySmallFontSize">36</x:Double>
 
 			<!-- HEADLINE -->
 
 			<!--  Headline Large  -->
+			<x:String x:Key="HeadlineLargeFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="HeadlineLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="HeadlineLargeFontSize">32</x:Double>
 
 			<!--  Headline Medium  -->
+			<x:String x:Key="HeadlineMediumFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="HeadlineMediumFontWeight">Normal</x:String>
 			<x:Double x:Key="HeadlineMediumFontSize">28</x:Double>
 
 			<!--  Headline Small  -->
+			<x:String x:Key="HeadlineSmallFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="HeadlineSmallFontWeight">Normal</x:String>
 			<x:Double x:Key="HeadlineSmallFontSize">24</x:Double>
 
 			<!-- TITLE -->
 
 			<!--  Title Large  -->
+			<x:String x:Key="TitleLargeFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="TitleLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="TitleLargeFontSize">22</x:Double>
 
 			<!--  Title Medium  -->
+			<x:String x:Key="TitleMediumFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="TitleMediumFontWeight">Medium</x:String>
 			<x:Double x:Key="TitleMediumFontSize">16</x:Double>
 			<!--  No Tracking / CharacterSpacing  -->
@@ -58,6 +66,7 @@
 			<!--  Compromise between the official M3 and Uno's Figma M3 design to ensure compatibility with all design systems styles  -->
 
 			<!--  Title Small  -->
+			<x:String x:Key="TitleSmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="TitleSmallFontWeight">Medium</x:String>
 			<x:Double x:Key="TitleSmallFontSize">14</x:Double>
 			<!--  No Tracking / CharacterSpacing  -->
@@ -67,6 +76,7 @@
 			<!-- LABEL -->
 
 			<!--  Label Large  -->
+			<x:String x:Key="LabelLargeFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="LabelLargeFontWeight">Medium</x:String>
 			<x:Double x:Key="LabelLargeFontSize">14</x:Double>
 			<!--  Tracking: 0.1 px  -->
@@ -75,12 +85,14 @@
 			<x:Int32 x:Key="LabelLargeCharacterSpacing">7</x:Int32>
 
 			<!--  Label Medium  -->
+			<x:String x:Key="LabelMediumFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="LabelMediumFontWeight">Medium</x:String>
 			<x:Double x:Key="LabelMediumFontSize">12</x:Double>
 			<!--  Tracking: 0.5 px  -->
 			<x:Int32 x:Key="LabelMediumCharacterSpacing">41</x:Int32>
 
 			<!--  Label Small  -->
+			<x:String x:Key="LabelSmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="LabelSmallFontWeight">Medium</x:String>
 			<x:Double x:Key="LabelSmallFontSize">11</x:Double>
 			<!--  Tracking: 0.5 px  -->
@@ -89,6 +101,7 @@
 			<!--  Label ExtraSmall  -->
 			<!-- Text style added for Badges so it will match Uno figma file -->
 			<!-- Not part of Material M3. See https://github.com/unoplatform/Uno.Figma/issues/628 -->
+			<x:String x:Key="LabelExtraSmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="LabelExtraSmallFontWeight">Normal</x:String>
 			<x:Double x:Key="LabelExtraSmallFontSize">11</x:Double>
 			<!--  Tracking: 0.1 px  -->
@@ -97,6 +110,7 @@
 			<!-- BODY -->
 
 			<!--  Body Large  -->
+			<x:String x:Key="BodyLargeFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="BodyLargeFontWeight">Medium</x:String>
 			<x:Double x:Key="BodyLargeFontSize">16</x:Double>
 			<!--  Tracking: 0.15 px  -->
@@ -105,12 +119,14 @@
 			<x:Int32 x:Key="BodyLargeCharacterSpacing">9</x:Int32>
 
 			<!--  Body Medium  -->
+			<x:String x:Key="BodyMediumFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="BodyMediumFontWeight">Medium</x:String>
 			<x:Double x:Key="BodyMediumFontSize">14</x:Double>
 			<!--  Tracking: 0.25 px  -->
 			<x:Int32 x:Key="BodyMediumCharacterSpacing">17</x:Int32>
 
 			<!--  Body Small  -->
+			<x:String x:Key="BodySmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="BodySmallFontWeight">Medium</x:String>
 			<x:Double x:Key="BodySmallFontSize">12</x:Double>
 			<!--  Tracking: 0.4 px  -->
@@ -120,6 +136,7 @@
 
 			<!--  Caption Large  -->
 			<!-- Gap Filler for the other design system - Not part of Material M3 -->
+			<x:String x:Key="CaptionLargeFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="CaptionLargeFontWeight">Medium</x:String>
 			<x:Double x:Key="CaptionLargeFontSize">13</x:Double>
 			<!--  Tracking: -0.05 px  -->
@@ -127,6 +144,7 @@
 
 			<!--  Caption Medium  -->
 			<!-- Gap Filler for the other design system - Not part of Material M3 -->
+			<x:String x:Key="CaptionMediumFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="CaptionMediumFontWeight">Medium</x:String>
 			<x:Double x:Key="CaptionMediumFontSize">12</x:Double>
 			<!--  Tracking: 0.4 px  -->
@@ -134,6 +152,7 @@
 
 			<!--  Caption Small  -->
 			<!-- Gap Filler for the other design system - Not part of Material M3 -->
+			<x:String x:Key="CaptionSmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="CaptionSmallFontWeight">Medium</x:String>
 			<x:Double x:Key="CaptionSmallFontSize">11</x:Double>
 			<!--  Tracking: 0.1 px  -->
@@ -153,6 +172,7 @@
 			<!-- DISPLAY -->
 
 			<!--  Display Large  -->
+			<x:String x:Key="DisplayLargeFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="DisplayLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="DisplayLargeFontSize">57</x:Double>
 			<!--  Tracking: -0.25 px -->
@@ -161,34 +181,41 @@
 			<x:Int32 x:Key="DisplayLargeCharacterSpacing">-17</x:Int32>
 
 			<!--  Display Medium  -->
+			<x:String x:Key="DisplayMediumFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="DisplayMediumFontWeight">Normal</x:String>
 			<x:Double x:Key="DisplayMediumFontSize">45</x:Double>
 
 			<!--  Display Small  -->
+			<x:String x:Key="DisplaySmallFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="DisplaySmallFontWeight">Normal</x:String>
 			<x:Double x:Key="DisplaySmallFontSize">36</x:Double>
 
 			<!-- HEADLINE -->
 
 			<!--  Headline Large  -->
+			<x:String x:Key="HeadlineLargeFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="HeadlineLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="HeadlineLargeFontSize">32</x:Double>
 
 			<!--  Headline Medium  -->
+			<x:String x:Key="HeadlineMediumFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="HeadlineMediumFontWeight">Normal</x:String>
 			<x:Double x:Key="HeadlineMediumFontSize">28</x:Double>
 
 			<!--  Headline Small  -->
+			<x:String x:Key="HeadlineSmallFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="HeadlineSmallFontWeight">Normal</x:String>
 			<x:Double x:Key="HeadlineSmallFontSize">24</x:Double>
 
 			<!-- TITLE -->
 
 			<!--  Title Large  -->
+			<x:String x:Key="TitleLargeFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="TitleLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="TitleLargeFontSize">22</x:Double>
 
 			<!--  Title Medium  -->
+			<x:String x:Key="TitleMediumFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="TitleMediumFontWeight">Medium</x:String>
 			<x:Double x:Key="TitleMediumFontSize">16</x:Double>
 			<!--  No Tracking / CharacterSpacing  -->
@@ -196,6 +223,7 @@
 			<!--  Compromise between the official M3 and Uno's Figma M3 design to ensure compatibility with all design systems styles  -->
 
 			<!--  Title Small  -->
+			<x:String x:Key="TitleSmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="TitleSmallFontWeight">Medium</x:String>
 			<x:Double x:Key="TitleSmallFontSize">14</x:Double>
 			<!--  No Tracking / CharacterSpacing  -->
@@ -205,6 +233,7 @@
 			<!-- LABEL -->
 
 			<!--  Label Large  -->
+			<x:String x:Key="LabelLargeFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="LabelLargeFontWeight">Medium</x:String>
 			<x:Double x:Key="LabelLargeFontSize">14</x:Double>
 			<!--  Tracking: 0.1 px  -->
@@ -213,12 +242,14 @@
 			<x:Int32 x:Key="LabelLargeCharacterSpacing">7</x:Int32>
 
 			<!--  Label Medium  -->
+			<x:String x:Key="LabelMediumFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="LabelMediumFontWeight">Medium</x:String>
 			<x:Double x:Key="LabelMediumFontSize">12</x:Double>
 			<!--  Tracking: 0.5 px  -->
 			<x:Int32 x:Key="LabelMediumCharacterSpacing">41</x:Int32>
 
 			<!--  Label Small  -->
+			<x:String x:Key="LabelSmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="LabelSmallFontWeight">Medium</x:String>
 			<x:Double x:Key="LabelSmallFontSize">11</x:Double>
 			<!--  Tracking: 0.5 px  -->
@@ -227,6 +258,7 @@
 			<!--  Label ExtraSmall  -->
 			<!-- Text style added for Badges so it will match Uno figma file -->
 			<!-- Not part of Material M3. See https://github.com/unoplatform/Uno.Figma/issues/628 -->
+			<x:String x:Key="LabelExtraSmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="LabelExtraSmallFontWeight">Medium</x:String>
 			<x:Double x:Key="LabelExtraSmallFontSize">11</x:Double>
 			<!--  Tracking: 0.1 px  -->
@@ -235,6 +267,7 @@
 			<!-- BODY -->
 
 			<!--  Body Large  -->
+			<x:String x:Key="BodyLargeFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="BodyLargeFontWeight">Medium</x:String>
 			<x:Double x:Key="BodyLargeFontSize">16</x:Double>
 			<!--  Tracking: 0.15 px  -->
@@ -243,12 +276,14 @@
 			<x:Int32 x:Key="BodyLargeCharacterSpacing">9</x:Int32>
 
 			<!--  Body Medium  -->
+			<x:String x:Key="BodyMediumFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="BodyMediumFontWeight">Medium</x:String>
 			<x:Double x:Key="BodyMediumFontSize">14</x:Double>
 			<!--  Tracking: 0.25 px  -->
 			<x:Int32 x:Key="BodyMediumCharacterSpacing">17</x:Int32>
 
 			<!--  Body Small  -->
+			<x:String x:Key="BodySmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="BodySmallFontWeight">Medium</x:String>
 			<x:Double x:Key="BodySmallFontSize">12</x:Double>
 			<!--  Tracking: 0.4 px  -->
@@ -258,6 +293,7 @@
 
 			<!--  Caption Large  -->
 			<!-- Gap Filler for the other design system - Not part of Material M3 -->
+			<x:String x:Key="CaptionLargeFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="CaptionLargeFontWeight">Medium</x:String>
 			<x:Double x:Key="CaptionLargeFontSize">13</x:Double>
 			<!--  Tracking: -0.05 px  -->
@@ -265,6 +301,7 @@
 
 			<!--  Caption Medium  -->
 			<!-- Gap Filler for the other design system - Not part of Material M3 -->
+			<x:String x:Key="CaptionMediumFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="CaptionMediumFontWeight">Medium</x:String>
 			<x:Double x:Key="CaptionMediumFontSize">12</x:Double>
 			<!--  Tracking: 0.4 px  -->
@@ -272,6 +309,7 @@
 
 			<!--  Caption Small  -->
 			<!-- Gap Filler for the other design system - Not part of Material M3 -->
+			<x:String x:Key="CaptionSmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="CaptionSmallFontWeight">Medium</x:String>
 			<x:Double x:Key="CaptionSmallFontSize">11</x:Double>
 			<!--  Tracking: 0.1 px  -->
@@ -291,6 +329,7 @@
 			<!-- DISPLAY -->
 
 			<!--  Display Large  -->
+			<x:String x:Key="DisplayLargeFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="DisplayLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="DisplayLargeFontSize">57</x:Double>
 			<!--  Tracking: -0.25 px -->
@@ -299,34 +338,41 @@
 			<x:Int32 x:Key="DisplayLargeCharacterSpacing">-17</x:Int32>
 
 			<!--  Display Medium  -->
+			<x:String x:Key="DisplayMediumFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="DisplayMediumFontWeight">Normal</x:String>
 			<x:Double x:Key="DisplayMediumFontSize">45</x:Double>
 
 			<!--  Display Small  -->
+			<x:String x:Key="DisplaySmallFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="DisplaySmallFontWeight">Normal</x:String>
 			<x:Double x:Key="DisplaySmallFontSize">36</x:Double>
 
 			<!-- HEADLINE -->
 
 			<!--  Headline Large  -->
+			<x:String x:Key="HeadlineLargeFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="HeadlineLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="HeadlineLargeFontSize">32</x:Double>
 
 			<!--  Headline Medium  -->
+			<x:String x:Key="HeadlineMediumFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="HeadlineMediumFontWeight">Normal</x:String>
 			<x:Double x:Key="HeadlineMediumFontSize">28</x:Double>
 
 			<!--  Headline Small  -->
+			<x:String x:Key="HeadlineSmallFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="HeadlineSmallFontWeight">Normal</x:String>
 			<x:Double x:Key="HeadlineSmallFontSize">24</x:Double>
 
 			<!-- TITLE -->
 
 			<!--  Title Large  -->
+			<x:String x:Key="TitleLargeFontFamily">MaterialRegularFontFamily</x:String>
 			<x:String x:Key="TitleLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="TitleLargeFontSize">22</x:Double>
 
 			<!--  Title Medium  -->
+			<x:String x:Key="TitleMediumFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="TitleMediumFontWeight">Medium</x:String>
 			<x:Double x:Key="TitleMediumFontSize">16</x:Double>
 			<!--  No Tracking / CharacterSpacing  -->
@@ -334,6 +380,7 @@
 			<!--  Compromise between the official M3 and Uno's Figma M3 design to ensure compatibility with all design systems styles  -->
 
 			<!--  Title Small  -->
+			<x:String x:Key="TitleSmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="TitleSmallFontWeight">Medium</x:String>
 			<x:Double x:Key="TitleSmallFontSize">14</x:Double>
 			<!--  No Tracking / CharacterSpacing  -->
@@ -343,6 +390,7 @@
 			<!-- LABEL -->
 
 			<!--  Label Large  -->
+			<x:String x:Key="LabelLargeFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="LabelLargeFontWeight">Medium</x:String>
 			<x:Double x:Key="LabelLargeFontSize">14</x:Double>
 			<!--  Tracking: 0.1 px  -->
@@ -351,12 +399,14 @@
 			<x:Int32 x:Key="LabelLargeCharacterSpacing">7</x:Int32>
 
 			<!--  Label Medium  -->
+			<x:String x:Key="LabelMediumFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="LabelMediumFontWeight">Medium</x:String>
 			<x:Double x:Key="LabelMediumFontSize">12</x:Double>
 			<!--  Tracking: 0.5 px  -->
 			<x:Int32 x:Key="LabelMediumCharacterSpacing">41</x:Int32>
 
 			<!--  Label Small  -->
+			<x:String x:Key="LabelSmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="LabelSmallFontWeight">Medium</x:String>
 			<x:Double x:Key="LabelSmallFontSize">11</x:Double>
 			<!--  Tracking: 0.5 px  -->
@@ -365,6 +415,7 @@
 			<!--  Label ExtraSmall  -->
 			<!-- Text style added for Badges so it will match Uno figma file -->
 			<!-- Not part of Material M3. See https://github.com/unoplatform/Uno.Figma/issues/628 -->
+			<x:String x:Key="LabelExtraSmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="LabelExtraSmallFontWeight">Medium</x:String>
 			<x:Double x:Key="LabelExtraSmallFontSize">11</x:Double>
 			<!--  Tracking: 0.1 px  -->
@@ -373,6 +424,7 @@
 			<!-- BODY -->
 
 			<!--  Body Large  -->
+			<x:String x:Key="BodyLargeFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="BodyLargeFontWeight">Medium</x:String>
 			<x:Double x:Key="BodyLargeFontSize">16</x:Double>
 			<!--  Tracking: 0.15 px  -->
@@ -381,12 +433,14 @@
 			<x:Int32 x:Key="BodyLargeCharacterSpacing">9</x:Int32>
 
 			<!--  Body Medium  -->
+			<x:String x:Key="BodyMediumFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="BodyMediumFontWeight">Medium</x:String>
 			<x:Double x:Key="BodyMediumFontSize">14</x:Double>
 			<!--  Tracking: 0.25 px  -->
 			<x:Int32 x:Key="BodyMediumCharacterSpacing">17</x:Int32>
 
 			<!--  Body Small  -->
+			<x:String x:Key="BodySmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="BodySmallFontWeight">Medium</x:String>
 			<x:Double x:Key="BodySmallFontSize">12</x:Double>
 			<!--  Tracking: 0.4 px  -->
@@ -396,6 +450,7 @@
 
 			<!--  Caption Large  -->
 			<!-- Gap Filler for the other design system - Not part of Material M3 -->
+			<x:String x:Key="CaptionLargeFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="CaptionLargeFontWeight">Medium</x:String>
 			<x:Double x:Key="CaptionLargeFontSize">13</x:Double>
 			<!--  Tracking: -0.05 px  -->
@@ -403,6 +458,7 @@
 
 			<!--  Caption Medium  -->
 			<!-- Gap Filler for the other design system - Not part of Material M3 -->
+			<x:String x:Key="CaptionMediumFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="CaptionMediumFontWeight">Medium</x:String>
 			<x:Double x:Key="CaptionMediumFontSize">12</x:Double>
 			<!--  Tracking: 0.4 px  -->
@@ -410,6 +466,7 @@
 
 			<!--  Caption Small  -->
 			<!-- Gap Filler for the other design system - Not part of Material M3 -->
+			<x:String x:Key="CaptionSmallFontFamily">MaterialMediumFontFamily</x:String>
 			<x:String x:Key="CaptionSmallFontWeight">Medium</x:String>
 			<x:Double x:Key="CaptionSmallFontSize">11</x:Double>
 			<!--  Tracking: 0.1 px  -->

--- a/src/library/Uno.Material/Styles/Controls/v2/TextBlock.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/TextBlock.xaml
@@ -26,6 +26,8 @@
 	<Style x:Key="MaterialDisplayLarge"
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
+		<Setter Property="FontFamily"
+				Value="{ThemeResource DisplayLargeFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource DisplayLargeFontWeight}" />
 		<Setter Property="FontSize"
@@ -38,6 +40,8 @@
 	<Style x:Key="MaterialDisplayMedium"
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
+		<Setter Property="FontFamily"
+				Value="{ThemeResource DisplayMediumFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource DisplayMediumFontWeight}" />
 		<Setter Property="FontSize"
@@ -48,6 +52,8 @@
 	<Style x:Key="MaterialDisplaySmall"
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
+		<Setter Property="FontFamily"
+				Value="{ThemeResource DisplaySmallFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource DisplaySmallFontWeight}" />
 		<Setter Property="FontSize"
@@ -60,6 +66,8 @@
 	<Style x:Key="MaterialHeadlineLarge"
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
+		<Setter Property="FontFamily"
+				Value="{ThemeResource HeadlineLargeFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource HeadlineLargeFontWeight}" />
 		<Setter Property="FontSize"
@@ -70,6 +78,8 @@
 	<Style x:Key="MaterialHeadlineMedium"
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
+		<Setter Property="FontFamily"
+				Value="{ThemeResource HeadlineMediumFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource HeadlineMediumFontWeight}" />
 		<Setter Property="FontSize"
@@ -80,6 +90,8 @@
 	<Style x:Key="MaterialHeadlineSmall"
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
+		<Setter Property="FontFamily"
+				Value="{ThemeResource HeadlineSmallFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource HeadlineSmallFontWeight}" />
 		<Setter Property="FontSize"
@@ -92,6 +104,8 @@
 	<Style x:Key="MaterialTitleLarge"
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
+		<Setter Property="FontFamily"
+				Value="{ThemeResource TitleLargeFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource TitleLargeFontWeight}" />
 		<Setter Property="FontSize"
@@ -103,7 +117,7 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource TitleMediumFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource TitleMediumFontWeight}" />
 		<Setter Property="FontSize"
@@ -115,7 +129,7 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource TitleSmallFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource TitleSmallFontWeight}" />
 		<Setter Property="FontSize"
@@ -129,7 +143,7 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource LabelLargeFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource LabelLargeFontWeight}" />
 		<Setter Property="FontSize"
@@ -143,7 +157,7 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource LabelMediumFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource LabelMediumFontWeight}" />
 		<Setter Property="FontSize"
@@ -157,7 +171,7 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource LabelSmallFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource LabelSmallFontWeight}" />
 		<Setter Property="FontSize"
@@ -173,7 +187,7 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource LabelExtraSmallFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource LabelExtraSmallFontWeight}" />
 		<Setter Property="FontSize"
@@ -189,7 +203,7 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource BodyLargeFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource BodyLargeFontWeight}" />
 		<Setter Property="FontSize"
@@ -203,7 +217,7 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource BodyMediumFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource BodyMediumFontWeight}" />
 		<Setter Property="FontSize"
@@ -217,7 +231,7 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource BodySmallFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource BodySmallFontWeight}" />
 		<Setter Property="FontSize"
@@ -234,7 +248,7 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource CaptionLargeFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource CaptionLargeFontWeight}" />
 		<Setter Property="FontSize"
@@ -249,7 +263,7 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource CaptionMediumFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource CaptionMediumFontWeight}" />
 		<Setter Property="FontSize"
@@ -264,7 +278,7 @@
 		   BasedOn="{StaticResource MaterialBaseTextBlockStyle}"
 		   TargetType="TextBlock">
 		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
+				Value="{ThemeResource CaptionSmallFontFamily}" />
 		<Setter Property="FontWeight"
 				Value="{ThemeResource CaptionSmallFontWeight}" />
 		<Setter Property="FontSize"


### PR DESCRIPTION
﻿GitHub Issue: closes #1250 

## PR Type
What kind of change does this PR introduce?
- Bugfix

## Description
Add overridable font-family resources for each of typography textblock styles.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [X] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
