### PR TITLE
docs: update simple cli param name

### DIFF
--- a/doc/simple-getting-started.md
+++ b/doc/simple-getting-started.md
@@ -25,7 +25,7 @@ Uno Simple is enabled through the `SimpleTheme` UnoFeatures and lets you apply S
 2. Create a new application with:
 
     ```bash
-    dotnet new unoapp -o UnoSimpleApp -theme simpletheme
+    dotnet new unoapp -o UnoSimpleApp -theme simple
     ```
 
 ### Installing Uno Simple in an existing project


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1671 

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## Summary
- Updates the Simple theme CLI parameter in the getting started docs from `-theme simpletheme` to `-theme simple`, matching the recent rename in `uno.templates`