### PR TITLE
chore: Bump to later net7 builds

### DIFF
--- a/build/templates/dotnet-install-macos.yml
+++ b/build/templates/dotnet-install-macos.yml
@@ -1,7 +1,7 @@
 ﻿parameters:
   DotNetVersion: '7.0.302'
-  UnoCheck_Version: '1.11.0-dev.2'
-  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/146b0b4b23d866bef455494a12ad7ffd2f6f2d20/manifests/uno.ui.manifest.json'
+  UnoCheck_Version: '1.18.1'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/8a14128754833984a0c83398e7dda6d995199e1b/manifests/uno.ui.manifest.json'
   Dotnet_Root: '/usr/local/share/dotnet/'
   Dotnet_Tools: '~/.dotnet/tools'
 

--- a/build/templates/dotnet-install-windows.yml
+++ b/build/templates/dotnet-install-windows.yml
@@ -1,7 +1,7 @@
 ﻿parameters:
   DotNetVersion: '7.0.302'
-  UnoCheck_Version: '1.11.0-dev.2'
-  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/146b0b4b23d866bef455494a12ad7ffd2f6f2d20/manifests/uno.ui.manifest.json'
+  UnoCheck_Version: '1.18.1'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/8a14128754833984a0c83398e7dda6d995199e1b/manifests/uno.ui.manifest.json'
 
 steps:
 


### PR DESCRIPTION
This change will bump to 7.0.401's workloads, in order to align with recent Uno 5.1 changes.