### PR TITLE
Version bump after 5.5 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,22 +1,21 @@
 {
-	"$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-	"version": "5.5-dev.{height}",
-	"versionHeightOffset": 86,
-	"nuGetPackageVersion": {
-		"semVer": 2.0
-	},
-	"publicReleaseRefSpec": [
-		"^refs/heads/master$",
-		"^refs/heads/release/stable/\\d+(?:\\.\\d+)?$"
-	],
-	"cloudBuild": {
-		"setAllVariables": true,
-		"buildNumber": {
-			"enabled": true
-		}
-	},
-	"release": {
-		"branchName": "release/stable/{version}",
-		"firstUnstableTag": "dev"
-	}
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "5.6-dev.{height}",
+  "nuGetPackageVersion": {
+    "semVer": 2.0
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$",
+    "^refs/heads/release/stable/\\d+(?:\\.\\d+)?$"
+  ],
+  "cloudBuild": {
+    "setAllVariables": true,
+    "buildNumber": {
+      "enabled": true
+    }
+  },
+  "release": {
+    "branchName": "release/stable/{version}",
+    "firstUnstableTag": "dev"
+  }
 }


### PR DESCRIPTION

This is an automated version bump of the  **master** branch after the creation of the release branch release/stable/5.5, based on #1531