### PR TITLE
fix: NavigationView - SplitView CornerRadius

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/v2/NavigationView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/NavigationView.xaml
@@ -1519,6 +1519,13 @@
 		   TargetType="local:NavigationView">
 		<Setter Property="Background" Value="{ThemeResource NavigationViewBackground}" />
 
+		<Setter Property="CornerRadius" Value="0">
+			<!--
+				note: this property is unused, we instead use
+				MaterialNavigationViewSplitViewCornerRadius & NavigationViewContentGridBorderThickness
+				to manipulate corner-radius of the pane and content grids.
+			-->
+		</Setter>
 		<Setter Property="OpenPaneLength" Value="360" />
 		<Setter Property="CompactPaneLength" Value="{ThemeResource NavigationViewCompactPaneLength}" />
 
@@ -1903,19 +1910,21 @@
 							<!-- Displaymode (compact/minimal/normal) left -->
 							<SplitView x:Name="RootSplitView"
 									   Grid.Row="1"
-									   CornerRadius="{ThemeResource MaterialNavigationViewSplitViewCornerRadius}"
 									   BorderBrush="{ThemeResource NavigationViewItemSeparatorForeground}"
-									   PaneBackground="{ThemeResource NavigationViewPaneBackground}"
+									   Background="Transparent"
+									   PaneBackground="Transparent"
 									   CompactPaneLength="{TemplateBinding CompactPaneLength}"
+									   CornerRadius="0"
 									   OpenPaneLength="{TemplateBinding OpenPaneLength}"
 									   IsPaneOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPaneOpen, Mode=TwoWay}"
 									   DisplayMode="Inline"
 									   IsTabStop="False"
 									   win:Style="{StaticResource ResetDefaultSplitViewStyle}">
-
 								<SplitView.Pane>
 									<Grid x:Name="PaneContentGrid"
+										  Background="{ThemeResource NavigationViewPaneBackground}"
 										  BorderBrush="{ThemeResource NavigationViewItemSeparatorForeground}"
+										  CornerRadius="{ThemeResource MaterialNavigationViewSplitViewCornerRadius}"
 										  Padding="{ThemeResource MaterialNavigationViewSplitViewPadding}"
 										  HorizontalAlignment="Left"
 										  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}">
@@ -2079,6 +2088,7 @@
 									<Grid x:Name="ContentGrid"
 										  BorderBrush="{ThemeResource NavigationViewBackground}"
 										  BorderThickness="{ThemeResource NavigationViewContentGridBorderThickness}"
+										  Background="{TemplateBinding Background}"
 										  Margin="{ThemeResource NavigationViewContentMargin}"
 										  CornerRadius="{ThemeResource MaterialNavigationViewContentGridCornerRadius}">
 										<Grid.RowDefinitions>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1552

Skia desktop with `MaterialNavigationViewSplitViewCornerRadius` overridden
<img width="438" height="410" alt="image" src="https://github.com/user-attachments/assets/83070e14-512a-46db-bf54-2d4ab821b0ee" />

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Other... Please describe:


## Description

<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
