### PR TITLE
fix: TextBox Outlined style inconsistencies

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
@@ -23,7 +23,7 @@
 			<StaticResource x:Key="TextBoxDeleteButtonForegroundPressed" ResourceKey="OnSurfaceVariantBrush" />
 			<StaticResource x:Key="TextBoxDeleteButtonForegroundDisabled" ResourceKey="OnSurfaceLowBrush" />
 			<!--#endregion-->
-			
+
 			<!--#region Leading Icon Brushes-->
 			<StaticResource x:Key="TextBoxLeadingIconForeground" ResourceKey="OnSurfaceVariantBrush" />
 			<StaticResource x:Key="TextBoxLeadingIconForegroundDisabled" ResourceKey="OnSurfaceLowBrush" />
@@ -122,7 +122,7 @@
 			<StaticResource x:Key="TextBoxDeleteButtonForegroundPressed" ResourceKey="OnSurfaceVariantBrush" />
 			<StaticResource x:Key="TextBoxDeleteButtonForegroundDisabled" ResourceKey="OnSurfaceLowBrush" />
 			<!--#endregion-->
-			
+
 			<!--#region Leading Icon Brushes-->
 			<StaticResource x:Key="TextBoxLeadingIconForeground" ResourceKey="OnSurfaceVariantBrush" />
 			<StaticResource x:Key="TextBoxLeadingIconForegroundDisabled" ResourceKey="OnSurfaceLowBrush" />
@@ -613,16 +613,18 @@
 
 							<!-- Border in place to properly vertically center the icon inside when it's a one-line TextBox -->
 							<!-- but keep it in the same place and at the top when it's a multiline TextBox -->
-							<Border Height="20"
-									VerticalAlignment="Top">
+							<Border Height="26"
+									VerticalAlignment="Top"
+									Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}">
 								<ContentPresenter x:Name="IconPresenter"
 												  Content="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}}"
 												  HorizontalAlignment="Center"
-												  Width="20"
-												  Margin="1,0,18,0"
+												  MinWidth="25"
+												  MaxWidth="34"
+												  MaxHeight="34"
+												  Margin="0,0,8,0"
 												  Foreground="{ThemeResource TextBoxLeadingIconForeground}"
-												  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-												  Visibility="{Binding Path=(um:ControlExtensions.Icon), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+												  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
 							</Border>
 
 							<ScrollViewer x:Name="ContentElement"
@@ -646,7 +648,7 @@
 							<!-- Border in place to properly vertically center the placeholder inside when it's a one-line TextBox -->
 							<!-- but keep it in the same place and at the top when it's a multiline TextBox -->
 							<Border Grid.Column="1"
-									Height="20"
+									Height="26"
 									VerticalAlignment="Top">
 								<TextBlock x:Name="PlaceholderElement"
 										   Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}}"


### PR DESCRIPTION
﻿GitHub Issue: closes #1334 

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description

<!-- (Please describe the changes that this PR introduces.) -->
This PR aligns the Outlined style of the TextBox to the Filled TextBox style and the PasswordBox style for consistency in the alignment of the TextBox components (icon, text, placeholder).
Before and after screenshots are available in issue #1334.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [x] UWP
	- [ ] iOS
	- [x] Android
	- [x] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
