### PR TITLE
chore: material semantic cleanup

### DIFF
--- a/.specify/specs/simple-theme/spec.md
+++ b/.specify/specs/simple-theme/spec.md
@@ -291,7 +291,7 @@ These register default styles for controls when no explicit `Style` is set:
 Short names without the `Simple` prefix for consumer convenience:
 
 `PrimaryButtonStyle`, `NeutralButtonStyle`, `SubtleButtonStyle`,
-`InputTextBoxStyle`, `SelectFieldStyle`,
+`TextBoxStyle`, `SelectFieldStyle`,
 `CheckBoxStyle`, `RadioButtonStyle`, `ToggleSwitchStyle`,
 `PersonPictureStyle`, `HyperlinkButtonStyle`, `NavigationViewStyle`,
 `ProgressBarStyle`, `ProgressRingStyle`, `PipsPagerStyle`,

--- a/doc/semantic-styles.md
+++ b/doc/semantic-styles.md
@@ -222,6 +222,71 @@ The following matrix shows which semantic style keys are supported by each theme
 |--------------------------------|:--------:|:------:|-------|
 | `MediaTransportControlsStyle`  | ✅ | ❌ | Simple has no media transport style |
 
+## SDS (Simple Design System) Style Keys
+
+In addition to the Material-derived semantic keys above, both themes also support **SDS-naming aliases** — a second set of theme-agnostic keys that use the Simple Design System vocabulary. These resolve to the best-fit style in whichever theme is active.
+
+### Button
+
+| SDS Style Key | Material | Simple | Notes |
+|---|:---:|:---:|---|
+| `PrimaryButtonStyle` | ⚠️ | ✅ | Material: aliases to `MaterialFilledButtonStyle` |
+| `NeutralButtonStyle` | ⚠️ | ✅ | Material: aliases to `MaterialFilledTonalButtonStyle` |
+| `SubtleButtonStyle` | ⚠️ | ✅ | Material: aliases to `MaterialTextButtonStyle` |
+| `DangerPrimaryButtonStyle` | ❌ | ✅ | Material has no danger variant |
+| `DangerSubtleButtonStyle` | ❌ | ✅ | Material has no danger variant |
+
+> [!NOTE]
+> Simple also provides `Small` and `Medium` size variants for each button style (e.g., `SmallPrimaryButtonStyle`, `MediumNeutralButtonStyle`). Material has no size variant system, so these are Simple-only.
+
+### IconButton
+
+| SDS Style Key | Material | Simple | Notes |
+|---|:---:|:---:|---|
+| `IconButtonPrimaryStyle` | ⚠️ | ✅ | Material: aliases to `MaterialIconButtonStyle` |
+| `IconButtonNeutralStyle` | ❌ | ✅ | Material has a single icon button style |
+| `IconButtonSubtleStyle` | ❌ | ✅ | Material has a single icon button style |
+| `IconButtonDangerPrimaryStyle` | ❌ | ✅ | Material has no danger variant |
+| `IconButtonDangerSubtleStyle` | ❌ | ✅ | Material has no danger variant |
+
+### TextBox
+
+| SDS Style Key | Material | Simple | Notes |
+|---|:---:|:---:|---|
+| `TextBoxStyle` | ⚠️ | ✅ | Material: aliases to `MaterialFilledTextBoxStyle` |
+| `TextBoxErrorStyle` | ❌ | ✅ | Material has no dedicated error TextBox style |
+| `TextBoxSmallStyle` | ❌ | ✅ | Material has no small TextBox variant |
+
+### PasswordBox
+
+| SDS Style Key | Material | Simple | Notes |
+|---|:---:|:---:|---|
+| `PasswordBoxStyle` | ⚠️ | ✅ | Material: aliases to `MaterialFilledPasswordBoxStyle` |
+
+### ComboBox (Select Field)
+
+| SDS Style Key | Material | Simple | Notes |
+|---|:---:|:---:|---|
+| `SelectFieldStyle` | ⚠️ | ✅ | Material: aliases to `MaterialComboBoxStyle` |
+| `SelectFieldItemStyle` | ❌ | ✅ | Material has no dedicated ComboBox item style |
+| `SelectFieldErrorStyle` | ❌ | ✅ | Material has no dedicated error ComboBox style |
+
+### ToggleButton
+
+| SDS Style Key | Material | Simple | Notes |
+|---|:---:|:---:|---|
+| `ToggleButtonStyle` | ⚠️ | ✅ | Material: aliases to `MaterialTextToggleButtonStyle` |
+| `SmallToggleButtonStyle` | ❌ | ✅ | Material has no size variants |
+| `MediumToggleButtonStyle` | ❌ | ✅ | Material has no size variants |
+
+### Controls with no Material equivalent
+
+| SDS Style Key | Material | Simple | Notes |
+|---|:---:|:---:|---|
+| `ToolTipStyle` | ❌ | ✅ | Material v2 has no ToolTip style |
+| `ExpanderStyle` | ❌ | ✅ | Material v2 has no Expander style |
+| `AutoSuggestBoxStyle` | ❌ | ✅ | Material v2 has no AutoSuggestBox style |
+
 ## Using Theme-Specific Style Keys Directly
 
 While Semantic Style Keys are the recommended approach, you can reference theme-prefixed style keys directly if needed. For example, if you want to use a Simple-specific style that has no semantic equivalent:

--- a/doc/simple-controls-styles.md
+++ b/doc/simple-controls-styles.md
@@ -167,9 +167,9 @@ The Simple theme also provides well-known style key aliases for compatibility wi
 | `MediumIconButtonSubtleStyle`          | `SimpleMediumIconButtonSubtleStyle`        |
 | `MediumIconButtonDangerPrimaryStyle`   | `SimpleMediumIconButtonDangerPrimaryStyle` |
 | `MediumIconButtonDangerSubtleStyle`    | `SimpleMediumIconButtonDangerSubtleStyle`  |
-| `InputTextBoxStyle`                    | `SimpleTextBoxStyle`                  |
-| `InputTextBoxErrorStyle`               | `SimpleTextBoxErrorStyle`             |
-| `InputTextBoxSmallStyle`               | `SimpleTextBoxSmallStyle`             |
+| `TextBoxStyle`                         | `SimpleTextBoxStyle`                  |
+| `TextBoxErrorStyle`                    | `SimpleTextBoxErrorStyle`             |
+| `TextBoxSmallStyle`                    | `SimpleTextBoxSmallStyle`             |
 | `FilledTextBoxStyle`                   | `SimpleTextBoxStyle`                  |
 | `OutlinedTextBoxStyle`                 | `SimpleOutlinedTextBoxStyle`          |
 | `PasswordBoxStyle`                     | `SimplePasswordBoxStyle`                   |

--- a/src/library/Uno.Material/Styles/Controls/v2/_Resources.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/_Resources.xaml
@@ -124,4 +124,43 @@
 	<StaticResource x:Key="TitleMedium"							ResourceKey="MaterialTitleMedium"					/>
 	<StaticResource x:Key="TitleSmall"							ResourceKey="MaterialTitleSmall"					/>
 
+	<!-- Theme-agnostic aliases (matches Figma SDS naming) -->
+	<!-- See: .specify/specs/semantic-abstraction-layer/spec.md -->
+
+	<!-- Button: Primary / Neutral / Subtle -->
+	<StaticResource x:Key="PrimaryButtonStyle"					ResourceKey="MaterialFilledButtonStyle"				/>
+	<StaticResource x:Key="NeutralButtonStyle"					ResourceKey="MaterialFilledTonalButtonStyle"		/>
+	<StaticResource x:Key="SubtleButtonStyle"					ResourceKey="MaterialTextButtonStyle"				/>
+	<!-- DangerPrimaryButtonStyle — GAP: Material has no danger button variant -->
+	<!-- DangerSubtleButtonStyle — GAP: Material has no danger button variant -->
+	<!-- Small/Medium size variants — GAP: Material has no size variants -->
+
+	<!-- TextBox -->
+	<StaticResource x:Key="TextBoxStyle"						ResourceKey="MaterialFilledTextBoxStyle"			/>
+	<!-- TextBoxErrorStyle — GAP: Material has no dedicated error TextBox style -->
+	<!-- TextBoxSmallStyle — GAP: Material has no small TextBox variant -->
+
+	<!-- PasswordBox -->
+	<StaticResource x:Key="PasswordBoxStyle"					ResourceKey="MaterialFilledPasswordBoxStyle"		/>
+
+	<!-- IconButton -->
+	<StaticResource x:Key="IconButtonPrimaryStyle"				ResourceKey="MaterialIconButtonStyle"				/>
+	<!-- IconButtonNeutralStyle — GAP: Material has a single icon button style -->
+	<!-- IconButtonSubtleStyle — GAP: Material has a single icon button style -->
+	<!-- Danger/Small/Medium icon button variants — GAP -->
+
+	<!-- ComboBox: Select Field -->
+	<StaticResource x:Key="SelectFieldStyle"					ResourceKey="MaterialComboBoxStyle"					/>
+	<!-- SelectFieldItemStyle — GAP: Material has no dedicated ComboBox item style -->
+	<!-- SelectFieldErrorStyle — GAP: Material has no dedicated error ComboBox style -->
+
+	<!-- ToggleButton -->
+	<StaticResource x:Key="ToggleButtonStyle"					ResourceKey="MaterialTextToggleButtonStyle"			/>
+	<!-- SmallToggleButtonStyle — GAP: Material has no size variants -->
+	<!-- MediumToggleButtonStyle — GAP: Material has no size variants -->
+
+	<!-- ToolTipStyle — GAP: Material v2 has no ToolTip style -->
+	<!-- ExpanderStyle — GAP: Material v2 has no Expander style -->
+	<!-- AutoSuggestBoxStyle — GAP: Material v2 has no AutoSuggestBox style -->
+
 </ResourceDictionary>

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/_Resources.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/_Resources.xaml
@@ -118,11 +118,10 @@
 	<StaticResource x:Key="MediumDangerPrimaryButtonStyle" ResourceKey="SimpleMediumDangerPrimaryButtonStyle" />
 	<StaticResource x:Key="MediumDangerSubtleButtonStyle" ResourceKey="SimpleMediumDangerSubtleButtonStyle" />
 
-	<!-- TextBox: Input / Error / Small -->
-	<!-- SDS has a single Input design — no Filled/Outlined variants -->
-	<StaticResource x:Key="InputTextBoxStyle" ResourceKey="SimpleTextBoxStyle" />
-	<StaticResource x:Key="InputTextBoxErrorStyle" ResourceKey="SimpleTextBoxErrorStyle" />
-	<StaticResource x:Key="InputTextBoxSmallStyle" ResourceKey="SimpleTextBoxSmallStyle" />
+	<!-- TextBox: Default / Error / Small -->
+	<StaticResource x:Key="TextBoxStyle" ResourceKey="SimpleTextBoxStyle" />
+	<StaticResource x:Key="TextBoxErrorStyle" ResourceKey="SimpleTextBoxErrorStyle" />
+	<StaticResource x:Key="TextBoxSmallStyle" ResourceKey="SimpleTextBoxSmallStyle" />
 
 	<!-- PasswordBox -->
 	<StaticResource x:Key="PasswordBoxStyle" ResourceKey="SimplePasswordBoxStyle" />

--- a/src/samples/SamplesApp.Shared/Content/Controls/TextBoxSamplePage.xaml
+++ b/src/samples/SamplesApp.Shared/Content/Controls/TextBoxSamplePage.xaml
@@ -493,15 +493,15 @@
 						<!-- Input TextBox -->
 						<smtx:XamlDisplay UniqueKey="Simple_TextBox_Input"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<TextBox Style="{StaticResource InputTextBoxStyle}" PlaceholderText="Placeholder" Width="300" />
+							<TextBox Style="{StaticResource TextBoxStyle}" PlaceholderText="Placeholder" Width="300" />
 						</smtx:XamlDisplay>
 						<smtx:XamlDisplay UniqueKey="Simple_TextBox_InputWithText"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<TextBox Style="{StaticResource InputTextBoxStyle}" Text="With text" Width="300" />
+							<TextBox Style="{StaticResource TextBoxStyle}" Text="With text" Width="300" />
 						</smtx:XamlDisplay>
 						<smtx:XamlDisplay UniqueKey="Simple_TextBox_InputDisabled"
 										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<TextBox Style="{StaticResource InputTextBoxStyle}" PlaceholderText="Disabled" IsEnabled="False" Width="300" />
+							<TextBox Style="{StaticResource TextBoxStyle}" PlaceholderText="Disabled" IsEnabled="False" Width="300" />
 						</smtx:XamlDisplay>
 
 						<!-- Input TextBox — Small -->

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_SemanticStyles.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_SemanticStyles.cs
@@ -31,11 +31,16 @@ public class Given_SemanticStyles
 
 	[TestMethod]
 	[RunsOnUIThread]
+	// Button variants
 	[DataRow("FilledButtonStyle", "SimplePrimaryButtonStyle")]
 	[DataRow("FilledTonalButtonStyle", "SimpleNeutralButtonStyle")]
 	[DataRow("OutlinedButtonStyle", "SimpleNeutralButtonStyle")]
 	[DataRow("TextButtonStyle", "SimpleSubtleButtonStyle")]
 	[DataRow("IconButtonStyle", "SimpleIconButtonPrimaryStyle")]
+	// SDS aliases → same Simple styles
+	[DataRow("PrimaryButtonStyle", "SimplePrimaryButtonStyle")]
+	[DataRow("NeutralButtonStyle", "SimpleNeutralButtonStyle")]
+	[DataRow("SubtleButtonStyle", "SimpleSubtleButtonStyle")]
 	public async Task When_SemanticAndSimpleStyles_AreApplied_LookIdentical(
 		string semanticStyleKey, string simpleStyleKey)
 	{
@@ -130,6 +135,48 @@ public class Given_SemanticStyles
 			$"Overriding {fgResourceKey} should change {semanticStyleKey} button Foreground");
 		Assert.AreEqual(expectedFg, simpleFg.Color,
 			$"Overriding {fgResourceKey} should also change {simpleStyleKey} button Foreground");
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Style resolution: non-button semantic keys resolve to a valid style.
+	// ─────────────────────────────────────────────────────────────────────
+
+	[TestMethod]
+	[RunsOnUIThread]
+	// Semantic (Material-derived) aliases
+	[DataRow("FilledTextBoxStyle", "SimpleTextBoxStyle")]
+	[DataRow("OutlinedTextBoxStyle", "SimpleOutlinedTextBoxStyle")]
+	[DataRow("FilledPasswordBoxStyle", "SimplePasswordBoxStyle")]
+	[DataRow("OutlinedPasswordBoxStyle", "SimpleOutlinedPasswordBoxStyle")]
+	[DataRow("CheckBoxStyle", "SimpleCheckBoxStyle")]
+	[DataRow("RadioButtonStyle", "SimpleRadioButtonStyle")]
+	[DataRow("ToggleSwitchStyle", "SimpleToggleSwitchStyle")]
+	[DataRow("SliderStyle", "SimpleSliderStyle")]
+	[DataRow("ComboBoxStyle", "SimpleSelectFieldStyle")]
+	[DataRow("TextToggleButtonStyle", "SimpleDefaultToggleButtonStyle")]
+	[DataRow("IconToggleButtonStyle", "SimpleIconToggleButtonStyle")]
+	[DataRow("HyperlinkButtonStyle", "SimpleHyperlinkButtonStyle")]
+	[DataRow("SecondaryHyperlinkButtonStyle", "SimpleSecondaryHyperlinkButtonStyle")]
+	// SDS aliases
+	[DataRow("TextBoxStyle", "SimpleTextBoxStyle")]
+	[DataRow("PasswordBoxStyle", "SimplePasswordBoxStyle")]
+	[DataRow("SelectFieldStyle", "SimpleSelectFieldStyle")]
+	[DataRow("ToggleButtonStyle", "SimpleDefaultToggleButtonStyle")]
+	[DataRow("IconButtonPrimaryStyle", "SimpleIconButtonPrimaryStyle")]
+	public async Task When_SemanticStyleKeyResolved_MatchesExpectedSimpleStyle(
+		string semanticStyleKey, string simpleStyleKey)
+	{
+		var container = CreateThemedContainer();
+
+		var semanticStyle = container.Resources[semanticStyleKey] as Style;
+		var simpleStyle = container.Resources[simpleStyleKey] as Style;
+
+		Assert.IsNotNull(semanticStyle, $"{semanticStyleKey} should resolve to a style");
+		Assert.IsNotNull(simpleStyle, $"{simpleStyleKey} should resolve to a style");
+
+		// Both keys should resolve to the same underlying style
+		Assert.AreEqual(simpleStyle, semanticStyle,
+			$"{semanticStyleKey} should resolve to {simpleStyleKey}");
 	}
 
 	// ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
GitHub Issue (If applicable): related to #1631 

## PR Type

What kind of change does this PR introduce?

- Feature
- Documentation content changes


## Description

Adds SDS (Simple Design System) theme-agnostic style aliases to the Material theme's `_Resources.xaml`, ensuring Material has the same semantic resource aliasing coverage as Simple. Also renames `InputTextBoxStyle` to `TextBoxStyle` across both themes for consistency, and expands documentation and test coverage for the semantic abstraction layer.

### Material `_Resources.xaml` — SDS aliases added
New theme-agnostic aliases that resolve to Material styles, matching what Simple already provides:
- `PrimaryButtonStyle` → `MaterialFilledButtonStyle`
- `NeutralButtonStyle` → `MaterialFilledTonalButtonStyle`
- `SubtleButtonStyle` → `MaterialTextButtonStyle`
- `TextBoxStyle` → `MaterialFilledTextBoxStyle`
- `PasswordBoxStyle` → `MaterialFilledPasswordBoxStyle`
- `IconButtonPrimaryStyle` → `MaterialIconButtonStyle`
- `SelectFieldStyle` → `MaterialComboBoxStyle`
- `ToggleButtonStyle` → `MaterialTextToggleButtonStyle`
- Gaps documented as XAML comments (Danger variants, size variants, ToolTip, Expander, AutoSuggestBox)

### `InputTextBoxStyle` → `TextBoxStyle` rename
- Updated in both Material and Simple `_Resources.xaml`
- Updated in `TextBoxSamplePage.xaml`, `simple-controls-styles.md`, and `simple-theme/spec.md`

### Documentation
- Added **SDS Style Keys** section to `doc/semantic-styles.md` with full support matrix across both themes

### Tests
- Added 3 SDS alias test rows to existing `When_SemanticAndSimpleStyles_AreApplied_LookIdentical`
- Added new `When_SemanticStyleKeyResolved_MatchesExpectedSimpleStyle` test with 18 data rows covering all non-button semantic and SDS style mappings (TextBox, PasswordBox, CheckBox, RadioButton, ToggleSwitch, Slider, ComboBox, ToggleButton, HyperlinkButton)


## PR Checklist
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
    - [ ] UWP
    - [ ] iOS
    - [ ] Android
    - [ ] WASM
    - [ ] MacOS
- [x] Updated the documentation as needed:
    - [x] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
    - [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
    - [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
    - [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [x] Contains **No** breaking changes


## Other information

All changes are additive. Existing theme-prefixed keys (`MaterialFilledButtonStyle`, `SimplePrimaryButtonStyle`, etc.) remain valid and unchanged. The SDS aliases are a new layer on top of the existing semantic aliases.

Files changed:
- `src/library/Uno.Material/Styles/Controls/v2/_Resources.xaml` — SDS aliases + `TextBoxStyle`
- `src/library/Uno.Simple.WinUI/Styles/Controls/_Resources.xaml` — `TextBoxStyle` rename
- `doc/semantic-styles.md` — SDS style key support matrix
- `doc/simple-controls-styles.md` — `TextBoxStyle` rename
- `.specify/specs/simple-theme/spec.md` — `TextBoxStyle` rename
- `src/samples/.../TextBoxSamplePage.xaml` — `TextBoxStyle` rename
- `src/samples/.../Given_SemanticStyles.cs` — expanded runtime tests
