### PR TITLE
fix: Texts not align with the Icon

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
@@ -565,7 +565,7 @@
 							<!-- Border in place to properly vertically center the placeholder inside when it's a one-line TextBox -->
 							<!-- but keep it in the same place and at the top when it's a multiline TextBox -->
 							<Border Grid.Column="1"
-									VerticalAlignment="Top">
+									VerticalAlignment="Center">
 								<Border Height="38">
 									<TextBlock x:Name="HeaderElement"
 											   Foreground="{ThemeResource FilledTextBoxHeaderForeground}"
@@ -870,7 +870,7 @@
 							<!-- Border in place to properly vertically center the placeholder inside when it's a one-line TextBox -->
 							<!-- but keep it in the same place and at the top when it's a multiline TextBox -->
 							<Border Grid.Column="1"
-									VerticalAlignment="Top">
+									VerticalAlignment="Center">
 								<Border Height="38">
 									<TextBlock x:Name="HeaderElement"
 											   Foreground="{ThemeResource OutlinedTextBoxHeaderForeground}"


### PR DESCRIPTION
﻿GitHub Issue: closes #1443 

## PR Type
What kind of change does this PR introduce?
- Bugfix

## Description
Fixed TextBox Text not aligning with the Icon
![image](https://github.com/user-attachments/assets/1fa4ef1a-8eb3-419a-8146-a66b3f252c04)

## PR Checklist 
- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)