### PR TITLE
Version bump after 5.6 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "5.6-dev.{height}",
+  "version": "5.7-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION

This is an automated version bump of the  **master** branch after the creation of the release branch release/stable/5.6, based on #1541