### PR TITLE
fix: ensure color overrides rebuild theme after seed palette gen

### DIFF
--- a/src/library/Uno.Themes/BaseTheme.cs
+++ b/src/library/Uno.Themes/BaseTheme.cs
@@ -20,7 +20,7 @@ using Windows.UI.Xaml.Media;
 namespace Uno.Themes;
 public abstract partial class BaseTheme : ResourceDictionary
 {
-	private bool _isColorOverrideMuted;
+	private bool _isUpdatingColorOverrides;
 	private bool _isFontOverrideMuted;
 	private ResourceDictionary _baseColorOverride;
 	private List<(string themeKey, string brushKey, SolidColorBrush brush)> _originalBrushes;
@@ -74,17 +74,26 @@ public abstract partial class BaseTheme : ResourceDictionary
 
 	private static void OnColorOverrideSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 	{
-		if (d is BaseTheme theme && e.NewValue is string sourceUri)
+		if (d is BaseTheme theme)
 		{
 			try
 			{
-				theme._isColorOverrideMuted = true;
-				var tc = theme.EnsureColors();
-				tc.OverrideSource = sourceUri;
+				theme._isUpdatingColorOverrides = true;
+				if (e.NewValue is string sourceUri)
+				{
+					var tc = theme.EnsureColors();
+					tc.OverrideSource = sourceUri;
+				}
+				else if (theme.Colors is { } tc)
+				{
+					tc.OverrideDictionary = null;
+				}
+
+				theme.UpdateSource();
 			}
 			finally
 			{
-				theme._isColorOverrideMuted = false;
+				theme._isUpdatingColorOverrides = false;
 			}
 		}
 	}
@@ -137,11 +146,11 @@ public abstract partial class BaseTheme : ResourceDictionary
 
 	private static void OnColorOverrideChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 	{
-		if (d is BaseTheme { _isColorOverrideMuted: false } theme)
+		if (d is BaseTheme { _isUpdatingColorOverrides: false } theme)
 		{
 			try
 			{
-				theme._isColorOverrideMuted = true;
+				theme._isUpdatingColorOverrides = true;
 				if (e.NewValue is ResourceDictionary dict)
 				{
 					var tc = theme.EnsureColors();
@@ -153,15 +162,13 @@ public abstract partial class BaseTheme : ResourceDictionary
 					{
 						tc.OverrideDictionary = null;
 					}
-					else
-					{
-						theme.UpdateSource();
-					}
 				}
+
+				theme.UpdateSource();
 			}
 			finally
 			{
-				theme._isColorOverrideMuted = false;
+				theme._isUpdatingColorOverrides = false;
 			}
 		}
 	}
@@ -199,7 +206,7 @@ public abstract partial class BaseTheme : ResourceDictionary
 			{
 				tc.SetChangedCallback((isStructural) =>
 				{
-					if (theme._isColorOverrideMuted)
+					if (theme._isUpdatingColorOverrides)
 					{
 						return;
 					}
@@ -217,7 +224,7 @@ public abstract partial class BaseTheme : ResourceDictionary
 				});
 			}
 
-			if (!theme._isColorOverrideMuted)
+			if (!theme._isUpdatingColorOverrides)
 			{
 				theme.UpdateSource();
 			}

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_ColorOverridePrecedence.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_ColorOverridePrecedence.cs
@@ -1,0 +1,126 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Simple;
+using Uno.UI.RuntimeTests;
+using Windows.UI;
+
+namespace Uno.Themes.Samples.RuntimeTests;
+
+/// <summary>
+/// Verifies that explicit color overrides take precedence over seed-generated
+/// colors in BaseTheme.UpdateSource(). This guards against regressions where
+/// seed palette colors "bleed through" user-defined overrides.
+/// </summary>
+[TestClass]
+public class Given_ColorOverridePrecedence
+{
+	// A distinctive blue that is clearly not from any default palette.
+	private static readonly Color OverrideBlue = Color.FromArgb(0xFF, 0x21, 0x96, 0xF3);
+
+	// The seed purple used for generation — should NOT appear when overridden.
+	private static readonly Color SeedPurple = Color.FromArgb(0xFF, 0x59, 0x46, 0xD2);
+
+	/// <summary>
+	/// Creates a SimpleTheme with a seed color active and an override dictionary
+	/// that redefines PrimaryColor. The override should win.
+	/// </summary>
+	private static SimpleTheme CreateThemeWithSeedAndOverride(Color seedColor, Color overridePrimaryColor)
+	{
+		var overrideDict = new ResourceDictionary();
+		var lightDict = new ResourceDictionary();
+		lightDict["PrimaryColor"] = overridePrimaryColor;
+		var darkDict = new ResourceDictionary();
+		darkDict["PrimaryColor"] = overridePrimaryColor;
+
+		overrideDict.ThemeDictionaries["Light"] = lightDict;
+		overrideDict.ThemeDictionaries["Default"] = darkDict;
+
+		var theme = new SimpleTheme();
+		theme.Colors = new ThemeColors
+		{
+			PrimarySeed = seedColor,
+			OverrideDictionary = overrideDict,
+		};
+
+		return theme;
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Color override vs seed: OverrideDictionary should take precedence
+	// over seed-generated colors in the merged resource chain.
+	// ─────────────────────────────────────────────────────────────────────
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_SeedAndOverrideBothSet_Then_OverrideWins()
+	{
+		var theme = CreateThemeWithSeedAndOverride(SeedPurple, OverrideBlue);
+
+		var container = new Grid();
+		container.Resources.MergedDictionaries.Add(theme);
+
+		// Use a styled button to verify the resolved primary color flows through.
+		var style = container.Resources["FilledButtonStyle"] as Style;
+		Assert.IsNotNull(style, "FilledButtonStyle should resolve from theme");
+
+		var button = new Button { Content = "Test", Style = style };
+		container.Children.Add(button);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(button);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var bg = button.Background as SolidColorBrush;
+		Assert.IsNotNull(bg, "Button should have a SolidColorBrush Background");
+
+		// The override blue should win over the seed-generated purple.
+		Assert.AreEqual(OverrideBlue, bg.Color,
+			$"Expected override color #{OverrideBlue} but got #{bg.Color}. " +
+			"Seed-generated colors are bleeding through the override.");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_OverrideSetViaDeprecatedColorOverrideDictionary_Then_OverrideWins()
+	{
+		// This test exercises the deprecated ColorOverrideDictionary DP path
+		// which historically had a bug where UpdateSource() was not called
+		// after unmuting the color override callback.
+		var overrideDict = new ResourceDictionary();
+		var lightDict = new ResourceDictionary();
+		lightDict["PrimaryColor"] = OverrideBlue;
+		var darkDict = new ResourceDictionary();
+		darkDict["PrimaryColor"] = OverrideBlue;
+		overrideDict.ThemeDictionaries["Light"] = lightDict;
+		overrideDict.ThemeDictionaries["Default"] = darkDict;
+
+		var theme = new SimpleTheme();
+		theme.Colors = new ThemeColors { PrimarySeed = SeedPurple };
+#pragma warning disable CS0618 // Testing deprecated API path
+		theme.ColorOverrideDictionary = overrideDict;
+#pragma warning restore CS0618
+
+		var container = new Grid();
+		container.Resources.MergedDictionaries.Add(theme);
+
+		var style = container.Resources["FilledButtonStyle"] as Style;
+		Assert.IsNotNull(style, "FilledButtonStyle should resolve from theme");
+
+		var button = new Button { Content = "Test", Style = style };
+		container.Children.Add(button);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(button);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var bg = button.Background as SolidColorBrush;
+		Assert.IsNotNull(bg, "Button should have a SolidColorBrush Background");
+
+		Assert.AreEqual(OverrideBlue, bg.Color,
+			$"Expected override color #{OverrideBlue} but got #{bg.Color}. " +
+			"ColorOverrideDictionary path is not taking precedence over seed colors.");
+	}
+
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/kahua-private/issues/462

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Other... Please describe:


## Description

<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
