### PR TITLE
fix(MediaTransportControls) MPE controls sizing

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/MediaPlayerElement.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/MediaPlayerElement.xaml
@@ -467,7 +467,6 @@
 										<CommandBar.Resources>
 											<Thickness x:Key="AppBarButtonInnerBorderMargin">5</Thickness>
 											<Thickness x:Key="AppBarButtonContentViewboxCollapsedMargin">0,12</Thickness>
-											<x:Double x:Key="AppBarThemeCompactHeight">40</x:Double>
 											<x:Double x:Key="AppBarMoreButtonColumnMinWidth">0</x:Double>
 										</CommandBar.Resources>
 										<CommandBar.PrimaryCommands>


### PR DESCRIPTION
﻿GitHub Issue: https://github.com/unoplatform/uno-private/issues/1163

## PR Type

What kind of change does this PR introduce?
- Bugfix


## Description

<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [x] iOS
	- [x] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
