### PR TITLE
fix(cupertino): Use Lottie UnoFeature instead of direct package pin

### DIFF
--- a/src/library/Directory.Packages.props
+++ b/src/library/Directory.Packages.props
@@ -16,7 +16,6 @@
 		<PackageVersion Include="Uno.Extensions.Markup.Generators" Version="5.2.0-dev.61" />
 		<PackageVersion Include="Uno.Fonts.Inter" Version="2.9.0-dev.12" />
 		<PackageVersion Include="Uno.Fonts.Roboto" Version="2.2.2" />
-		<PackageVersion Include="Uno.WinUI.Lottie" Version="6.4.229" />
 		<PackageVersion Include="Uno.WinUI.Markup" Version="5.2.0-dev.61" />
 		<PackageVersion Include="Uno.XamlMerge.Task" Version="$(_Uno_XamlMerge_Task_Version)" />
 	</ItemGroup>

--- a/src/library/Uno.Cupertino/Uno.Cupertino.WinUI.csproj
+++ b/src/library/Uno.Cupertino/Uno.Cupertino.WinUI.csproj
@@ -14,9 +14,9 @@
 
 	<Import Project="cupertino-common.props" />
 
-	<ItemGroup>
-		<PackageReference Include="Uno.WinUI.Lottie" Condition="!$(_IsWinUI)" />
-	</ItemGroup>
+	<PropertyGroup>
+		<UnoFeatures>Lottie;</UnoFeatures>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Themes\Uno.Themes.WinUI.csproj">


### PR DESCRIPTION
## Problem

`Uno.Cupertino.WinUI` references **`Uno.WinUI.Lottie` as a direct, hard-pinned package** (`6.4.229`) rather than via the Lottie UnoFeature. On the canary, the updater bumps that standalone `Uno.WinUI.Lottie` to the latest dev (e.g. `6.7.0-dev.707`) while `Uno.WinUI` comes from the **Uno.Sdk** at a lower dev height (e.g. `6.7.0-dev.704`), so:

```
error NU1605: Detected package downgrade: Uno.WinUI from 6.7.0-dev.707 to 6.7.0-dev.704
  Uno.Cupertino.WinUI -> Uno.WinUI.Lottie 6.7.0-dev.707 -> Uno.WinUI (>= 6.7.0-dev.707)
  Uno.Cupertino.WinUI -> Uno.WinUI (>= 6.7.0-dev.704)
```

This fails all four Cupertino sample heads (Android/iOS/Wasm/Desktop) on the canary.

## Root cause (validated via history)

The direct pin is a **leftover from the UWP drop (#1609)** — it was carried over from the UWP-era set (`Uno.UI`/`Uno.UI.Lottie`/`Uno.WinUI`/`Uno.WinUI.Lottie` @ `5.0.19`) and never migrated. Its sibling **`Uno.Material.WinUI` already uses `<UnoFeatures>Lottie;</UnoFeatures>`** — so this just brings Cupertino in line.

## Fix

- `Uno.Cupertino.WinUI.csproj`: replace the direct `Uno.WinUI.Lottie` `PackageReference` with **`<UnoFeatures>Lottie;</UnoFeatures>`** (matching `Uno.Material.WinUI`).
- Drop the now-unused `Uno.WinUI.Lottie` CPM `PackageVersion`.

The Uno.Sdk groups `Uno.WinUI` and `Uno.WinUI.Lottie` in the same "Core" group, so it now resolves Lottie **in lockstep with `Uno.WinUI`** — no standalone bump, no downgrade. This is also how the app templates enable Lottie.

## Scope

Fixes the 4 Cupertino canary heads.