### PR TITLE
fix: Use BodyLarge typography for TextBox Placholder

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
@@ -439,6 +439,7 @@
 									Height="26"
 									VerticalAlignment="Top">
 								<TextBlock x:Name="PlaceholderElement"
+											 Style="{StaticResource BodyLarge}"
 										   Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}}"
 										   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 										   IsHitTestVisible="False"
@@ -652,6 +653,7 @@
 									Height="26"
 									VerticalAlignment="Top">
 								<TextBlock x:Name="PlaceholderElement"
+											 Style="{StaticResource BodyLarge}"
 										   Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}}"
 										   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 										   IsHitTestVisible="False"


### PR DESCRIPTION
related https://github.com/unoplatform/Uno.Themes/issues/1379

## PR Type

What kind of change does this PR introduce?

- Bugfix


The PlaceholderText should be using the BodyLarge typography values, same as the TextBox's Content element. For now, until https://github.com/unoplatform/Uno.Themes/pull/1014 is merged, we will also keep those typorgaphy values when the PlaceholderElement is translated to serve as the "header"/"label" of the TextBox and keep it scaled down to the same size as BodySmall