### PR TITLE
chore: bump uno.winui.markup to 5.2

### DIFF
--- a/src/library/Directory.Packages.props
+++ b/src/library/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />
     <PackageVersion Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-    <PackageVersion Include="Uno.Extensions.Markup.Generators" Version="5.0.13" />
+    <PackageVersion Include="Uno.Extensions.Markup.Generators" Version="5.2.0-dev.61" />
     <PackageVersion Include="Uno.Fonts.Roboto" Version="2.2.2" />
     <PackageVersion Include="Uno.UI" Version="5.0.19" />
     <PackageVersion Include="Uno.UI.Lottie" Version="5.0.19" />

--- a/src/library/Directory.Packages.props
+++ b/src/library/Directory.Packages.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 		<_Uno_XamlMerge_Task_Version>1.1.0-dev.12</_Uno_XamlMerge_Task_Version>
@@ -17,7 +17,7 @@
     <PackageVersion Include="Uno.UI.Lottie" Version="5.0.19" />
     <PackageVersion Include="Uno.WinUI" Version="5.0.19" />
     <PackageVersion Include="Uno.WinUI.Lottie" Version="5.0.19" />
-    <PackageVersion Include="Uno.WinUI.Markup" Version="5.0.13" />
+    <PackageVersion Include="Uno.WinUI.Markup" Version="5.2.0-dev.61" />
 		<PackageVersion Include="Uno.XamlMerge.Task" Version="$(_Uno_XamlMerge_Task_Version)" />
 	</ItemGroup>
 </Project>

--- a/src/library/Uno.Themes.WinUI.Markup/Uno.Themes.WinUI.Markup.csproj
+++ b/src/library/Uno.Themes.WinUI.Markup/Uno.Themes.WinUI.Markup.csproj
@@ -14,7 +14,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.WinUI.Markup" />
-		<PackageReference Include="Uno.WinUI" />
 		<PackageReference Include="Uno.Extensions.Markup.Generators" PrivateAssets="All" />
 	</ItemGroup>
 


### PR DESCRIPTION
closes #1371
