### PR TITLE
fix(canary): pin SkiaSharp to 4.148.0 on canaries/dev samples

### DIFF
--- a/src/samples/Directory.Build.props
+++ b/src/samples/Directory.Build.props
@@ -4,6 +4,9 @@
     <Nullable>enable</Nullable>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
+    <!-- Canary-only: pin SkiaSharp to v4 (4.148.0) so the dev Uno.Material / Uno.WinUI.Lottie floor (>=3.119.4) is satisfied without the broken 3.119.4 iOS 26.2 assets. Remove when a fixed 3.119.x ships or the Uno.Sdk moves to v4 (7.0). https://github.com/unoplatform/uno/issues/23680 -->
+    <SkiaSharpVersion>4.148.0</SkiaSharpVersion>
+
     <!-- Set root namespace to match the shared project -->
     <RootNamespace>Uno.Themes.Samples</RootNamespace>
 


### PR DESCRIPTION
Canary-only workaround on `canaries/dev` (default branch left untouched, per team convention for canary-only adjustments).

Pins SkiaSharp to **4.148.0** for the sample apps so the dev `Uno.Material.WinUI` / `Uno.WinUI.Lottie` floor (`>=3.119.4`) is satisfied, avoiding the `NU1605` downgrade. v4 also ships the corrected `ios26.0` native assets (no `MT0099`). Reverts once SkiaSharp ships a fixed `3.119.x` or the Uno.Sdk moves to v4 in 7.0.

Related to https://github.com/unoplatform/uno/issues/23680