### PR TITLE
fix: move Focused visualstate to CommonStates group

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/Button.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/Button.xaml
@@ -730,6 +730,26 @@
 										<Setter Target="Root.BorderBrush" Value="{ThemeResource FilledTonalButtonBorderBrushDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
+
+								<VisualState x:Name="Focused">
+									<VisualState.Setters>
+										<Setter Target="Root.Background" Value="{ThemeResource FilledTonalButtonBackgroundFocused}" />
+										<Setter Target="StateLayer.Background" Value="{ThemeResource FilledTonalButtonStateLayerBackgroundFocused}" />
+										<Setter Target="IconPresenter.Foreground" Value="{ThemeResource FilledTonalButtonIconForegroundFocused}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource FilledTonalButtonForegroundFocused}" />
+										<Setter Target="Root.BorderBrush" Value="{ThemeResource FilledTonalButtonBorderBrushFocused}" />
+									</VisualState.Setters>
+								</VisualState>
+
+								<VisualState x:Name="PointerFocused">
+									<VisualState.Setters>
+										<Setter Target="Root.Background" Value="{ThemeResource FilledTonalButtonBackgroundPointerFocused}" />
+										<Setter Target="StateLayer.Background" Value="{ThemeResource FilledTonalButtonStateLayerBackgroundPointerFocused}" />
+										<Setter Target="IconPresenter.Foreground" Value="{ThemeResource FilledTonalButtonIconForegroundPointerFocused}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource FilledTonalButtonForegroundPointerFocused}" />
+										<Setter Target="Root.BorderBrush" Value="{ThemeResource FilledTonalButtonBorderBrushPointerFocused}" />
+									</VisualState.Setters>
+								</VisualState>
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 

--- a/src/library/Uno.Material/Styles/Controls/v2/Button.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/Button.xaml
@@ -460,9 +460,7 @@
 										<Setter Target="ElevatedView.Elevation" Value="{ThemeResource ElevatedButtonElevationDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
-							</VisualStateGroup>
 
-							<VisualStateGroup x:Name="FocusStates">
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
 										<Setter Target="Root.Background" Value="{ThemeResource ElevatedButtonBackgroundFocused}" />
@@ -482,8 +480,6 @@
 										<Setter Target="Root.BorderBrush" Value="{ThemeResource ElevatedButtonBorderBrushPointerFocused}" />
 									</VisualState.Setters>
 								</VisualState>
-
-								<VisualState x:Name="Unfocused" />
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 
@@ -599,9 +595,6 @@
 										<Setter Target="Root.BorderBrush" Value="{ThemeResource FilledButtonBorderBrushDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
-							</VisualStateGroup>
-
-							<VisualStateGroup x:Name="FocusStates">
 
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
@@ -622,8 +615,6 @@
 										<Setter Target="Root.BorderBrush" Value="{ThemeResource FilledButtonBorderBrushPointerFocused}" />
 									</VisualState.Setters>
 								</VisualState>
-
-								<VisualState x:Name="Unfocused" />
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 
@@ -739,31 +730,6 @@
 										<Setter Target="Root.BorderBrush" Value="{ThemeResource FilledTonalButtonBorderBrushDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
-							</VisualStateGroup>
-
-							<VisualStateGroup x:Name="FocusStates">
-
-								<VisualState x:Name="Focused">
-									<VisualState.Setters>
-										<Setter Target="Root.Background" Value="{ThemeResource FilledTonalButtonBackgroundFocused}" />
-										<Setter Target="StateLayer.Background" Value="{ThemeResource FilledTonalButtonStateLayerBackgroundFocused}" />
-										<Setter Target="IconPresenter.Foreground" Value="{ThemeResource FilledTonalButtonIconForegroundFocused}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource FilledTonalButtonForegroundFocused}" />
-										<Setter Target="Root.BorderBrush" Value="{ThemeResource FilledTonalButtonBorderBrushFocused}" />
-									</VisualState.Setters>
-								</VisualState>
-
-								<VisualState x:Name="PointerFocused">
-									<VisualState.Setters>
-										<Setter Target="Root.Background" Value="{ThemeResource FilledTonalButtonBackgroundPointerFocused}" />
-										<Setter Target="StateLayer.Background" Value="{ThemeResource FilledTonalButtonStateLayerBackgroundPointerFocused}" />
-										<Setter Target="IconPresenter.Foreground" Value="{ThemeResource FilledTonalButtonIconForegroundPointerFocused}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource FilledTonalButtonForegroundPointerFocused}" />
-										<Setter Target="Root.BorderBrush" Value="{ThemeResource FilledTonalButtonBorderBrushPointerFocused}" />
-									</VisualState.Setters>
-								</VisualState>
-
-								<VisualState x:Name="Unfocused" />
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 
@@ -881,9 +847,6 @@
 										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OutlinedButtonForegroundDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
-							</VisualStateGroup>
-
-							<VisualStateGroup x:Name="FocusStates">
 
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
@@ -904,8 +867,6 @@
 										<Setter Target="Root.BorderBrush" Value="{ThemeResource OutlinedButtonBorderBrushPointerFocused}" />
 									</VisualState.Setters>
 								</VisualState>
-
-								<VisualState x:Name="Unfocused" />
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 
@@ -1014,9 +975,6 @@
 										<Setter Target="Root.BorderBrush" Value="{ThemeResource TextButtonBorderBrushDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
-							</VisualStateGroup>
-
-							<VisualStateGroup x:Name="FocusStates">
 
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
@@ -1037,8 +995,6 @@
 										<Setter Target="Root.BorderBrush" Value="{ThemeResource TextButtonBorderBrushPointerFocused}" />
 									</VisualState.Setters>
 								</VisualState>
-
-								<VisualState x:Name="Unfocused" />
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 

--- a/src/library/Uno.Material/Styles/Controls/v2/FloatingActionButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/FloatingActionButton.xaml
@@ -285,19 +285,12 @@
 										<Setter Target="StateOverlay.Background" Value="{ThemeResource FabStateOverlayBackgroundDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
-							</VisualStateGroup>
-
-							<VisualStateGroup x:Name="FocusStates">
 
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
 										<Setter Target="StateOverlay.Background" Value="{ThemeResource FabStateOverlayBackgroundFocused}" />
 									</VisualState.Setters>
 								</VisualState>
-
-								<VisualState x:Name="PointerFocused" />
-
-								<VisualState x:Name="Unfocused" />
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 					</Grid>
@@ -409,19 +402,12 @@
 										<Setter Target="StateOverlay.Background" Value="{ThemeResource FabSurfaceStateOverlayBackgroundDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
-							</VisualStateGroup>
-
-							<VisualStateGroup x:Name="FocusStates">
 
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
 										<Setter Target="StateOverlay.Background" Value="{ThemeResource FabSurfaceStateOverlayBackgroundFocused}" />
 									</VisualState.Setters>
 								</VisualState>
-
-								<VisualState x:Name="PointerFocused" />
-
-								<VisualState x:Name="Unfocused" />
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 					</Grid>
@@ -533,19 +519,12 @@
 										<Setter Target="StateOverlay.Background" Value="{ThemeResource FabSecondaryStateOverlayBackgroundDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
-							</VisualStateGroup>
-
-							<VisualStateGroup x:Name="FocusStates">
 
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
 										<Setter Target="StateOverlay.Background" Value="{ThemeResource FabSecondaryStateOverlayBackgroundFocused}" />
 									</VisualState.Setters>
 								</VisualState>
-
-								<VisualState x:Name="PointerFocused" />
-
-								<VisualState x:Name="Unfocused" />
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 					</Grid>
@@ -657,19 +636,12 @@
 										<Setter Target="StateOverlay.Background" Value="{ThemeResource FabTertiaryStateOverlayBackgroundDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
-							</VisualStateGroup>
-
-							<VisualStateGroup x:Name="FocusStates">
 
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
 										<Setter Target="StateOverlay.Background" Value="{ThemeResource FabTertiaryStateOverlayBackgroundFocused}" />
 									</VisualState.Setters>
 								</VisualState>
-
-								<VisualState x:Name="PointerFocused" />
-
-								<VisualState x:Name="Unfocused" />
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 					</Grid>


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/14633
closes #1293 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Move Focused visual state into CommonStates VisualStateGroup to avoid conflicts between the FocuseStates and the CommonStates when an element is Focused and then becomes Disabled.

This sort of VisualState organization can be seen in the [Fluent styles as well](https://github.com/unoplatform/uno/blob/095d213ab1143dc2799c289696123102db7c13e0/src/Uno.UI.FluentTheme.v2/Resources/Version2/Priority02/PasswordBox_themeresources.xaml#L196).

## Previous Behavior

![button-state-broken](https://github.com/unoplatform/Uno.Themes/assets/4793020/7034ee61-b70b-48e3-872c-7f74c7597d77)


## New Behavior

![button-state-working](https://github.com/unoplatform/Uno.Themes/assets/4793020/8338dca0-8239-4a37-ac1d-12f979af5b9c)

