### PR TITLE
fix: Properly set material TextBox padding

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
@@ -460,7 +460,7 @@
 
 						</VisualStateManager.VisualStateGroups>
 
-						<Grid Margin="{TemplateBinding Padding}">
+						<Grid Padding="{TemplateBinding Padding}">
 							<Grid.ColumnDefinitions>
 								<ColumnDefinition Width="Auto" />
 								<ColumnDefinition Width="*" />
@@ -711,7 +711,7 @@
 
 						<Grid x:Name="Root"
 							  Background="{TemplateBinding Background}"
-							  Margin="{TemplateBinding Padding}">
+							  Padding="{TemplateBinding Padding}">
 							<Grid.ColumnDefinitions>
 								<ColumnDefinition Width="Auto" />
 								<ColumnDefinition Width="*" />


### PR DESCRIPTION
﻿GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR 


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Other... Please describe:

-->
## Description

![image](https://github.com/user-attachments/assets/b276b7b9-9970-4263-9b01-1a8bab838266)
![image](https://github.com/user-attachments/assets/51a12f10-dca7-409f-9fd7-db0294a8679a)


<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
