### PR TITLE
ci: Include .markdownlint.json and cspell.json as part of the documentation

### DIFF
--- a/build/stage-determine-changes.yml
+++ b/build/stage-determine-changes.yml
@@ -34,11 +34,11 @@ jobs:
       }
 
       foreach ($file in $changedFiles -split "`n") {
-        # Identifying changes as documentation if they occur:
-        # Within the doc folder, or
-        # Are Markdown files at the root level (with no subdirectories involved), or
-        # Are Markdown files within the .github folder (including its subdirectories)
-          $isDoc = $file.StartsWith("doc/") -or ($file -match "^[^/]+\.md$") -or ($file -match "^\.github/.*\.md$")
+        # Identifying changes as documentation:
+          $isDoc = $file.StartsWith("doc/") -or               # Files in the 'doc/' directory
+            ($file -match "^[^/]+\.md$") -or                  # Markdown files at the root level (with no subdirectories involved)
+            ($file -match "^\.github/.*\.md$") -or            # Markdown files within the .github folder (including its subdirectories)
+            ($file -match "^\.(markdownlint|cspell)\.json$")  # Specific JSON files: .markdownlint.json and cspell.json
           
           if ($isDoc) {
               $docFiles++


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes


## Description

Include .markdownlint.json and cspell.json as part of the documentation changes to avoid ci running the full build in some conditions

