### PR TITLE
docs: update cspell file change detection

### DIFF
--- a/build/stage-determine-changes.yml
+++ b/build/stage-determine-changes.yml
@@ -38,7 +38,7 @@ jobs:
           $isDoc = $file.StartsWith("doc/") -or               # Files in the 'doc/' directory
             ($file -match "^[^/]+\.md$") -or                  # Markdown files at the root level (with no subdirectories involved)
             ($file -match "^\.github/.*\.md$") -or            # Markdown files within the .github folder (including its subdirectories)
-            ($file -match "^\.(markdownlint|cspell)\.json$")  # Specific JSON files: .markdownlint.json and cspell.json
+            ($file -match '(^|[\\/])(markdownlint|cspell)\.json$')  # Specific JSON files: .markdownlint.json and cspell.json
           
           if ($isDoc) {
               $docFiles++


### PR DESCRIPTION
This pull request includes a minor update to the logic that determines documentation files in the build pipeline. The change improves how specific JSON files are matched, ensuring that `.markdownlint.json` and `cspell.json` are correctly identified regardless of their location in the directory structure.

* Improved the file matching pattern for `.markdownlint.json` and `cspell.json` in the documentation file detection logic within `build/stage-determine-changes.yml`, allowing for more flexible file placement.