### PR TITLE
fix: adjust FlyoutMenuSeparator style

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/Flyout.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/Flyout.xaml
@@ -608,21 +608,15 @@
 
 	<!--  Material MenuFlyoutSeparator Style  -->
 	<Style x:Key="MaterialMenuFlyoutSeparatorStyle"
-	       TargetType="MenuFlyoutSeparator">
-
-		<Setter Property="Background"
-		        Value="{ThemeResource SurfaceVariantBrush}" />
-		<Setter Property="Padding"
-		        Value="0,8" />
-		<Setter Property="Height"
-		        Value="{StaticResource MaterialFlyoutMenuSeparatorHeight}" />
-
+		   TargetType="MenuFlyoutSeparator">
+		<Setter Property="Background" Value="{ThemeResource SurfaceVariantBrush}" />
+		<Setter Property="Padding" Value="0,8" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="MenuFlyoutSeparator">
-					<Rectangle Height="{TemplateBinding Height}"
-					           Margin="{TemplateBinding Padding}"
-					           Fill="{TemplateBinding Background}" />
+					<Rectangle Fill="{TemplateBinding Background}"
+							   Margin="{TemplateBinding Padding}"
+							   Height="{StaticResource MaterialFlyoutMenuSeparatorHeight}" />
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>


### PR DESCRIPTION
fixes #1506

Do not force the Height property on the MenuFlyoutSeparator style