### PR TITLE
fix: Adjust Selected Opacity

### DIFF
--- a/doc/material-colors.md
+++ b/doc/material-colors.md
@@ -50,7 +50,7 @@ uid: Uno.Themes.Material.Colors
 | FocusedOpacity  | 0.12  |
 | PressedOpacity  | 0.12  |
 | DraggedOpacity  | 0.16  |
-| SelectedOpacity | 0.16  |
+| SelectedOpacity | 0.08  |
 | MediumOpacity   | 0.64  |
 | LowOpacity      | 0.32  |
 | DisabledOpacity | 0.12  |

--- a/src/library/Uno.Themes/Styles/Applications/Common/SharedColorPalette.xaml
+++ b/src/library/Uno.Themes/Styles/Applications/Common/SharedColorPalette.xaml
@@ -128,7 +128,7 @@
 	<x:Double x:Key="FocusedOpacity">0.12</x:Double>
 	<x:Double x:Key="PressedOpacity">0.12</x:Double>
 	<x:Double x:Key="DraggedOpacity">0.16</x:Double>
-	<x:Double x:Key="SelectedOpacity">0.16</x:Double>
+	<x:Double x:Key="SelectedOpacity">0.08</x:Double>
 	<x:Double x:Key="MediumOpacity">0.64</x:Double>
 	<x:Double x:Key="LowOpacity">0.32</x:Double>
 	<x:Double x:Key="DisabledOpacity">0.12</x:Double>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Bugfix
- Documentation content changes

## Description
While working on samples I noticed that the Selected opacity from Material and Figma did not match the value in Uno Themes.

Details shared previously by @NVLudwig [here](https://github.com/unoplatform/Uno.Themes/issues/1000#issuecomment-1749431493) included an erratum for Selected opacity. It should be 8% instead of 16%.

@NVLudwig verified Material, his Excel file, and Figma files - they all converged to 8% opacity.
