### PR TITLE
chore: Update canary updater and adjust samples path for UWP to fix canary build

### DIFF
--- a/Uno.Themes.sln
+++ b/Uno.Themes.sln
@@ -5,13 +5,13 @@ VisualStudioVersion = 17.1.31903.286
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Material", "src\library\Uno.Material\Uno.Material.csproj", "{B5279EE5-E662-45B0-8929-D90D0BDE16AB}"
 EndProject
-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Uno.Themes.Samples.Shared", "src\samples\uwp\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.shproj", "{6279C845-92F8-4333-AB99-3D213163593C}"
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Uno.Themes.Samples.Shared", "src\samples\UWP\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.shproj", "{6279C845-92F8-4333-AB99-3D213163593C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Themes.Samples.UWP", "src\samples\uwp\Uno.Themes.Samples.UWP\Uno.Themes.Samples.UWP.csproj", "{265517E4-AB14-453D-92DA-F32AA1D4007D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Themes.Samples.UWP", "src\samples\UWP\Uno.Themes.Samples.UWP\Uno.Themes.Samples.UWP.csproj", "{265517E4-AB14-453D-92DA-F32AA1D4007D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Themes.Samples.Wasm", "src\samples\uwp\Uno.Themes.Samples.Wasm\Uno.Themes.Samples.Wasm.csproj", "{5D0F3763-F3BF-4478-B2D3-B47AB74205C9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Themes.Samples.Wasm", "src\samples\UWP\Uno.Themes.Samples.Wasm\Uno.Themes.Samples.Wasm.csproj", "{5D0F3763-F3BF-4478-B2D3-B47AB74205C9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Themes.Samples.Mobile", "src\samples\uwp\Uno.Themes.Samples.Mobile\Uno.Themes.Samples.Mobile.csproj", "{D45D0327-B421-48F5-98BC-7C9B1D6ABD9E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Themes.Samples.Mobile", "src\samples\UWP\Uno.Themes.Samples.Mobile\Uno.Themes.Samples.Mobile.csproj", "{D45D0327-B421-48F5-98BC-7C9B1D6ABD9E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{F42C65EA-6E6A-43B9-9D9F-D8C6063AD309}"
 	ProjectSection(SolutionItems) = preProject
@@ -35,7 +35,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\conventional-commits.yml = .github\workflows\conventional-commits.yml
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Themes.Samples.Skia.Gtk", "src\samples\uwp\Uno.Themes.Samples.Skia.Gtk\Uno.Themes.Samples.Skia.Gtk.csproj", "{290980EF-0A64-43A5-AEB4-E022D82BBF8B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Themes.Samples.Skia.Gtk", "src\samples\UWP\Uno.Themes.Samples.Skia.Gtk\Uno.Themes.Samples.Skia.Gtk.csproj", "{290980EF-0A64-43A5-AEB4-E022D82BBF8B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{DBF3AF2F-F909-4106-A436-7D76CBFBADCC}"
 	ProjectSection(SolutionItems) = preProject
@@ -1034,14 +1034,14 @@ Global
 		SolutionGuid = {66F0EE99-4E63-43F2-9504-0CFC104E7084}
 	EndGlobalSection
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		src\samples\uwp\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{0e06ab03-d48d-40a6-b779-3ff8d968e262}*SharedItemsImports = 5
-		src\samples\uwp\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{265517e4-ab14-453d-92da-f32aa1d4007d}*SharedItemsImports = 4
-		src\samples\uwp\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{290980ef-0a64-43a5-aeb4-e022d82bbf8b}*SharedItemsImports = 5
-		src\samples\uwp\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{5d0f3763-f3bf-4478-b2d3-b47ab74205c9}*SharedItemsImports = 5
-		src\samples\uwp\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{6279c845-92f8-4333-ab99-3d213163593c}*SharedItemsImports = 13
-		src\samples\uwp\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{62b6a5f9-dd6c-4fa1-82cb-da96e40f88f2}*SharedItemsImports = 5
-		src\samples\uwp\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{a9c9ece3-e056-4375-a48a-2882f215309d}*SharedItemsImports = 5
-		src\samples\uwp\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{b3d3007a-8fc2-47f6-abc4-b2d9a65da625}*SharedItemsImports = 5
-		src\samples\uwp\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{d45d0327-b421-48f5-98bc-7c9b1d6abd9e}*SharedItemsImports = 5
+		src\samples\UWP\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{0e06ab03-d48d-40a6-b779-3ff8d968e262}*SharedItemsImports = 5
+		src\samples\UWP\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{265517e4-ab14-453d-92da-f32aa1d4007d}*SharedItemsImports = 4
+		src\samples\UWP\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{290980ef-0a64-43a5-aeb4-e022d82bbf8b}*SharedItemsImports = 5
+		src\samples\UWP\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{5d0f3763-f3bf-4478-b2d3-b47ab74205c9}*SharedItemsImports = 5
+		src\samples\UWP\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{6279c845-92f8-4333-ab99-3d213163593c}*SharedItemsImports = 13
+		src\samples\UWP\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{62b6a5f9-dd6c-4fa1-82cb-da96e40f88f2}*SharedItemsImports = 5
+		src\samples\UWP\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{a9c9ece3-e056-4375-a48a-2882f215309d}*SharedItemsImports = 5
+		src\samples\UWP\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{b3d3007a-8fc2-47f6-abc4-b2d9a65da625}*SharedItemsImports = 5
+		src\samples\UWP\Uno.Themes.Samples.Shared\Uno.Themes.Samples.Shared.projitems*{d45d0327-b421-48f5-98bc-7c9b1d6abd9e}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/build/templates/canary-updater.yml
+++ b/build/templates/canary-updater.yml
@@ -25,7 +25,7 @@
       usePrivateFeed: false
       mergeBranch: true
       branchToMerge: master
-      nugetUpdaterVersion: 2.3.0-alpha.46
+      nugetUpdaterVersion: 2.3.0-alpha.62
       packageAuthor: 'nventive,Uno Platform'
       summaryFile: '$(Build.ArtifactStagingDirectory)/Canary.md'
       resultFile: '$(Build.ArtifactStagingDirectory)/Results.json'


### PR DESCRIPTION
﻿GitHub Issue: https://github.com/unoplatform/uno.themes-private/issues/28

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes


## Description

Update canary updater and adjust samples path for UWP to fix canary build
