### PR TITLE
chore: bump to 6.0 for breaking change

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "5.8-dev.{height}",
+  "version": "6.0-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
This pull request updates the project version in preparation for the next major release.

Version bump:

* Updated the version in `version.json` from `5.8-dev.{height}` to `6.0-dev.{height}` to reflect the start of development for version 6.0.

Breaking change coming from: https://github.com/unoplatform/Uno.Themes/pull/1578/