### PR TITLE
fix: show default sized fabs in sample page

### DIFF
--- a/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/FabSamplePage.xaml
+++ b/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/FabSamplePage.xaml
@@ -173,7 +173,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Icon"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialSmallFabStyle}"
+								<Button Style="{StaticResource MaterialFabStyle}"
 										HorizontalAlignment="Center">
 									<um:ControlExtensions.Icon>
 										<PathIcon Data="M16 9.14286H9.14286V16H6.85714V9.14286H0V6.85714H6.85714V0H9.14286V6.85714H16V9.14286Z" />
@@ -186,7 +186,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Icon_Surface"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialSurfaceSmallFabStyle}"
+								<Button Style="{StaticResource MaterialSurfaceFabStyle}"
 										HorizontalAlignment="Center">
 									<um:ControlExtensions.Icon>
 										<PathIcon Data="M16 9.14286H9.14286V16H6.85714V9.14286H0V6.85714H6.85714V0H9.14286V6.85714H16V9.14286Z" />
@@ -198,7 +198,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Icon_Secondary"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialSecondarySmallFabStyle}"
+								<Button Style="{StaticResource MaterialSecondaryFabStyle}"
 										HorizontalAlignment="Center">
 									<um:ControlExtensions.Icon>
 										<PathIcon Data="M16 9.14286H9.14286V16H6.85714V9.14286H0V6.85714H6.85714V0H9.14286V6.85714H16V9.14286Z" />
@@ -210,7 +210,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Icon_Tertiary"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialTertiarySmallFabStyle}"
+								<Button Style="{StaticResource MaterialTertiaryFabStyle}"
 										HorizontalAlignment="Center">
 									<um:ControlExtensions.Icon>
 										<PathIcon Data="M16 9.14286H9.14286V16H6.85714V9.14286H0V6.85714H6.85714V0H9.14286V6.85714H16V9.14286Z" />
@@ -221,7 +221,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Icon_Disabled"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialTertiarySmallFabStyle}"
+								<Button Style="{StaticResource MaterialTertiaryFabStyle}"
 										IsEnabled="False"
 										HorizontalAlignment="Center">
 									<um:ControlExtensions.Icon>
@@ -241,7 +241,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Icon_Label"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialSmallFabStyle}"
+								<Button Style="{StaticResource MaterialFabStyle}"
 										HorizontalAlignment="Center"
 										Content="Create">
 									<um:ControlExtensions.Icon>
@@ -255,7 +255,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Icon_Label_Surface"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialSurfaceSmallFabStyle}"
+								<Button Style="{StaticResource MaterialSurfaceFabStyle}"
 										HorizontalAlignment="Center"
 										Content="Create">
 									<um:ControlExtensions.Icon>
@@ -268,7 +268,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Icon_Label_Secondary"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialSecondarySmallFabStyle}"
+								<Button Style="{StaticResource MaterialSecondaryFabStyle}"
 										HorizontalAlignment="Center"
 										Content="Create">
 									<um:ControlExtensions.Icon>
@@ -281,7 +281,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Icon_Label_Tertiary"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialTertiarySmallFabStyle}"
+								<Button Style="{StaticResource MaterialTertiaryFabStyle}"
 										HorizontalAlignment="Center"
 										Content="Create">
 									<um:ControlExtensions.Icon>
@@ -294,7 +294,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Icon_Label_Disabled"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialTertiarySmallFabStyle}"
+								<Button Style="{StaticResource MaterialTertiaryFabStyle}"
 										HorizontalAlignment="Center"
 										IsEnabled="False"
 										Content="Create">
@@ -315,7 +315,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Label"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialSmallFabStyle}"
+								<Button Style="{StaticResource MaterialFabStyle}"
 										HorizontalAlignment="Center"
 										Content="Create"/>
 							</smtx:XamlDisplay>
@@ -325,7 +325,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Label_Surface"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialSurfaceSmallFabStyle}"
+								<Button Style="{StaticResource MaterialSurfaceFabStyle}"
 										HorizontalAlignment="Center"
 										Content="Create"/>
 							</smtx:XamlDisplay>
@@ -334,7 +334,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Label_Secondary"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialSecondarySmallFabStyle}"
+								<Button Style="{StaticResource MaterialSecondaryFabStyle}"
 										HorizontalAlignment="Center"
 										Content="Create"/>
 							</smtx:XamlDisplay>
@@ -343,7 +343,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Label_Tertiary"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialTertiarySmallFabStyle}"
+								<Button Style="{StaticResource MaterialTertiaryFabStyle}"
 										HorizontalAlignment="Center"
 										Content="Create"/>
 							</smtx:XamlDisplay>
@@ -352,7 +352,7 @@
 							<smtx:XamlDisplay UniqueKey="M3_FabSamplePage_Default_Label_Disabled"
 											  Style="{StaticResource XamlDisplayBelowStyle}"
 											  Margin="{StaticResource XamlDisplayMargin}">
-								<Button Style="{StaticResource MaterialTertiarySmallFabStyle}"
+								<Button Style="{StaticResource MaterialTertiaryFabStyle}"
 										HorizontalAlignment="Center"
 										IsEnabled="False"
 										Content="Create" />


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description
Changed the small styles to the default styles in the default section of the fab sample page
<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested the changes where applicable:
	- [x] UWP
	- [ ] iOS
	- [ ] Android
	- [X] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
