### PR TITLE
fix: ensure attribute animations respond to code changes

### DIFF
--- a/doc/material-migration.md
+++ b/doc/material-migration.md
@@ -17,7 +17,7 @@ Previously, the `PlaceholderText` property acted as a header, displaying in the 
 ##### New Behavior
 
 - **PlaceholderText**: Displays inside the TextBox when it's empty. Disappears when text is entered.
-- **Header**: Acts as a label. Animates upwards when the TextBox is focused.
+- **Header**: Acts as a label. Animates upwards when text is entered.
 
 ##### Example
 

--- a/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
@@ -18,7 +18,7 @@
 
 		- With placeholder but no header: The placeholder will be displayed where the text is supposed to be until text is inputed
 
-		- With header but no placeholder: The header will be displayed where the text is supposed to be and will move up when focused
+		- With header but no placeholder: The header will be displayed where the text is supposed to be and will move up when text is inputed
 
 		- Whith header and placeholder: The header will be displayed at the top and the placeholder will be displayed where the text is supposed to be until text is inputed
 	-->
@@ -358,7 +358,6 @@
 							<VisualStateGroup x:Name="CommonStates">
 								<VisualState x:Name="Normal" />
 
-
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
 										<Setter Target="NormalBorder.Fill" Value="{ThemeResource FilledTextBoxBorderBrushPointerOver}" />
@@ -425,7 +424,7 @@
 								<VisualState x:Name="HeaderNotEmpty">
 									<VisualState.Setters>
 										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
 										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
@@ -482,31 +481,25 @@
 									<VisualState.Setters>
 										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-
-										<!-- Setters instead of animations on WASM work -->
-										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 									</VisualState.Setters>
 
-									<!-- Animations not working properly on WASM -->
-									<!--<Storyboard>
+									<Storyboard>
 										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
 														 Storyboard.TargetProperty="TranslateY"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+														 To="-11" />
 										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
 														 Storyboard.TargetProperty="ScaleX"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+														 To="0.7" />
 										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
 														 Storyboard.TargetProperty="ScaleY"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-									</Storyboard>-->
+														 To="0.7" />
+									</Storyboard>
 									<VisualState.StateTriggers>
 										<StateTrigger IsActive="{Binding Text, Converter={StaticResource EmptyToFalseConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
 									</VisualState.StateTriggers>
@@ -736,7 +729,7 @@
 								<VisualState x:Name="HeaderNotEmpty">
 									<VisualState.Setters>
 										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
 										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
@@ -793,31 +786,25 @@
 									<VisualState.Setters>
 										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-
-										<!-- Setters instead of animations on WASM work -->
-										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 									</VisualState.Setters>
 
-									<!-- Animations not working properly on WASM -->
-									<!-- <Storyboard>
+									<Storyboard>
 										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
 														 Storyboard.TargetProperty="TranslateY"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+														 To="-11" />
 										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
 														 Storyboard.TargetProperty="ScaleX"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+														 To="0.7" />
 										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
 														 Storyboard.TargetProperty="ScaleY"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-									</Storyboard> -->
+														 To="0.7" />
+									</Storyboard>
 									<VisualState.StateTriggers>
 										<StateTrigger IsActive="{Binding Text, Converter={StaticResource EmptyToFalseConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
 									</VisualState.StateTriggers>

--- a/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
@@ -356,16 +356,8 @@
 
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">
-								<VisualState x:Name="Normal">
-									<VisualState.Setters>
-										<!-- Header and Placeholder animations -->
-										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-									</VisualState.Setters>
-								</VisualState>
+								<VisualState x:Name="Normal" />
+
 
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
@@ -376,13 +368,6 @@
 										<Setter Target="ContentElement.Foreground" Value="{ThemeResource FilledTextBoxForegroundPointerOver}" />
 										<Setter Target="DeleteButton.Foreground" Value="{ThemeResource FilledTextBoxDeleteButtonForegroundPointerOver}" />
 										<Setter Target="NormalBorder.Height" Value="2" />
-
-										<!-- Header and Placeholder animations -->
-										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -400,12 +385,6 @@
 										<Setter Target="DeleteButton.Foreground" Value="{ThemeResource FilledTextBoxDeleteButtonForegroundDisabled}" />
 										<Setter Target="IconPresenter.Foreground" Value="{ThemeResource TextBoxLeadingIconForegroundDisabled}" />
 
-										<!-- Header and Placeholder animations -->
-										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -420,38 +399,11 @@
 										<Setter Target="DeleteButton.Foreground" Value="{ThemeResource FilledTextBoxDeleteButtonForegroundFocused}" />
 									</VisualState.Setters>
 									<Storyboard>
-										<!-- Animate Header Upwards -->
 										<DoubleAnimation Storyboard.TargetName="FocusedBorder_ScaleTransform"
 														 Storyboard.TargetProperty="ScaleX"
 														 Duration="{StaticResource MaterialAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
 														 To="1" />
-
-										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
-														 Storyboard.TargetProperty="TranslateY"
-														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="-11" />
-										<DoubleAnimation Storyboard.TargetName="ContentElement_CompositeTransform"
-														 Storyboard.TargetProperty="TranslateY"
-														 Duration="{StaticResource MaterialAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<DoubleAnimation Storyboard.TargetName="PlaceholderElement_CompositeTransform"
-														 Storyboard.TargetProperty="TranslateY"
-														 Duration="{StaticResource MaterialAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
-														 Storyboard.TargetProperty="ScaleX"
-														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="0.7" />
-										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
-														 Storyboard.TargetProperty="ScaleY"
-														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="0.7" />
 									</Storyboard>
 								</VisualState>
 							</VisualStateGroup>
@@ -466,45 +418,109 @@
 								<VisualState x:Name="ButtonCollapsed" />
 							</VisualStateGroup>
 
-							<!-- HeaderStates in place to manage animations when the TextBox is manipulated via code -->
+							<!-- We need to use VisualStateGroups in order to capture when any of those properties are changed via code -->
+
+							<!-- HeaderStates -->
 							<VisualStateGroup x:Name="HeaderStates">
-								<VisualState x:Name="NotEmpty">
-									<Storyboard>
+								<VisualState x:Name="HeaderNotEmpty">
+									<VisualState.Setters>
+										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+									</VisualState.Setters>
+									<VisualState.StateTriggers>
+										<StateTrigger IsActive="{Binding Header, Converter={StaticResource EmptyToFalseConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+									</VisualState.StateTriggers>
+								</VisualState>
+								<VisualState x:Name="HeaderEmpty">
+									<VisualState.Setters>
+										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+									</VisualState.Setters>
+									<VisualState.StateTriggers>
+										<StateTrigger IsActive="{Binding Header, Converter={StaticResource EmptyToTrueConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+									</VisualState.StateTriggers>
+								</VisualState>
+							</VisualStateGroup>
+
+							<!-- PlaceholderStates -->
+							<VisualStateGroup x:Name="PlaceholderStates">
+								<VisualState x:Name="PlaceholderNotEmpty">
+									<VisualState.Setters>
+										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+									</VisualState.Setters>
+									<VisualState.StateTriggers>
+										<StateTrigger IsActive="{Binding PlaceholderText, Converter={StaticResource EmptyToFalseConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+									</VisualState.StateTriggers>
+								</VisualState>
+								<VisualState x:Name="PlaceholderEmpty">
+									<VisualState.Setters>
+										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+									</VisualState.Setters>
+									<VisualState.StateTriggers>
+										<StateTrigger IsActive="{Binding PlaceholderText, Converter={StaticResource EmptyToTrueConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+									</VisualState.StateTriggers>
+								</VisualState>
+							</VisualStateGroup>
+
+							<!-- TextStates -->
+							<VisualStateGroup x:Name="TextStates">
+								<VisualState x:Name="TextNotEmpty">
+									<VisualState.Setters>
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+
+										<!-- Setters instead of animations on WASM work -->
+										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+									</VisualState.Setters>
+
+									<!-- Animations not working properly on WASM -->
+									<!--<Storyboard>
 										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
 														 Storyboard.TargetProperty="TranslateY"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="-11" />
-										<DoubleAnimation Storyboard.TargetName="ContentElement_CompositeTransform"
-														 Storyboard.TargetProperty="TranslateY"
-														 Duration="{StaticResource MaterialAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
 														 Storyboard.TargetProperty="ScaleX"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="0.7" />
-										<DoubleAnimation Storyboard.TargetName="PlaceholderElement_CompositeTransform"
-														 Storyboard.TargetProperty="TranslateY"
-														 Duration="{StaticResource MaterialAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
 										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
 														 Storyboard.TargetProperty="ScaleY"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="0.7" />
-									</Storyboard>
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+									</Storyboard>-->
 									<VisualState.StateTriggers>
 										<StateTrigger IsActive="{Binding Text, Converter={StaticResource EmptyToFalseConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
-										<StateTrigger IsActive="{Binding PlaceholderText, Converter={StaticResource EmptyToFalseConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
 									</VisualState.StateTriggers>
 								</VisualState>
-								<VisualState x:Name="Empty">
+								<VisualState x:Name="TextEmpty">
+									<VisualState.Setters>
+										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+									</VisualState.Setters>
 									<VisualState.StateTriggers>
 										<StateTrigger IsActive="{Binding Text, Converter={StaticResource EmptyToTrueConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
-										<StateTrigger IsActive="{Binding PlaceholderText, Converter={StaticResource EmptyToTrueConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
 									</VisualState.StateTriggers>
 								</VisualState>
 							</VisualStateGroup>
@@ -666,16 +682,7 @@
 
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">
-								<VisualState x:Name="Normal">
-									<VisualState.Setters>
-										<!-- Header and Placeholder animations -->
-										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-									</VisualState.Setters>
-								</VisualState>
+								<VisualState x:Name="Normal" />
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
 										<Setter Target="RootBorder.BorderBrush" Value="{ThemeResource OutlinedTextBoxBorderBrushPointerOver}" />
@@ -684,13 +691,6 @@
 										<Setter Target="HeaderElement.Foreground" Value="{ThemeResource OutlinedTextBoxHeaderForegroundPointerOver}" />
 										<Setter Target="RootBorder.BorderThickness" Value="2" />
 										<Setter Target="RootBorder.Padding" Value="0" />
-
-										<!-- Header and Placeholder animations -->
-										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="Pressed" />
@@ -704,13 +704,6 @@
 										<Setter Target="PlaceholderElement.Foreground" Value="{ThemeResource OutlinedTextBoxPlaceholderForegroundDisabled}" />
 										<Setter Target="HeaderElement.Foreground" Value="{ThemeResource OutlinedTextBoxHeaderForegroundDisabled}" />
 										<Setter Target="IconPresenter.Foreground" Value="{ThemeResource TextBoxLeadingIconForegroundDisabled}" />
-
-										<!-- Header and Placeholder animations -->
-										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -724,35 +717,6 @@
 										<Setter Target="RootBorder.BorderThickness" Value="{ThemeResource MaterialOutlinedTextBoxBorderThicknessFocused}" />
 										<Setter Target="RootBorder.Padding" Value="0" />
 									</VisualState.Setters>
-
-									<Storyboard>
-										<!-- Animate Header Upwards -->
-										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
-														 Storyboard.TargetProperty="TranslateY"
-														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="-11" />
-										<DoubleAnimation Storyboard.TargetName="ContentElement_CompositeTransform"
-														 Storyboard.TargetProperty="TranslateY"
-														 Duration="{StaticResource MaterialAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<DoubleAnimation Storyboard.TargetName="PlaceholderElement_CompositeTransform"
-														 Storyboard.TargetProperty="TranslateY"
-														 Duration="{StaticResource MaterialAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
-										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
-														 Storyboard.TargetProperty="ScaleX"
-														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="0.7" />
-										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
-														 Storyboard.TargetProperty="ScaleY"
-														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="0.7" />
-									</Storyboard>
 								</VisualState>
 							</VisualStateGroup>
 
@@ -765,45 +729,109 @@
 								<VisualState x:Name="ButtonCollapsed" />
 							</VisualStateGroup>
 
-							<!-- HeaderStates in place to manage animations when the TextBox is manipulated via code -->
+							<!-- We need to use VisualStateGroups in order to capture when any of those properties are changed via code -->
+
+							<!-- HeaderStates -->
 							<VisualStateGroup x:Name="HeaderStates">
-								<VisualState x:Name="NotEmpty">
-									<Storyboard>
+								<VisualState x:Name="HeaderNotEmpty">
+									<VisualState.Setters>
+										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+									</VisualState.Setters>
+									<VisualState.StateTriggers>
+										<StateTrigger IsActive="{Binding Header, Converter={StaticResource EmptyToFalseConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+									</VisualState.StateTriggers>
+								</VisualState>
+								<VisualState x:Name="HeaderEmpty">
+									<VisualState.Setters>
+										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+									</VisualState.Setters>
+									<VisualState.StateTriggers>
+										<StateTrigger IsActive="{Binding Header, Converter={StaticResource EmptyToTrueConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+									</VisualState.StateTriggers>
+								</VisualState>
+							</VisualStateGroup>
+
+							<!-- PlaceholderStates -->
+							<VisualStateGroup x:Name="PlaceholderStates">
+								<VisualState x:Name="PlaceholderNotEmpty">
+									<VisualState.Setters>
+										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+									</VisualState.Setters>
+									<VisualState.StateTriggers>
+										<StateTrigger IsActive="{Binding PlaceholderText, Converter={StaticResource EmptyToFalseConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+									</VisualState.StateTriggers>
+								</VisualState>
+								<VisualState x:Name="PlaceholderEmpty">
+									<VisualState.Setters>
+										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+									</VisualState.Setters>
+									<VisualState.StateTriggers>
+										<StateTrigger IsActive="{Binding PlaceholderText, Converter={StaticResource EmptyToTrueConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+									</VisualState.StateTriggers>
+								</VisualState>
+							</VisualStateGroup>
+
+							<!-- TextStates -->
+							<VisualStateGroup x:Name="TextStates">
+								<VisualState x:Name="TextNotEmpty">
+									<VisualState.Setters>
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+
+										<!-- Setters instead of animations on WASM work -->
+										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+									</VisualState.Setters>
+
+									<!-- Animations not working properly on WASM -->
+									<!-- <Storyboard>
 										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
 														 Storyboard.TargetProperty="TranslateY"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="-11" />
-										<DoubleAnimation Storyboard.TargetName="ContentElement_CompositeTransform"
-														 Storyboard.TargetProperty="TranslateY"
-														 Duration="{StaticResource MaterialAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
 														 Storyboard.TargetProperty="ScaleX"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="0.7" />
-										<DoubleAnimation Storyboard.TargetName="PlaceholderElement_CompositeTransform"
-														 Storyboard.TargetProperty="TranslateY"
-														 Duration="{StaticResource MaterialAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
 										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
 														 Storyboard.TargetProperty="ScaleY"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
 														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="0.7" />
-									</Storyboard>
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+									</Storyboard> -->
 									<VisualState.StateTriggers>
 										<StateTrigger IsActive="{Binding Text, Converter={StaticResource EmptyToFalseConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
-										<StateTrigger IsActive="{Binding PlaceholderText, Converter={StaticResource EmptyToFalseConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
 									</VisualState.StateTriggers>
 								</VisualState>
-								<VisualState x:Name="Empty">
+								<VisualState x:Name="TextEmpty">
+									<VisualState.Setters>
+										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+									</VisualState.Setters>
 									<VisualState.StateTriggers>
 										<StateTrigger IsActive="{Binding Text, Converter={StaticResource EmptyToTrueConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
-										<StateTrigger IsActive="{Binding PlaceholderText, Converter={StaticResource EmptyToTrueConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
 									</VisualState.StateTriggers>
 								</VisualState>
 							</VisualStateGroup>

--- a/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
@@ -466,6 +466,49 @@
 								<VisualState x:Name="ButtonCollapsed" />
 							</VisualStateGroup>
 
+							<!-- HeaderStates in place to manage animations when the TextBox is manipulated via code -->
+							<VisualStateGroup x:Name="HeaderStates">
+								<VisualState x:Name="NotEmpty">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
+														 Storyboard.TargetProperty="TranslateY"
+														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="-11" />
+										<DoubleAnimation Storyboard.TargetName="ContentElement_CompositeTransform"
+														 Storyboard.TargetProperty="TranslateY"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
+														 Storyboard.TargetProperty="ScaleX"
+														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="0.7" />
+										<DoubleAnimation Storyboard.TargetName="PlaceholderElement_CompositeTransform"
+														 Storyboard.TargetProperty="TranslateY"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
+														 Storyboard.TargetProperty="ScaleY"
+														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="0.7" />
+									</Storyboard>
+									<VisualState.StateTriggers>
+										<StateTrigger IsActive="{Binding Text, Converter={StaticResource EmptyToFalseConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+										<StateTrigger IsActive="{Binding PlaceholderText, Converter={StaticResource EmptyToFalseConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+									</VisualState.StateTriggers>
+								</VisualState>
+								<VisualState x:Name="Empty">
+									<VisualState.StateTriggers>
+										<StateTrigger IsActive="{Binding Text, Converter={StaticResource EmptyToTrueConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+										<StateTrigger IsActive="{Binding PlaceholderText, Converter={StaticResource EmptyToTrueConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+									</VisualState.StateTriggers>
+								</VisualState>
+							</VisualStateGroup>
+
 						</VisualStateManager.VisualStateGroups>
 
 						<Grid Padding="{TemplateBinding Padding}">
@@ -720,6 +763,49 @@
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="ButtonCollapsed" />
+							</VisualStateGroup>
+
+							<!-- HeaderStates in place to manage animations when the TextBox is manipulated via code -->
+							<VisualStateGroup x:Name="HeaderStates">
+								<VisualState x:Name="NotEmpty">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
+														 Storyboard.TargetProperty="TranslateY"
+														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="-11" />
+										<DoubleAnimation Storyboard.TargetName="ContentElement_CompositeTransform"
+														 Storyboard.TargetProperty="TranslateY"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
+														 Storyboard.TargetProperty="ScaleX"
+														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="0.7" />
+										<DoubleAnimation Storyboard.TargetName="PlaceholderElement_CompositeTransform"
+														 Storyboard.TargetProperty="TranslateY"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FocusedPlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
+														 Storyboard.TargetProperty="ScaleY"
+														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="0.7" />
+									</Storyboard>
+									<VisualState.StateTriggers>
+										<StateTrigger IsActive="{Binding Text, Converter={StaticResource EmptyToFalseConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+										<StateTrigger IsActive="{Binding PlaceholderText, Converter={StaticResource EmptyToFalseConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+									</VisualState.StateTriggers>
+								</VisualState>
+								<VisualState x:Name="Empty">
+									<VisualState.StateTriggers>
+										<StateTrigger IsActive="{Binding Text, Converter={StaticResource EmptyToTrueConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+										<StateTrigger IsActive="{Binding PlaceholderText, Converter={StaticResource EmptyToTrueConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+									</VisualState.StateTriggers>
+								</VisualState>
 							</VisualStateGroup>
 
 						</VisualStateManager.VisualStateGroups>

--- a/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
@@ -358,6 +358,7 @@
 							<VisualStateGroup x:Name="CommonStates">
 								<VisualState x:Name="Normal">
 									<VisualState.Setters>
+										<!-- Header and Placeholder animations -->
 										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
@@ -398,6 +399,13 @@
 										<Setter Target="Root.Background" Value="{ThemeResource FilledTextBoxBackgroundDisabled}" />
 										<Setter Target="DeleteButton.Foreground" Value="{ThemeResource FilledTextBoxDeleteButtonForegroundDisabled}" />
 										<Setter Target="IconPresenter.Foreground" Value="{ThemeResource TextBoxLeadingIconForegroundDisabled}" />
+
+										<!-- Header and Placeholder animations -->
+										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -617,13 +625,12 @@
 							<VisualStateGroup x:Name="CommonStates">
 								<VisualState x:Name="Normal">
 									<VisualState.Setters>
-
+										<!-- Header and Placeholder animations -->
 										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
 										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
-
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="PointerOver">
@@ -634,6 +641,8 @@
 										<Setter Target="HeaderElement.Foreground" Value="{ThemeResource OutlinedTextBoxHeaderForegroundPointerOver}" />
 										<Setter Target="RootBorder.BorderThickness" Value="2" />
 										<Setter Target="RootBorder.Padding" Value="0" />
+
+										<!-- Header and Placeholder animations -->
 										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
 										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
@@ -652,6 +661,13 @@
 										<Setter Target="PlaceholderElement.Foreground" Value="{ThemeResource OutlinedTextBoxPlaceholderForegroundDisabled}" />
 										<Setter Target="HeaderElement.Foreground" Value="{ThemeResource OutlinedTextBoxHeaderForegroundDisabled}" />
 										<Setter Target="IconPresenter.Foreground" Value="{ThemeResource TextBoxLeadingIconForegroundDisabled}" />
+
+										<!-- Header and Placeholder animations -->
+										<Setter Target="HeaderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="ContentElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="PlaceholderElement_CompositeTransform.TranslateY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PlaceholderContentCompositeTransformTranslateY}, TargetNullValue=0, FallbackValue=0}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleX" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
+										<Setter Target="HeaderElement_CompositeTransform.ScaleY" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HeaderCompositeTransformScales}, TargetNullValue=1, FallbackValue=1}" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -668,7 +684,6 @@
 
 									<Storyboard>
 										<!-- Animate Header Upwards -->
-
 										<DoubleAnimation Storyboard.TargetName="HeaderElement_CompositeTransform"
 														 Storyboard.TargetProperty="TranslateY"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"

--- a/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
@@ -16,11 +16,11 @@
 
 		- Without Header/Placeholder: Simple TextBox
 
-		- With placeholder but no header: The placeholder will be displayed where the text is supposed to be until text is inputed
+		- With placeholder but no header: The placeholder will be displayed where the text is supposed to be until the text is inputted
 
-		- With header but no placeholder: The header will be displayed where the text is supposed to be and will move up when text is inputed
+		- With header but no placeholder: The header will be displayed where the text is supposed to be and will move up when text is inputted
 
-		- Whith header and placeholder: The header will be displayed at the top and the placeholder will be displayed where the text is supposed to be until text is inputed
+		- With header and placeholder: The header will be displayed at the top, and the placeholder will be displayed where the text is supposed to be until the text is inputted
 	-->
 
 	<!-- Converters -->

--- a/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
+++ b/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
@@ -10,43 +10,7 @@
 	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-		<Grid.RowDefinitions>
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="*" />
-		</Grid.RowDefinitions>
-
-		<StackPanel Spacing="10"
-					HorizontalAlignment="Center"
-					Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-					Orientation="Vertical">
-			<TextBox Style="{StaticResource MaterialFilledTextBoxStyle}"
-					 x:Name="txtMyTb"
-					 Width="270" />
-			<TextBox Style="{StaticResource MaterialOutlinedTextBoxStyle}"
-					 x:Name="txtMyTb1"
-					 Width="270" />
-			<StackPanel HorizontalAlignment="Center"
-						Orientation="Horizontal">
-				<Button Content="Add Header"
-						Click="AddHeader" />
-				<Button Content="Add Placeholder"
-						Click="AddPlaceholder" />
-				<Button Content="Add Text"
-						Click="AddText" />
-			</StackPanel>
-
-			<StackPanel VerticalAlignment="Center"
-						Orientation="Horizontal">
-				<Button Content="Remove Header"
-						Click="RemoveHeader" />
-				<Button Content="Remove Placeholder"
-						Click="RemovePlaceholder" />
-				<Button Content="Remove Text"
-						Click="RemoveText" />
-			</StackPanel>
-
-		</StackPanel>
-		<sample:SamplePageLayout Grid.Row="1">
+		<sample:SamplePageLayout>
 			<sample:SamplePageLayout.MaterialTemplate>
 				<DataTemplate>
 					<StackPanel>

--- a/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
+++ b/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
@@ -10,7 +10,43 @@
 	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-		<sample:SamplePageLayout>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<StackPanel Spacing="10"
+					HorizontalAlignment="Center"
+					Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+					Orientation="Vertical">
+			<TextBox Style="{StaticResource MaterialFilledTextBoxStyle}"
+					 x:Name="txtMyTb"
+					 Width="270" />
+			<TextBox Style="{StaticResource MaterialOutlinedTextBoxStyle}"
+					 x:Name="txtMyTb1"
+					 Width="270" />
+			<StackPanel HorizontalAlignment="Center"
+						Orientation="Horizontal">
+				<Button Content="Add Header"
+						Click="AddHeader" />
+				<Button Content="Add Placeholder"
+						Click="AddPlaceholder" />
+				<Button Content="Add Text"
+						Click="AddText" />
+			</StackPanel>
+
+			<StackPanel VerticalAlignment="Center"
+						Orientation="Horizontal">
+				<Button Content="Remove Header"
+						Click="RemoveHeader" />
+				<Button Content="Remove Placeholder"
+						Click="RemovePlaceholder" />
+				<Button Content="Remove Text"
+						Click="RemoveText" />
+			</StackPanel>
+
+		</StackPanel>
+		<sample:SamplePageLayout Grid.Row="1">
 			<sample:SamplePageLayout.MaterialTemplate>
 				<DataTemplate>
 					<StackPanel>

--- a/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
+++ b/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
@@ -116,6 +116,15 @@
 							<TextBox Style="{StaticResource MaterialFilledTextBoxStyle}" />
 						</smtx:XamlDisplay>
 
+						<!-- TextBox Filled Disabled -->
+						<TextBlock Text="MaterialFilledTextBoxStyle Disabled" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_28"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Style="{StaticResource MaterialFilledTextBoxStyle}"
+									 Text="Disabled"
+									 IsEnabled="False" />
+						</smtx:XamlDisplay>
+
 						<!-- TextBox Filled with placeholder -->
 						<TextBlock Text="MaterialFilledTextBoxStyle - Placeholder only (No header)" />
 						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_21"
@@ -124,12 +133,31 @@
 									 PlaceholderText="Placeholder" />
 						</smtx:XamlDisplay>
 
+						<!-- TextBox Filled with placeholder disabled -->
+						<TextBlock Text="MaterialFilledTextBoxStyle - Placeholder only (No header) Disabled" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_25"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Style="{StaticResource MaterialFilledTextBoxStyle}"
+									 PlaceholderText="Placeholder"
+									 IsEnabled="False" />
+						</smtx:XamlDisplay>
+
 						<!-- TextBox Filled with header -->
 						<TextBlock Text="MaterialFilledTextBoxStyle - Header only (No Placeholder)" />
 						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_22"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox Style="{StaticResource MaterialFilledTextBoxStyle}"
 									 Header="Header" />
+						</smtx:XamlDisplay>
+
+						<!-- TextBox Filled with header disabled -->
+						<TextBlock Text="MaterialFilledTextBoxStyle - Header only (No Placeholder) Disabled" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_26"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Style="{StaticResource MaterialFilledTextBoxStyle}"
+									 Header="Header"
+									 Text="Disabled"
+									 IsEnabled="False" />
 						</smtx:XamlDisplay>
 
 						<!-- TextBox Filled With PlaceholderText and header -->
@@ -141,11 +169,12 @@
 									 Style="{StaticResource MaterialFilledTextBoxStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- TextBox Filled Disabled with PlaceholderText -->
-						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_3"
+						<!-- TextBox Filled With PlaceholderText and header disabled -->
+						<TextBlock Text="MaterialFilledTextBoxStyle - Header + Placeholder Disabled" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_27"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox PlaceholderText="Placeholder"
-									 Text="Filled Disabled"
+									 Header="Header"
 									 Style="{StaticResource MaterialFilledTextBoxStyle}"
 									 IsEnabled="False" />
 						</smtx:XamlDisplay>
@@ -157,6 +186,15 @@
 							<TextBox Style="{StaticResource MaterialOutlinedTextBoxStyle}" />
 						</smtx:XamlDisplay>
 
+						<!-- TextBox Outlined Disabled -->
+						<TextBlock Text="MaterialOutlinedTextBoxStyle Disabled" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_30"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Style="{StaticResource MaterialOutlinedTextBoxStyle}"
+									 Text="Disabled"
+									 IsEnabled="False" />
+						</smtx:XamlDisplay>
+
 						<!-- TextBox Outlined with PlaceholderText -->
 						<TextBlock Text="MaterialOutlinedTextBoxStyle - Placeholder only (No header)" />
 						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_5"
@@ -165,12 +203,31 @@
 									 Style="{StaticResource MaterialOutlinedTextBoxStyle}" />
 						</smtx:XamlDisplay>
 
+						<!-- TextBox Outlined with PlaceholderText Disabled -->
+						<TextBlock Text="MaterialOutlinedTextBoxStyle - Placeholder only (No header) Disabled" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_31"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox PlaceholderText="Placeholder"
+									 Style="{StaticResource MaterialOutlinedTextBoxStyle}"
+									 IsEnabled="False" />
+						</smtx:XamlDisplay>
+
 						<!-- TextBox Outlined with header -->
 						<TextBlock Text="MaterialOutlinedTextBoxStyle - Header only (No Placeholder)" />
 						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_23"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox Style="{StaticResource MaterialOutlinedTextBoxStyle}"
 									 Header="Header" />
+						</smtx:XamlDisplay>
+
+						<!-- TextBox Outlined with header Disabled -->
+						<TextBlock Text="MaterialOutlinedTextBoxStyle - Header only (No Placeholder) Disabled" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_32"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Style="{StaticResource MaterialOutlinedTextBoxStyle}"
+									 Header="Header"
+									 Text="Disabled"
+									 IsEnabled="False" />
 						</smtx:XamlDisplay>
 
 						<!-- TextBox Outlined With PlaceholderText and header -->
@@ -182,13 +239,139 @@
 									 Style="{StaticResource MaterialOutlinedTextBoxStyle}" />
 						</smtx:XamlDisplay>
 
-						<!-- TextBox Outlined Disabled with PlaceholderText -->
-						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_6"
+						<!-- TextBox Outlined With PlaceholderText and header Disabled -->
+						<TextBlock Text="MaterialOutlinedTextBoxStyle - Header + Placeholder Disabled" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_33"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
 							<TextBox PlaceholderText="Placeholder"
-									 Text="Outlined Disabled"
+									 Header="Header"
 									 Style="{StaticResource MaterialOutlinedTextBoxStyle}"
 									 IsEnabled="False" />
+						</smtx:XamlDisplay>
+
+						<!-- TextBox Filled Icon -->
+						<TextBlock Text="MaterialFilledTextBoxStyle + Icon" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_11"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Style="{StaticResource MaterialFilledTextBoxStyle}">
+								<ut:ControlExtensions.Icon>
+									<SymbolIcon Symbol="Favorite" />
+								</ut:ControlExtensions.Icon>
+							</TextBox>
+						</smtx:XamlDisplay>
+
+						<!-- TextBox Filled Icon Placeholder -->
+						<TextBlock Text="MaterialFilledTextBoxStyle + Icon + PlaceholderText" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_34"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox PlaceholderText="Filled with Icon"
+									 Style="{StaticResource MaterialFilledTextBoxStyle}">
+								<ut:ControlExtensions.Icon>
+									<SymbolIcon Symbol="Favorite" />
+								</ut:ControlExtensions.Icon>
+							</TextBox>
+						</smtx:XamlDisplay>
+
+						<!-- TextBox Filled Icon Header -->
+						<TextBlock Text="MaterialFilledTextBoxStyle + Icon + Header" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_35"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Header="Filled with Icon"
+									 Style="{StaticResource MaterialFilledTextBoxStyle}">
+								<ut:ControlExtensions.Icon>
+									<SymbolIcon Symbol="Favorite" />
+								</ut:ControlExtensions.Icon>
+							</TextBox>
+						</smtx:XamlDisplay>
+
+						<!-- TextBox Filled Icon Header Placeholder -->
+						<TextBlock Text="MaterialFilledTextBoxStyle + Icon + Header + PlaceholderText" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_36"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Header="Header"
+									 PlaceholderText="Placeholder"
+									 Style="{StaticResource MaterialFilledTextBoxStyle}">
+								<ut:ControlExtensions.Icon>
+									<SymbolIcon Symbol="Favorite" />
+								</ut:ControlExtensions.Icon>
+							</TextBox>
+						</smtx:XamlDisplay>
+
+						<!-- TextBox Filled Icon Header Placeholder Disabled -->
+						<TextBlock Text="MaterialFilledTextBoxStyle + Icon + Header + PlaceholderText + Disabled" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_37"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Header="Header"
+									 PlaceholderText="Placeholder"
+									 Style="{StaticResource MaterialFilledTextBoxStyle}"
+									 IsEnabled="False">
+								<ut:ControlExtensions.Icon>
+									<SymbolIcon Symbol="Favorite" />
+								</ut:ControlExtensions.Icon>
+							</TextBox>
+						</smtx:XamlDisplay>
+
+						<!-- TextBox Outlined Icon -->
+						<TextBlock Text="MaterialOutlinedTextBoxStyle + Icon" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_38"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Style="{StaticResource MaterialOutlinedTextBoxStyle}">
+								<ut:ControlExtensions.Icon>
+									<SymbolIcon Symbol="Favorite" />
+								</ut:ControlExtensions.Icon>
+							</TextBox>
+						</smtx:XamlDisplay>
+
+						<!-- TextBox Outlined Icon with PlaceholderText -->
+						<TextBlock Text="MaterialOutlinedTextBoxStyle + Icon + PlaceholderText" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_12"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox PlaceholderText="Outlined with Icon"
+									 Style="{StaticResource MaterialOutlinedTextBoxStyle}">
+								<ut:ControlExtensions.Icon>
+									<SymbolIcon Symbol="Favorite" />
+								</ut:ControlExtensions.Icon>
+							</TextBox>
+						</smtx:XamlDisplay>
+
+						<!-- TextBox Outlined Icon with Header -->
+						<TextBlock Text="MaterialOutlinedTextBoxStyle + Icon + Header" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_41"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Style="{StaticResource MaterialOutlinedTextBoxStyle}"
+									 Header="Outlined with Icon">
+								<ut:ControlExtensions.Icon>
+									<SymbolIcon Symbol="Favorite" />
+								</ut:ControlExtensions.Icon>
+							</TextBox>
+						</smtx:XamlDisplay>
+
+						<!-- TextBox Outlined Icon with Header and Placeholder -->
+						<TextBlock Text="MaterialOutlinedTextBoxStyle + Icon + Header + Placeholder" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_39"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Style="{StaticResource MaterialOutlinedTextBoxStyle}"
+									 Header="Header"
+									 PlaceholderText="Placeholder">
+								<ut:ControlExtensions.Icon>
+									<SymbolIcon Symbol="Favorite" />
+								</ut:ControlExtensions.Icon>
+							</TextBox>
+						</smtx:XamlDisplay>
+
+
+						<!-- TextBox Outlined Icon with Header and Placeholder disabled -->
+						<TextBlock Text="MaterialOutlinedTextBoxStyle + Icon + Header + Placeholder + Disabled" />
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_40"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Style="{StaticResource MaterialOutlinedTextBoxStyle}"
+									 Header="Header"
+									 PlaceholderText="Placeholder"
+									 IsEnabled="False">
+								<ut:ControlExtensions.Icon>
+									<SymbolIcon Symbol="Favorite" />
+								</ut:ControlExtensions.Icon>
+							</TextBox>
 						</smtx:XamlDisplay>
 
 						<!-- TextBox Filled MultiLine -->
@@ -201,6 +384,17 @@
 									 AcceptsReturn="True" />
 						</smtx:XamlDisplay>
 
+						<!-- TextBox Filled MultiLine Disabled -->
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_42"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Text="Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper commodo primis ornare himenaeos, inceptos tellus accumsan praesent laoreet. Pharetra semper ullamcorper neque mollis vestibulum luctus gravida facilisi rhoncus, rutrum massa bibendum vitae imperdiet quisque fames dignissim, varius curae erat risus platea orci quis scelerisque. Auctor erat vestibulum enim sodales sapien nam litora rhoncus condimentum praesent, platea dui odio eros integer id gravida turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo habitant."
+									 Header="Disabled"
+									 Style="{StaticResource MaterialFilledTextBoxStyle}"
+									 TextWrapping="Wrap"
+									 AcceptsReturn="True"
+									 IsEnabled="False" />
+						</smtx:XamlDisplay>
+
 						<!-- TextBox Outlined MultiLine -->
 						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_8"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
@@ -209,6 +403,17 @@
 									 Style="{StaticResource MaterialOutlinedTextBoxStyle}"
 									 TextWrapping="Wrap"
 									 AcceptsReturn="True" />
+						</smtx:XamlDisplay>
+
+						<!-- TextBox Outlined MultiLine Disabled -->
+						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_43"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TextBox Text="Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper commodo primis ornare himenaeos, inceptos tellus accumsan praesent laoreet. Pharetra semper ullamcorper neque mollis vestibulum luctus gravida facilisi rhoncus, rutrum massa bibendum vitae imperdiet quisque fames dignissim, varius curae erat risus platea orci quis scelerisque. Auctor erat vestibulum enim sodales sapien nam litora rhoncus condimentum praesent, platea dui odio eros integer id gravida turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo habitant."
+									 Header="Disabled"
+									 Style="{StaticResource MaterialOutlinedTextBoxStyle}"
+									 TextWrapping="Wrap"
+									 AcceptsReturn="True"
+									 IsEnabled="False" />
 						</smtx:XamlDisplay>
 
 						<!-- TextBox Filled MultiLine with Icon -->
@@ -233,28 +438,6 @@
 									 Style="{StaticResource MaterialOutlinedTextBoxStyle}"
 									 TextWrapping="Wrap"
 									 AcceptsReturn="True">
-								<ut:ControlExtensions.Icon>
-									<SymbolIcon Symbol="Favorite" />
-								</ut:ControlExtensions.Icon>
-							</TextBox>
-						</smtx:XamlDisplay>
-
-						<!-- TextBox Filled Icon with PlaceholderText -->
-						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_11"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<TextBox PlaceholderText="Filled with Icon"
-									 Style="{StaticResource MaterialFilledTextBoxStyle}">
-								<ut:ControlExtensions.Icon>
-									<SymbolIcon Symbol="Favorite" />
-								</ut:ControlExtensions.Icon>
-							</TextBox>
-						</smtx:XamlDisplay>
-
-						<!-- TextBox Outlined Icon with PlaceholderText -->
-						<smtx:XamlDisplay UniqueKey="M3Material_TextBoxSamplePage_12"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<TextBox PlaceholderText="Outlined with Icon"
-									 Style="{StaticResource MaterialOutlinedTextBoxStyle}">
 								<ut:ControlExtensions.Icon>
 									<SymbolIcon Symbol="Favorite" />
 								</ut:ControlExtensions.Icon>

--- a/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml.cs
+++ b/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml.cs
@@ -7,40 +7,4 @@ public sealed partial class TextBoxSamplePage : Page
 	{
 		this.InitializeComponent();
 	}
-
-	private void AddHeader(object sender, RoutedEventArgs e)
-	{
-		txtMyTb.Header = "Header";
-		txtMyTb1.Header = "Header";
-	}
-
-	private void RemoveHeader(object sender, RoutedEventArgs e)
-	{
-		txtMyTb.Header = null;
-		txtMyTb1.Header = null;
-	}
-
-	private void AddPlaceholder(object sender, RoutedEventArgs e)
-	{
-		txtMyTb.PlaceholderText = "Placeholder";
-		txtMyTb1.PlaceholderText = "Placeholder";
-	}
-
-	private void RemovePlaceholder(object sender, RoutedEventArgs e)
-	{
-		txtMyTb.PlaceholderText = null;
-		txtMyTb1.PlaceholderText = null;
-	}
-
-	private void AddText(object sender, RoutedEventArgs e)
-	{
-		txtMyTb.Text = "Text";
-		txtMyTb1.Text = "Text";
-	}
-
-	private void RemoveText(object sender, RoutedEventArgs e)
-	{
-		txtMyTb.Text = null;
-		txtMyTb1.Text = null;
-	}
 }

--- a/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml.cs
+++ b/src/samples/UWP/Uno.Themes.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml.cs
@@ -1,4 +1,4 @@
-﻿namespace Uno.Themes.Samples.Content.Controls;
+namespace Uno.Themes.Samples.Content.Controls;
 
 [SamplePage(SampleCategory.Controls, "TextBox", Description = "This control allows users to input a textual value.", DocumentationLink = "https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.textbox")]
 public sealed partial class TextBoxSamplePage : Page
@@ -6,5 +6,41 @@ public sealed partial class TextBoxSamplePage : Page
 	public TextBoxSamplePage()
 	{
 		this.InitializeComponent();
+	}
+
+	private void AddHeader(object sender, RoutedEventArgs e)
+	{
+		txtMyTb.Header = "Header";
+		txtMyTb1.Header = "Header";
+	}
+
+	private void RemoveHeader(object sender, RoutedEventArgs e)
+	{
+		txtMyTb.Header = null;
+		txtMyTb1.Header = null;
+	}
+
+	private void AddPlaceholder(object sender, RoutedEventArgs e)
+	{
+		txtMyTb.PlaceholderText = "Placeholder";
+		txtMyTb1.PlaceholderText = "Placeholder";
+	}
+
+	private void RemovePlaceholder(object sender, RoutedEventArgs e)
+	{
+		txtMyTb.PlaceholderText = null;
+		txtMyTb1.PlaceholderText = null;
+	}
+
+	private void AddText(object sender, RoutedEventArgs e)
+	{
+		txtMyTb.Text = "Text";
+		txtMyTb1.Text = "Text";
+	}
+
+	private void RemoveText(object sender, RoutedEventArgs e)
+	{
+		txtMyTb.Text = null;
+		txtMyTb1.Text = null;
 	}
 }


### PR DESCRIPTION
﻿GitHub Issue: unoplatform/Uno.Themes#1451

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Other... Please describe:
 -->

## Description
When `TextBox` was disabled PlaceholderText and Header were not properly placed.
<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [X] UWP
	- [ ] iOS
	- [X] Android
	- [X] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [X] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
