### PR TITLE
fix: bundle Inter font files in Uno.Simple.WinUI

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="local" value="D:\source\local-nuget" />
     <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
     <add key="platform.uno dev" value="https://uno-platform.pkgs.visualstudio.com/Uno%20Platform/_packaging/unoplatformdev/nuget/v3/index.json" />
   </packageSources>

--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <add key="local" value="D:\source\local-nuget" />
     <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
     <add key="platform.uno dev" value="https://uno-platform.pkgs.visualstudio.com/Uno%20Platform/_packaging/unoplatformdev/nuget/v3/index.json" />
   </packageSources>

--- a/src/library/Directory.Packages.props
+++ b/src/library/Directory.Packages.props
@@ -14,6 +14,7 @@
 		<PackageVersion Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
 		<PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
 		<PackageVersion Include="Uno.Extensions.Markup.Generators" Version="5.2.0-dev.61" />
+		<PackageVersion Include="Uno.Fonts.Inter" Version="1.0.0" />
 		<PackageVersion Include="Uno.Fonts.Roboto" Version="2.2.2" />
 		<PackageVersion Include="Uno.WinUI.Lottie" Version="6.4.229" />
 		<PackageVersion Include="Uno.WinUI.Markup" Version="5.2.0-dev.61" />

--- a/src/library/Directory.Packages.props
+++ b/src/library/Directory.Packages.props
@@ -14,7 +14,7 @@
 		<PackageVersion Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
 		<PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
 		<PackageVersion Include="Uno.Extensions.Markup.Generators" Version="5.2.0-dev.61" />
-		<PackageVersion Include="Uno.Fonts.Inter" Version="1.0.0" />
+		<PackageVersion Include="Uno.Fonts.Inter" Version="2.9.0-dev.12" />
 		<PackageVersion Include="Uno.Fonts.Roboto" Version="2.2.2" />
 		<PackageVersion Include="Uno.WinUI.Lottie" Version="6.4.229" />
 		<PackageVersion Include="Uno.WinUI.Markup" Version="5.2.0-dev.61" />

--- a/src/library/Uno.Simple.WinUI/Styles/Application/Common/Fonts.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Application/Common/Fonts.xaml
@@ -11,19 +11,31 @@
 		<!-- ─── Light Theme ─── -->
 		<ResourceDictionary x:Key="Light">
 			<!-- Root typeface tokens (cascade to all type scales) -->
-			<FontFamily x:Key="TypefacePlain">Inter</FontFamily>
-			<FontFamily x:Key="TypefaceBrand">Inter</FontFamily>
+			<FontFamily x:Key="TypefacePlain">ms-appx:///Uno.Fonts.Inter/Fonts/Inter-Regular.ttf#Inter</FontFamily>
+			<FontFamily x:Key="TypefaceBrand">ms-appx:///Uno.Fonts.Inter/Fonts/Inter-Medium.ttf#Inter</FontFamily>
 
-			<!-- Legacy Simple-specific font family key -->
-			<FontFamily x:Key="SimpleFontFamily">Inter</FontFamily>
+			<!-- Per-weight font family resources -->
+			<FontFamily x:Key="SimpleRegularFontFamily">ms-appx:///Uno.Fonts.Inter/Fonts/Inter-Regular.ttf#Inter</FontFamily>
+			<FontFamily x:Key="SimpleMediumFontFamily">ms-appx:///Uno.Fonts.Inter/Fonts/Inter-Medium.ttf#Inter</FontFamily>
+			<FontFamily x:Key="SimpleSemiBoldFontFamily">ms-appx:///Uno.Fonts.Inter/Fonts/Inter-SemiBold.ttf#Inter</FontFamily>
+			<FontFamily x:Key="SimpleBoldFontFamily">ms-appx:///Uno.Fonts.Inter/Fonts/Inter-Bold.ttf#Inter</FontFamily>
+
+			<!-- Legacy Simple-specific font family key (points to Regular) -->
+			<FontFamily x:Key="SimpleFontFamily">ms-appx:///Uno.Fonts.Inter/Fonts/Inter-Regular.ttf#Inter</FontFamily>
 		</ResourceDictionary>
 		<ResourceDictionary x:Key="Default">
 			<!-- Root typeface tokens (cascade to all type scales) -->
-			<FontFamily x:Key="TypefacePlain">Inter</FontFamily>
-			<FontFamily x:Key="TypefaceBrand">Inter</FontFamily>
+			<FontFamily x:Key="TypefacePlain">ms-appx:///Uno.Fonts.Inter/Fonts/Inter-Regular.ttf#Inter</FontFamily>
+			<FontFamily x:Key="TypefaceBrand">ms-appx:///Uno.Fonts.Inter/Fonts/Inter-Medium.ttf#Inter</FontFamily>
 
-			<!-- Legacy Simple-specific font family key -->
-			<FontFamily x:Key="SimpleFontFamily">Inter</FontFamily>
+			<!-- Per-weight font family resources -->
+			<FontFamily x:Key="SimpleRegularFontFamily">ms-appx:///Uno.Fonts.Inter/Fonts/Inter-Regular.ttf#Inter</FontFamily>
+			<FontFamily x:Key="SimpleMediumFontFamily">ms-appx:///Uno.Fonts.Inter/Fonts/Inter-Medium.ttf#Inter</FontFamily>
+			<FontFamily x:Key="SimpleSemiBoldFontFamily">ms-appx:///Uno.Fonts.Inter/Fonts/Inter-SemiBold.ttf#Inter</FontFamily>
+			<FontFamily x:Key="SimpleBoldFontFamily">ms-appx:///Uno.Fonts.Inter/Fonts/Inter-Bold.ttf#Inter</FontFamily>
+
+			<!-- Legacy Simple-specific font family key (points to Regular) -->
+			<FontFamily x:Key="SimpleFontFamily">ms-appx:///Uno.Fonts.Inter/Fonts/Inter-Regular.ttf#Inter</FontFamily>
 		</ResourceDictionary>
 
 	</ResourceDictionary.ThemeDictionaries>

--- a/src/library/Uno.Simple.WinUI/Styles/Application/Typography.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Application/Typography.xaml
@@ -38,77 +38,77 @@
 			<!-- DISPLAY -->
 
 			<!-- Display Large — SDS title-hero (72px, Bold) -->
-			<StaticResource x:Key="DisplayLargeFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="DisplayLargeFontFamily" ResourceKey="SimpleBoldFontFamily" />
 			<x:String x:Key="DisplayLargeFontWeight">Bold</x:String>
 			<x:Double x:Key="DisplayLargeFontSize">72</x:Double>
 			<x:Int32 x:Key="DisplayLargeCharacterSpacing">0</x:Int32>
 
 			<!-- Display Medium — SDS title-page (48px, Bold) -->
-			<StaticResource x:Key="DisplayMediumFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="DisplayMediumFontFamily" ResourceKey="SimpleBoldFontFamily" />
 			<x:String x:Key="DisplayMediumFontWeight">Bold</x:String>
 			<x:Double x:Key="DisplayMediumFontSize">48</x:Double>
 
 			<!-- Display Small — Best guess: SDS scale07 (40px), Normal weight -->
-			<StaticResource x:Key="DisplaySmallFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="DisplaySmallFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="DisplaySmallFontWeight">Normal</x:String>
 			<x:Double x:Key="DisplaySmallFontSize">40</x:Double>
 
 			<!-- HEADLINE -->
 
 			<!-- Headline Large — SDS subtitle (32px, Normal) -->
-			<StaticResource x:Key="HeadlineLargeFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="HeadlineLargeFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="HeadlineLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="HeadlineLargeFontSize">32</x:Double>
 
 			<!-- Headline Medium — SDS heading (24px, SemiBold) -->
-			<StaticResource x:Key="HeadlineMediumFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="HeadlineMediumFontFamily" ResourceKey="SimpleSemiBoldFontFamily" />
 			<x:String x:Key="HeadlineMediumFontWeight">SemiBold</x:String>
 			<x:Double x:Key="HeadlineMediumFontSize">24</x:Double>
 
 			<!-- Headline Small — SDS subheading (20px, Normal) -->
-			<StaticResource x:Key="HeadlineSmallFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="HeadlineSmallFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="HeadlineSmallFontWeight">Normal</x:String>
 			<x:Double x:Key="HeadlineSmallFontSize">20</x:Double>
 
 			<!-- TITLE -->
 
 			<!-- Title Large — Best guess: SDS subheading size (20px) with SemiBold for title emphasis -->
-			<StaticResource x:Key="TitleLargeFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="TitleLargeFontFamily" ResourceKey="SimpleSemiBoldFontFamily" />
 			<x:String x:Key="TitleLargeFontWeight">SemiBold</x:String>
 			<x:Double x:Key="TitleLargeFontSize">20</x:Double>
 
 			<!-- Title Medium — SDS body-strong (16px, SemiBold) -->
-			<StaticResource x:Key="TitleMediumFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="TitleMediumFontFamily" ResourceKey="SimpleSemiBoldFontFamily" />
 			<x:String x:Key="TitleMediumFontWeight">SemiBold</x:String>
 			<x:Double x:Key="TitleMediumFontSize">16</x:Double>
 
 			<!-- Title Small — SDS body-small-strong (14px, SemiBold) -->
-			<StaticResource x:Key="TitleSmallFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="TitleSmallFontFamily" ResourceKey="SimpleSemiBoldFontFamily" />
 			<x:String x:Key="TitleSmallFontWeight">SemiBold</x:String>
 			<x:Double x:Key="TitleSmallFontSize">14</x:Double>
 
 			<!-- LABEL -->
 
 			<!-- Label Large — SDS body-strong (16px, SemiBold) -->
-			<StaticResource x:Key="LabelLargeFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="LabelLargeFontFamily" ResourceKey="SimpleSemiBoldFontFamily" />
 			<x:String x:Key="LabelLargeFontWeight">SemiBold</x:String>
 			<x:Double x:Key="LabelLargeFontSize">16</x:Double>
 			<x:Int32 x:Key="LabelLargeCharacterSpacing">0</x:Int32>
 
 			<!-- Label Medium — SDS body-small-strong weight (14px, SemiBold) -->
-			<StaticResource x:Key="LabelMediumFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="LabelMediumFontFamily" ResourceKey="SimpleSemiBoldFontFamily" />
 			<x:String x:Key="LabelMediumFontWeight">SemiBold</x:String>
 			<x:Double x:Key="LabelMediumFontSize">14</x:Double>
 			<x:Int32 x:Key="LabelMediumCharacterSpacing">0</x:Int32>
 
 			<!-- Label Small — Best guess: SDS caption size (12px) with SemiBold -->
-			<StaticResource x:Key="LabelSmallFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="LabelSmallFontFamily" ResourceKey="SimpleSemiBoldFontFamily" />
 			<x:String x:Key="LabelSmallFontWeight">SemiBold</x:String>
 			<x:Double x:Key="LabelSmallFontSize">12</x:Double>
 			<x:Int32 x:Key="LabelSmallCharacterSpacing">0</x:Int32>
 
 			<!-- Label ExtraSmall — Best guess: SDS minimum size (12px), Normal weight -->
-			<StaticResource x:Key="LabelExtraSmallFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="LabelExtraSmallFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="LabelExtraSmallFontWeight">Normal</x:String>
 			<x:Double x:Key="LabelExtraSmallFontSize">12</x:Double>
 			<x:Int32 x:Key="LabelExtraSmallCharacterSpacing">0</x:Int32>
@@ -116,19 +116,19 @@
 			<!-- BODY -->
 
 			<!-- Body Large — SDS body-base (16px, Normal) -->
-			<StaticResource x:Key="BodyLargeFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="BodyLargeFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="BodyLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="BodyLargeFontSize">16</x:Double>
 			<x:Int32 x:Key="BodyLargeCharacterSpacing">0</x:Int32>
 
 			<!-- Body Medium — SDS body-small (14px, Normal) -->
-			<StaticResource x:Key="BodyMediumFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="BodyMediumFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="BodyMediumFontWeight">Normal</x:String>
 			<x:Double x:Key="BodyMediumFontSize">14</x:Double>
 			<x:Int32 x:Key="BodyMediumCharacterSpacing">0</x:Int32>
 
 			<!-- Body Small — SDS caption (12px, Normal) -->
-			<StaticResource x:Key="BodySmallFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="BodySmallFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="BodySmallFontWeight">Normal</x:String>
 			<x:Double x:Key="BodySmallFontSize">12</x:Double>
 			<x:Int32 x:Key="BodySmallCharacterSpacing">0</x:Int32>
@@ -136,19 +136,19 @@
 			<!-- CAPTION -->
 
 			<!-- Caption Large — Best guess: SDS body-small size (14px), Normal weight -->
-			<StaticResource x:Key="CaptionLargeFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="CaptionLargeFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="CaptionLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="CaptionLargeFontSize">14</x:Double>
 			<x:Int32 x:Key="CaptionLargeCharacterSpacing">0</x:Int32>
 
 			<!-- Caption Medium — SDS caption (12px, Normal) -->
-			<StaticResource x:Key="CaptionMediumFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="CaptionMediumFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="CaptionMediumFontWeight">Normal</x:String>
 			<x:Double x:Key="CaptionMediumFontSize">12</x:Double>
 			<x:Int32 x:Key="CaptionMediumCharacterSpacing">0</x:Int32>
 
 			<!-- Caption Small — Best guess: SDS minimum size (12px), Normal weight -->
-			<StaticResource x:Key="CaptionSmallFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="CaptionSmallFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="CaptionSmallFontWeight">Normal</x:String>
 			<x:Double x:Key="CaptionSmallFontSize">12</x:Double>
 			<x:Int32 x:Key="CaptionSmallCharacterSpacing">0</x:Int32>
@@ -163,77 +163,77 @@
 			<!-- DISPLAY -->
 
 			<!-- Display Large — SDS title-hero (72px, Bold) -->
-			<StaticResource x:Key="DisplayLargeFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="DisplayLargeFontFamily" ResourceKey="SimpleBoldFontFamily" />
 			<x:String x:Key="DisplayLargeFontWeight">Bold</x:String>
 			<x:Double x:Key="DisplayLargeFontSize">72</x:Double>
 			<x:Int32 x:Key="DisplayLargeCharacterSpacing">0</x:Int32>
 
 			<!-- Display Medium — SDS title-page (48px, Bold) -->
-			<StaticResource x:Key="DisplayMediumFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="DisplayMediumFontFamily" ResourceKey="SimpleBoldFontFamily" />
 			<x:String x:Key="DisplayMediumFontWeight">Bold</x:String>
 			<x:Double x:Key="DisplayMediumFontSize">48</x:Double>
 
 			<!-- Display Small — Best guess: SDS scale07 (40px), Normal weight -->
-			<StaticResource x:Key="DisplaySmallFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="DisplaySmallFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="DisplaySmallFontWeight">Normal</x:String>
 			<x:Double x:Key="DisplaySmallFontSize">40</x:Double>
 
 			<!-- HEADLINE -->
 
 			<!-- Headline Large — SDS subtitle (32px, Normal) -->
-			<StaticResource x:Key="HeadlineLargeFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="HeadlineLargeFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="HeadlineLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="HeadlineLargeFontSize">32</x:Double>
 
 			<!-- Headline Medium — SDS heading (24px, SemiBold) -->
-			<StaticResource x:Key="HeadlineMediumFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="HeadlineMediumFontFamily" ResourceKey="SimpleSemiBoldFontFamily" />
 			<x:String x:Key="HeadlineMediumFontWeight">SemiBold</x:String>
 			<x:Double x:Key="HeadlineMediumFontSize">24</x:Double>
 
 			<!-- Headline Small — SDS subheading (20px, Normal) -->
-			<StaticResource x:Key="HeadlineSmallFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="HeadlineSmallFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="HeadlineSmallFontWeight">Normal</x:String>
 			<x:Double x:Key="HeadlineSmallFontSize">20</x:Double>
 
 			<!-- TITLE -->
 
 			<!-- Title Large — Best guess: SDS subheading size (20px) with SemiBold for title emphasis -->
-			<StaticResource x:Key="TitleLargeFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="TitleLargeFontFamily" ResourceKey="SimpleSemiBoldFontFamily" />
 			<x:String x:Key="TitleLargeFontWeight">SemiBold</x:String>
 			<x:Double x:Key="TitleLargeFontSize">20</x:Double>
 
 			<!-- Title Medium — SDS body-strong (16px, SemiBold) -->
-			<StaticResource x:Key="TitleMediumFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="TitleMediumFontFamily" ResourceKey="SimpleSemiBoldFontFamily" />
 			<x:String x:Key="TitleMediumFontWeight">SemiBold</x:String>
 			<x:Double x:Key="TitleMediumFontSize">16</x:Double>
 
 			<!-- Title Small — SDS body-small-strong (14px, SemiBold) -->
-			<StaticResource x:Key="TitleSmallFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="TitleSmallFontFamily" ResourceKey="SimpleSemiBoldFontFamily" />
 			<x:String x:Key="TitleSmallFontWeight">SemiBold</x:String>
 			<x:Double x:Key="TitleSmallFontSize">14</x:Double>
 
 			<!-- LABEL -->
 
 			<!-- Label Large — SDS body-strong (16px, SemiBold) -->
-			<StaticResource x:Key="LabelLargeFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="LabelLargeFontFamily" ResourceKey="SimpleSemiBoldFontFamily" />
 			<x:String x:Key="LabelLargeFontWeight">SemiBold</x:String>
 			<x:Double x:Key="LabelLargeFontSize">16</x:Double>
 			<x:Int32 x:Key="LabelLargeCharacterSpacing">0</x:Int32>
 
 			<!-- Label Medium — SDS body-small-strong weight (14px, SemiBold) -->
-			<StaticResource x:Key="LabelMediumFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="LabelMediumFontFamily" ResourceKey="SimpleSemiBoldFontFamily" />
 			<x:String x:Key="LabelMediumFontWeight">SemiBold</x:String>
 			<x:Double x:Key="LabelMediumFontSize">14</x:Double>
 			<x:Int32 x:Key="LabelMediumCharacterSpacing">0</x:Int32>
 
 			<!-- Label Small — Best guess: SDS caption size (12px) with SemiBold -->
-			<StaticResource x:Key="LabelSmallFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="LabelSmallFontFamily" ResourceKey="SimpleSemiBoldFontFamily" />
 			<x:String x:Key="LabelSmallFontWeight">SemiBold</x:String>
 			<x:Double x:Key="LabelSmallFontSize">12</x:Double>
 			<x:Int32 x:Key="LabelSmallCharacterSpacing">0</x:Int32>
 
 			<!-- Label ExtraSmall — Best guess: SDS minimum size (12px), Normal weight -->
-			<StaticResource x:Key="LabelExtraSmallFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="LabelExtraSmallFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="LabelExtraSmallFontWeight">Normal</x:String>
 			<x:Double x:Key="LabelExtraSmallFontSize">12</x:Double>
 			<x:Int32 x:Key="LabelExtraSmallCharacterSpacing">0</x:Int32>
@@ -241,19 +241,19 @@
 			<!-- BODY -->
 
 			<!-- Body Large — SDS body-base (16px, Normal) -->
-			<StaticResource x:Key="BodyLargeFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="BodyLargeFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="BodyLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="BodyLargeFontSize">16</x:Double>
 			<x:Int32 x:Key="BodyLargeCharacterSpacing">0</x:Int32>
 
 			<!-- Body Medium — SDS body-small (14px, Normal) -->
-			<StaticResource x:Key="BodyMediumFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="BodyMediumFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="BodyMediumFontWeight">Normal</x:String>
 			<x:Double x:Key="BodyMediumFontSize">14</x:Double>
 			<x:Int32 x:Key="BodyMediumCharacterSpacing">0</x:Int32>
 
 			<!-- Body Small — SDS caption (12px, Normal) -->
-			<StaticResource x:Key="BodySmallFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="BodySmallFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="BodySmallFontWeight">Normal</x:String>
 			<x:Double x:Key="BodySmallFontSize">12</x:Double>
 			<x:Int32 x:Key="BodySmallCharacterSpacing">0</x:Int32>
@@ -261,19 +261,19 @@
 			<!-- CAPTION -->
 
 			<!-- Caption Large — Best guess: SDS body-small size (14px), Normal weight -->
-			<StaticResource x:Key="CaptionLargeFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="CaptionLargeFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="CaptionLargeFontWeight">Normal</x:String>
 			<x:Double x:Key="CaptionLargeFontSize">14</x:Double>
 			<x:Int32 x:Key="CaptionLargeCharacterSpacing">0</x:Int32>
 
 			<!-- Caption Medium — SDS caption (12px, Normal) -->
-			<StaticResource x:Key="CaptionMediumFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="CaptionMediumFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="CaptionMediumFontWeight">Normal</x:String>
 			<x:Double x:Key="CaptionMediumFontSize">12</x:Double>
 			<x:Int32 x:Key="CaptionMediumCharacterSpacing">0</x:Int32>
 
 			<!-- Caption Small — Best guess: SDS minimum size (12px), Normal weight -->
-			<StaticResource x:Key="CaptionSmallFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="CaptionSmallFontFamily" ResourceKey="SimpleRegularFontFamily" />
 			<x:String x:Key="CaptionSmallFontWeight">Normal</x:String>
 			<x:Double x:Key="CaptionSmallFontSize">12</x:Double>
 			<x:Int32 x:Key="CaptionSmallCharacterSpacing">0</x:Int32>

--- a/src/library/Uno.Simple.WinUI/simple-common.props
+++ b/src/library/Uno.Simple.WinUI/simple-common.props
@@ -48,6 +48,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Uno.Fonts.Inter" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<XamlMergeInput Include="Styles\Controls\**\*.xaml" />
 		<XamlMergeInput Include="Styles\Application\**\*.xaml" />
 		<None Remove="Styles\Controls\_Resources.xaml" />

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_Fonts.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_Fonts.cs
@@ -33,10 +33,10 @@ public class Given_Fonts
 		return null!;
 	}
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// 1. FONT URI — all font family resources must use ms-appx:/// URIs
-	//    pointing to bundled Inter TTF files (not bare "Inter" system name).
-	// ═══════════════════════════════════════════════════════════════════════
+	// ─────────────────────────────────────────────────────────────────────
+	// Font URI: all font family resources must use ms-appx:/// URIs
+	// pointing to bundled Inter TTF files (not bare "Inter" system name).
+	// ─────────────────────────────────────────────────────────────────────
 
 	[TestMethod]
 	[RunsOnUIThread]
@@ -71,7 +71,7 @@ public class Given_Fonts
 		var container = CreateThemedContainer();
 		var fontFamily = GetFontFamily(container, resourceKey);
 
-		// Source should be like "ms-appx:///Uno.Simple.WinUI/Fonts/Inter-*.ttf#Inter"
+		// Source should be like "ms-appx:///Uno.Fonts.Inter/Fonts/Inter-*.ttf#Inter"
 		StringAssert.Contains(
 			fontFamily.Source,
 			"Inter-",
@@ -85,9 +85,9 @@ public class Given_Fonts
 			$"Actual Source: '{fontFamily.Source}'");
 	}
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// 2. WEIGHT MAPPING — each weight slot should use the correct TTF file
-	// ═══════════════════════════════════════════════════════════════════════
+	// ─────────────────────────────────────────────────────────────────────
+	// Weight mapping: each weight slot should use the correct TTF file.
+	// ─────────────────────────────────────────────────────────────────────
 
 	[TestMethod]
 	[RunsOnUIThread]
@@ -108,9 +108,9 @@ public class Given_Fonts
 			$"Actual Source: '{fontFamily.Source}'");
 	}
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// 3. TYPOGRAPHY SCALE — type scale slots must reference bundled fonts
-	// ═══════════════════════════════════════════════════════════════════════
+	// ─────────────────────────────────────────────────────────────────────
+	// Typography scale: type scale slots must reference bundled fonts.
+	// ─────────────────────────────────────────────────────────────────────
 
 	[TestMethod]
 	[RunsOnUIThread]
@@ -138,9 +138,9 @@ public class Given_Fonts
 			$"Actual Source: '{fontFamily.Source}'");
 	}
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// 4. BOLD SLOTS — display/headline bold slots must use Inter-Bold, not Inter-Regular
-	// ═══════════════════════════════════════════════════════════════════════
+	// ─────────────────────────────────────────────────────────────────────
+	// Bold/SemiBold slots: display and headline slots must use the correct weight file.
+	// ─────────────────────────────────────────────────────────────────────
 
 	[TestMethod]
 	[RunsOnUIThread]

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_Fonts.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_Fonts.cs
@@ -1,0 +1,177 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Simple;
+using Uno.UI.RuntimeTests;
+
+namespace Uno.Themes.Samples.RuntimeTests;
+
+/// <summary>
+/// Regression tests for font bundling in Uno.Simple.
+/// Verifies that Inter font files are properly bundled and referenced via ms-appx URIs
+/// rather than relying on a system-installed "Inter" font 
+/// </summary>
+[TestClass]
+public class Given_Fonts
+{
+	private static Grid CreateThemedContainer()
+	{
+		var theme = new SimpleTheme();
+		var container = new Grid();
+		container.Resources.MergedDictionaries.Add(theme);
+		return container;
+	}
+
+	private static FontFamily GetFontFamily(Grid container, string key)
+	{
+		if (container.Resources.TryGetValue(key, out var value) && value is FontFamily ff)
+		{
+			return ff;
+		}
+
+		Assert.Fail($"Resource '{key}' not found or not of type FontFamily");
+		return null!;
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 1. FONT URI — all font family resources must use ms-appx:/// URIs
+	//    pointing to bundled Inter TTF files (not bare "Inter" system name).
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow("SimpleFontFamily")]
+	[DataRow("SimpleRegularFontFamily")]
+	[DataRow("SimpleMediumFontFamily")]
+	[DataRow("SimpleSemiBoldFontFamily")]
+	[DataRow("SimpleBoldFontFamily")]
+	[DataRow("TypefacePlain")]
+	[DataRow("TypefaceBrand")]
+	public void When_SimpleThemeLoaded_Then_FontFamilyUsesAppxUri(string resourceKey)
+	{
+		var container = CreateThemedContainer();
+		var fontFamily = GetFontFamily(container, resourceKey);
+
+		StringAssert.StartsWith(
+			fontFamily.Source,
+			"ms-appx:///Uno.Fonts.Inter/",
+			$"Font resource '{resourceKey}' must use a ms-appx:///Uno.Fonts.Inter/ URI to a bundled font file, " +
+			$"not a bare system font name. Actual Source: '{fontFamily.Source}'");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow("SimpleFontFamily")]
+	[DataRow("SimpleRegularFontFamily")]
+	[DataRow("SimpleMediumFontFamily")]
+	[DataRow("SimpleSemiBoldFontFamily")]
+	[DataRow("SimpleBoldFontFamily")]
+	public void When_SimpleThemeLoaded_Then_FontFamilyReferencesInterFile(string resourceKey)
+	{
+		var container = CreateThemedContainer();
+		var fontFamily = GetFontFamily(container, resourceKey);
+
+		// Source should be like "ms-appx:///Uno.Simple.WinUI/Fonts/Inter-*.ttf#Inter"
+		StringAssert.Contains(
+			fontFamily.Source,
+			"Inter-",
+			$"Font resource '{resourceKey}' should reference an Inter TTF file. " +
+			$"Actual Source: '{fontFamily.Source}'");
+
+		StringAssert.EndsWith(
+			fontFamily.Source,
+			"#Inter",
+			$"Font resource '{resourceKey}' should specify the Inter face name. " +
+			$"Actual Source: '{fontFamily.Source}'");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 2. WEIGHT MAPPING — each weight slot should use the correct TTF file
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow("SimpleRegularFontFamily", "Inter-Regular.ttf")]
+	[DataRow("SimpleMediumFontFamily", "Inter-Medium.ttf")]
+	[DataRow("SimpleSemiBoldFontFamily", "Inter-SemiBold.ttf")]
+	[DataRow("SimpleBoldFontFamily", "Inter-Bold.ttf")]
+	public void When_SimpleThemeLoaded_Then_WeightSpecificFontFamilyMapsToCorrectFile(
+		string resourceKey, string expectedFileName)
+	{
+		var container = CreateThemedContainer();
+		var fontFamily = GetFontFamily(container, resourceKey);
+
+		StringAssert.Contains(
+			fontFamily.Source,
+			expectedFileName,
+			$"'{resourceKey}' should map to '{expectedFileName}'. " +
+			$"Actual Source: '{fontFamily.Source}'");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 3. TYPOGRAPHY SCALE — type scale slots must reference bundled fonts
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow("DisplayLargeFontFamily")]
+	[DataRow("HeadlineMediumFontFamily")]
+	[DataRow("TitleMediumFontFamily")]
+	[DataRow("BodyLargeFontFamily")]
+	[DataRow("LabelMediumFontFamily")]
+	[DataRow("CaptionMediumFontFamily")]
+	public void When_SimpleThemeLoaded_Then_TypographyScaleFontFamilyUsesAppxUri(string resourceKey)
+	{
+		var container = CreateThemedContainer();
+		var fontFamily = GetFontFamily(container, resourceKey);
+
+		StringAssert.StartsWith(
+			fontFamily.Source,
+			"ms-appx:///Uno.Fonts.Inter/",
+			$"Typography resource '{resourceKey}' must use a ms-appx:///Uno.Fonts.Inter/ URI. " +
+			$"Actual Source: '{fontFamily.Source}'");
+
+		StringAssert.Contains(
+			fontFamily.Source,
+			"Inter-",
+			$"Typography resource '{resourceKey}' should reference a bundled Inter font file. " +
+			$"Actual Source: '{fontFamily.Source}'");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 4. BOLD SLOTS — display/headline bold slots must use Inter-Bold, not Inter-Regular
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow("DisplayLargeFontFamily")]
+	[DataRow("DisplayMediumFontFamily")]
+	public void When_SimpleThemeLoaded_Then_BoldDisplaySlotsUseBoldFontFile(string resourceKey)
+	{
+		var container = CreateThemedContainer();
+		var fontFamily = GetFontFamily(container, resourceKey);
+
+		StringAssert.Contains(
+			fontFamily.Source,
+			"Inter-Bold.ttf",
+			$"'{resourceKey}' is a Bold display slot and must reference 'Inter-Bold.ttf'. " +
+			$"Actual Source: '{fontFamily.Source}'");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow("HeadlineMediumFontFamily")]
+	[DataRow("TitleMediumFontFamily")]
+	[DataRow("LabelLargeFontFamily")]
+	public void When_SimpleThemeLoaded_Then_SemiBoldSlotUseSemiBoldFontFile(string resourceKey)
+	{
+		var container = CreateThemedContainer();
+		var fontFamily = GetFontFamily(container, resourceKey);
+
+		StringAssert.Contains(
+			fontFamily.Source,
+			"Inter-SemiBold.ttf",
+			$"'{resourceKey}' is a SemiBold slot and must reference 'Inter-SemiBold.ttf'. " +
+			$"Actual Source: '{fontFamily.Source}'");
+	}
+}


### PR DESCRIPTION
Replace bare `Inter` font name with `ms-appx:///` URIs pointing to bundled TTF files via a new `Uno.Fonts.Inter` NuGet package, preventing fallback to the system font on platforms where Inter is not installed.

- Add `Uno.Fonts.Inter` package reference (mirrors `Uno.Fonts.Roboto` pattern — fonts ship via the package, not inlined)
- Update all font URIs in `Fonts.xaml` to `ms-appx:///Uno.Fonts.Inter/Fonts/Inter-*.ttf#Inter`
- Introduce weight-specific font family resource keys (`SimpleRegularFontFamily`, `SimpleMediumFontFamily`, `SimpleSemiBoldFontFamily`, `SimpleBoldFontFamily`)
- Update `Typography.xaml` to use weight-specific keys per type scale slot
- Add `Given_Fonts` runtime tests to guard against regression

Fixes https://github.com/unoplatform/studio.live/issues/1926

## PR Type

- [x] Bugfix

## PR Checklist

- Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable
- [ ] Contains **No** breaking changes