### PR TITLE
ci: Bump canary updater tool to 1.3.1

### DIFF
--- a/build/templates/canary-updater.yml
+++ b/build/templates/canary-updater.yml
@@ -25,7 +25,7 @@ steps:
       branchToMerge: master
       summaryFile: '$(Build.ArtifactStagingDirectory)/Canary.md'
       resultFile: '$(Build.ArtifactStagingDirectory)/result.json'
-      nugetUpdaterVersion: '1.2.10'
+      nugetUpdaterVersion: '1.3.1'
       useVersionOverrides: true
       versionOverridesFile: '$(build.sourcesdirectory)/build/templates/versionOverrides.json'
       packageAuthor: 'Uno Platform,unoplatform'


### PR DESCRIPTION
Bump `nugetUpdaterVersion` `1.2.10 → 1.3.1` (latest stable) as the single source on the default branch; `canaries/dev` inherits it via the `master` merge. `1.3.1` adds the property-package fallback mappings (unoplatform/nuget.updater#40) so `UnoMaterial`/`UnoThemes` resolve their WinUI variants instead of the stale legacy base IDs.

Note: this aligns the tool version.