### PR TITLE
fix: make seed generation opt-in

### DIFF
--- a/build/stage-runtimetests-desktop.yml
+++ b/build/stage-runtimetests-desktop.yml
@@ -7,10 +7,17 @@ jobs:
   pool:
     vmImage: 'ubuntu-latest'
 
+  strategy:
+    matrix:
+      Material:
+        SampleAppName: MaterialSampleApp
+        ProjectPath: src/samples/MaterialSampleApp
+      Simple:
+        SampleAppName: SimpleSampleApp
+        ProjectPath: src/samples/SimpleSampleApp
+
   variables:
-    SampleAppName: SimpleSampleApp
-    ProjectPath: src/samples/SimpleSampleApp
-    ArtifactName: runtimetests-desktop-SimpleSampleApp
+    ArtifactName: runtimetests-desktop-$(SampleAppName)
 
   steps:
   - checkout: self

--- a/doc/seed-colors.md
+++ b/doc/seed-colors.md
@@ -6,7 +6,7 @@ uid: Uno.Themes.SeedColors
 
 Uno Themes supports algorithmic color palette generation using the Material Design 3 [HCT (Hue-Chroma-Tone)](https://material.io/blog/science-of-color-design) color space. Instead of manually defining 30+ color resources for Light and Dark themes, you can provide a single **seed color** and the library will derive the full semantic color palette automatically.
 
-Both `MaterialTheme` and `SimpleTheme` use seed color generation by default — even without explicit configuration. `MaterialTheme` uses `#5946D2` (deep purple) and `SimpleTheme` uses `#808080` (neutral gray) as their built-in default seeds. You can override them by setting `PrimarySeed` on a `ThemeColors` object.
+Seed color generation is **opt-in**: by default, `MaterialTheme` and `SimpleTheme` use their built-in palettes. The generator only runs when you explicitly set `PrimarySeed` on a `ThemeColors` object.
 
 ## Overview
 
@@ -97,8 +97,7 @@ SemanticThemeHelper.PrimarySeed = Colors.Green;
 SemanticThemeHelper.SecondarySeed = Colors.Teal;
 SemanticThemeHelper.TertiarySeed = Colors.Orange;
 
-// Clear seed to revert to theme's default seed color
-// (MaterialTheme → #5946D2, SimpleTheme → #808080)
+// Clear seed to revert to the theme's default palette
 SemanticThemeHelper.PrimarySeed = null;
 ```
 
@@ -146,11 +145,11 @@ Static convenience class for runtime theme configuration.
 When building the final theme palette, the following precedence order applies (highest wins):
 
 1. **`ThemeColors.OverrideDictionary`** (or `OverrideSource`) - explicit user overrides
-2. **Seed-generated palette** - algorithmically derived from `PrimarySeed` (or the theme's `DefaultPrimarySeed`)
+2. **Seed-generated palette** - algorithmically derived from `PrimarySeed`, only when one is explicitly set
 3. **Theme base colors** - e.g., Simple's grayscale palette or Material's built-in defaults
 4. **`SharedColorPalette`** - library defaults
 
-Both themes provide default primary seeds (`MaterialTheme` → `#5946D2`, `SimpleTheme` → `#808080`), so seed generation is always active. Setting `PrimarySeed` overrides the default; clearing it (`null`) reverts to the built-in seed.
+Neither theme sets a seed by default, so without explicit configuration the built-in default palettes apply. Setting `PrimarySeed` activates generation; clearing it (`null`) reverts to the default palette.
 
 This means seed colors override the built-in defaults, but any colors you explicitly set in the `OverrideDictionary` will take precedence over the seed-generated values.
 

--- a/specs/03-seed-color-palette/seed-color-palette.md
+++ b/specs/03-seed-color-palette/seed-color-palette.md
@@ -67,7 +67,7 @@ theme.Colors.PrimarySeed = Color.FromArgb(0xFF, 0x00, 0x6A, 0x6A);
 | Property | Type | Default | Description |
 |---|---|---|---|
 | `Colors` | `ThemeColors` | `null` | Grouped color configuration including seed colors and overrides. |
-| `DefaultPrimarySeed` | `Color?` (virtual) | `null` | Theme-specific default primary seed. `MaterialTheme` returns `#5946D2`; `SimpleTheme` returns `#808080`. When non-null, seed generation is always active even without explicit `ThemeColors`. |
+| `DefaultPrimarySeed` | `Color?` (virtual) | `null` | Theme-specific default primary seed. |
 
 ### Properties on `ThemeColors`
 
@@ -81,12 +81,12 @@ theme.Colors.PrimarySeed = Color.FromArgb(0xFF, 0x00, 0x6A, 0x6A);
 
 ### Default Seed Behavior
 
-Both `MaterialTheme` and `SimpleTheme` provide default primary seeds so that seed color generation is always active — even when no `ThemeColors` is explicitly configured:
+Neither `MaterialTheme` nor `SimpleTheme` provides a default primary seed (`DefaultPrimarySeed` returns `null` in both). Without explicit configuration, each theme uses its built-in default palette:
 
-- **`MaterialTheme`**: Default seed `#5946D2` (deep purple), producing a vibrant Material palette.
-- **`SimpleTheme`**: Default seed `#808080` (neutral gray), producing a near-neutral palette. Primary/Secondary/Tertiary carry a slight tint due to enforced minimum chroma values.
+- **`MaterialTheme`**: the default Material palette from `SharedColorPalette.xaml` (light primary `#5946D2`, dark primary `#C7BFFF`).
+- **`SimpleTheme`**: the grayscale palette from its `ColorPalette.xaml`.
 
-Setting `Colors.PrimarySeed` overrides the default in either theme.
+Seed generation only runs when `Colors.PrimarySeed` is explicitly set.
 
 Seed colors are configured exclusively via `ThemeColors` (the `BaseTheme.Colors` property). This works with `MaterialTheme`, `SimpleTheme`, and any future theme subclass.
 

--- a/specs/04-hot-reload-support/hot-reload-support.md
+++ b/specs/04-hot-reload-support/hot-reload-support.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-Edits to a colour / font / control-style XAML file referenced (directly or transitively) from a `BaseTheme`-derived dictionary — e.g. `ThemeColors.xaml` brought in via `Colors.OverrideSource`, or any merged-pages entry baked into `Uno.Material` / `Uno.Cupertino` / `Uno.Simple.WinUI` — now propagate to the running app on .NET hot reload without an app restart.
+Edits to a color / font / control-style XAML file referenced (directly or transitively) from a `BaseTheme`-derived dictionary — e.g. `ThemeColors.xaml` brought in via `Colors.OverrideSource`, or any merged-pages entry baked into `Uno.Material` / `Uno.Cupertino` / `Uno.Simple.WinUI` — now propagate to the running app on .NET hot reload without an app restart.
 
 The pre-fix theme model rebuilt its merged-dictionary tree from scratch each time a DP input changed (`PrimarySeed`, `DefaultDensity`, `DefaultCornerRadius`, override DPs, …). On hot reload there was no rebuild trigger at all, because `BaseTheme` had no opt-in to .NET's `MetadataUpdateHandler` pipeline. The framework's generic `UpdateResourceDictionaries` walk also couldn't help: it refreshes the *content* of a source-backed `ResourceDictionary` in-place, but it cannot regenerate a code-built dictionary (spacing scale, shape scale, density defaults, generated seed palette) or re-apply a precedence stack of merged children that lives in private fields on a typed subclass.
 
@@ -46,7 +46,7 @@ this.Clear();
 // …rebuild everything from scratch (converters / colors / typography / mergedpages / overrides)
 ```
 
-Combined with a brush-tracking pass (`CollectBrushes` / `UpdateOldBrushes`) to keep already-bound `{ThemeResource}` brushes pointing at the freshly-rebuilt colour values across the wipe. On the seed-color-change path the brush tracker compensated for the wipe; on hot reload, however, **there was nothing wiring the rebuild to the runtime's HR pass**, so brushes never got the new colours.
+Combined with a brush-tracking pass (`CollectBrushes` / `UpdateOldBrushes`) to keep already-bound `{ThemeResource}` brushes pointing at the freshly-rebuilt color values across the wipe. On the seed-color-change path the brush tracker compensated for the wipe; on hot reload, however, **there was nothing wiring the rebuild to the runtime's HR pass**, so brushes never got the new colors.
 
 Post-fix `UpdateSource` keeps the URI-backed layer intact and only manages the *dynamic* layers it owns:
 
@@ -86,7 +86,7 @@ Consequence: the brush-tracking pass (`CollectBrushes`, `CollectBrushEntries`, `
 - `GetSimpleColorOverride` merged the consumer `colorOverride` on top of `Uno.Simple.WinUI/Styles/Application/ColorPalette.xaml`.
 - `GenerateSpecificResources` returned a fresh `ResourceDictionary` whose merged graph stitched together `MergedPages`, `Thickness`, and `Fonts` (plus the font override).
 
-Both methods exist *only* because the base class used to require subclasses to materialise their full static layer per rebuild. With the new "set `Source` once" contract the static layer comes from the merged-pages XAML directly, and a new `src/library/Uno.Simple.WinUI/Styles/Application/BaseDictionaries.xaml` file gathers the shared converters / typography / palette / shared-colours plus Simple's own fonts, thickness and grayscale palette in the correct precedence order:
+Both methods exist *only* because the base class used to require subclasses to materialise their full static layer per rebuild. With the new "set `Source` once" contract the static layer comes from the merged-pages XAML directly, and a new `src/library/Uno.Simple.WinUI/Styles/Application/BaseDictionaries.xaml` file gathers the shared converters / typography / palette / shared-colors plus Simple's own fonts, thickness and grayscale palette in the correct precedence order:
 
 ```xml
 <ResourceDictionary.MergedDictionaries>
@@ -182,12 +182,12 @@ These run under the existing `Uno.UI.RuntimeTests.Engine` host inside `SimpleSam
 - `BaseTheme.cs` — Source-once + `_dynamicDictionaries` model. Removed `_originalBrushes` / `_isInResourceTree`. Replaced abstract `GenerateSpecificResources` with abstract `DefaultStylesSource`.
 - `BaseTheme.SeedColors.cs` — removed `CollectBrushes`, `CollectBrushEntries`, `UpdateOldBrushes`, `IsInResourceTree`, `IsReachableFrom` (no longer needed under the non-destructive rebuild).
 - `ColorGeneration/Hct/HctColor.cs` — `[SuppressMessage(CA1815)]` justification for not implementing `Equals` on the value type (transient computation result; equality not part of the consumer contract).
-- `Converters/FromBoolToValueConverter.cs`, `Converters/StringFormatConverter.cs` — `CultureInfo.InvariantCulture` passed explicitly to `Convert.ToBoolean` / `string.Format` to silence the culture analyser without behaviour change.
+- `Converters/FromBoolToValueConverter.cs`, `Converters/StringFormatConverter.cs` — `CultureInfo.InvariantCulture` passed explicitly to `Convert.ToBoolean` / `string.Format` to silence the culture analyzer without behavior change.
 
 ### `src/library/Uno.Simple.WinUI/`
 
 - `SimpleTheme.cs` — collapsed to `DefaultPrimarySeed` / `UseHighFidelityColors` / `DefaultStylesSource`. Removed `GetSimpleColorOverride` and `GenerateSpecificResources`.
-- `Styles/Application/BaseDictionaries.xaml` (new) — static base layer (shared converters/typography/palette/colours + Simple fonts/thickness/grayscale palette), picked up by the existing `XamlMergeInput` glob in `simple-common.props`.
+- `Styles/Application/BaseDictionaries.xaml` (new) — static base layer (shared converters/typography/palette/colors + Simple fonts/thickness/grayscale palette), picked up by the existing `XamlMergeInput` glob in `simple-common.props`.
 
 ### `src/library/Uno.Material/`
 
@@ -248,6 +248,6 @@ The earlier debugging instrumentation (three `Console.WriteLine($"[STEVE] …")`
 ## Related Specs
 
 - `specs/01-design-tokens/` — token model the dynamic spacing/shape/density layers regenerate from.
-- `specs/02-semantic-brushes/` — brush layer that consumes the regenerated colour palette.
+- `specs/02-semantic-brushes/` — brush layer that consumes the regenerated color palette.
 - `specs/03-seed-color-palette/` — seed-driven palette generation; one of the dynamic layers `UpdateSource` rebuilds.
 - `uno-private/specs/043-hotreload-resource-dictionary-refresh/` — framework-side counterpart that makes the source-backed entries inside a `BaseTheme` reachable for the in-place refresh.

--- a/src/library/Uno.Material/MaterialTheme.cs
+++ b/src/library/Uno.Material/MaterialTheme.cs
@@ -22,11 +22,11 @@ namespace Uno.Material;
 public class MaterialTheme : BaseTheme
 {
 	/// <summary>
-	/// Default primary seed color that generates the standard Material color palette.
-	/// When no explicit <see cref="ThemeColors.PrimarySeed"/> is set, this seed is
-	/// used so that seed color generation is always active.
+	/// Material uses the default Material color palette (SharedColorPalette.xaml)
+	/// when no seed is set. Seed color generation only runs when a user
+	/// explicitly sets <see cref="ThemeColors.PrimarySeed"/>.
 	/// </summary>
-	protected override Color? DefaultPrimarySeed { get; } = Color.FromArgb(0xFF, 0x59, 0x46, 0xD2);
+	protected override Color? DefaultPrimarySeed => null;
 	public MaterialTheme()
 	{ }
 

--- a/src/samples/MaterialSampleApp/RuntimeTests/Given_DefaultPalette.cs
+++ b/src/samples/MaterialSampleApp/RuntimeTests/Given_DefaultPalette.cs
@@ -1,0 +1,125 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Material;
+using Uno.Themes;
+using Uno.UI.RuntimeTests;
+using Windows.UI;
+
+namespace Uno.Themes.Samples.RuntimeTests;
+
+/// <summary>
+/// Verifies that a default MaterialTheme (no seed configured) resolves the
+/// default Material palette from SharedColorPalette.xaml, and that seed
+/// generation only activates when a PrimarySeed is explicitly set.
+/// This guards against regressions where an implicit default seed (or a
+/// change to the generation algorithm) silently shifts the default colors
+/// of every Material app — see unoplatform/uno.toolkit.ui#1606.
+/// </summary>
+[TestClass]
+public class Given_DefaultPalette
+{
+	// Default Material primaries from SharedColorPalette.xaml.
+	private static readonly Color DefaultPrimaryLight = Color.FromArgb(0xFF, 0x59, 0x46, 0xD2);
+	private static readonly Color DefaultPrimaryDark = Color.FromArgb(0xFF, 0xC7, 0xBF, 0xFF);
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_NoSeedConfigured_Then_PrimaryColorIsDefaultPalette()
+	{
+		var theme = new MaterialTheme();
+
+		var container = new Grid();
+		container.Resources.MergedDictionaries.Add(theme);
+
+		Assert.IsTrue(
+			container.Resources.TryGetValue("PrimaryColor", out var colorVal),
+			"PrimaryColor should be resolvable from the theme");
+
+		// The ambient theme (Light/Dark) at test time is host-dependent, so
+		// accept either default tone; a seed-generated tone matches neither.
+		var color = (Color)colorVal;
+		Assert.IsTrue(
+			color == DefaultPrimaryLight || color == DefaultPrimaryDark,
+			$"A default MaterialTheme must resolve the default Material primary " +
+			$"(#{DefaultPrimaryLight} or #{DefaultPrimaryDark}), but got #{color} — " +
+			"a seed-generated tone must not apply without an explicit PrimarySeed.");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_NoSeedConfigured_Then_ButtonUsesDefaultPalette()
+	{
+		var theme = new MaterialTheme();
+
+		var container = new Grid();
+		container.Resources.MergedDictionaries.Add(theme);
+
+		var style = container.Resources["FilledButtonStyle"] as Style;
+		Assert.IsNotNull(style, "FilledButtonStyle should resolve from theme");
+
+		var button = new Button { Content = "Test", Style = style };
+		container.Children.Add(button);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(button);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		// Theme brushes only re-materialize when the root element's theme
+		// changes, so drive the XamlRoot content like an app theme switch.
+		var root = (FrameworkElement)container.XamlRoot!.Content!;
+		var initialTheme = root.RequestedTheme;
+		try
+		{
+			foreach (var (elementTheme, expected) in new[]
+			{
+				(ElementTheme.Light, DefaultPrimaryLight),
+				(ElementTheme.Dark, DefaultPrimaryDark),
+			})
+			{
+				root.RequestedTheme = elementTheme;
+				await UnitTestsUIContentHelper.WaitForIdle();
+
+				var bg = button.Background as SolidColorBrush;
+				Assert.IsNotNull(bg, "Button should have a SolidColorBrush Background");
+
+				Assert.AreEqual(expected, bg.Color,
+					$"[{elementTheme}] Expected the default Material primary #{expected} but got #{bg.Color}. " +
+					"A default MaterialTheme must not use seed-generated colors.");
+			}
+		}
+		finally
+		{
+			root.RequestedTheme = initialTheme;
+			await UnitTestsUIContentHelper.WaitForIdle();
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_PrimarySeedExplicitlySet_Then_GenerationActivates()
+	{
+		// Seeding with the default primary itself must still produce generated
+		// tones (M3 tone steps), proving generation is opt-in rather than a
+		// pass-through of the seed. The exact generated value is intentionally
+		// not pinned so the algorithm can evolve.
+		var theme = new MaterialTheme
+		{
+			Colors = new ThemeColors { PrimarySeed = DefaultPrimaryLight },
+		};
+
+		var container = new Grid();
+		container.Resources.MergedDictionaries.Add(theme);
+
+		Assert.IsTrue(
+			container.Resources.TryGetValue("PrimaryColor", out var colorVal),
+			"PrimaryColor should be resolvable from the theme");
+
+		var color = (Color)colorVal;
+		Assert.IsTrue(
+			color != DefaultPrimaryLight && color != DefaultPrimaryDark,
+			"Setting an explicit PrimarySeed should activate palette generation " +
+			$"and replace the default Material primaries, but got #{color}.");
+	}
+}

--- a/src/samples/MaterialSampleApp/RuntimeTests/Given_DefaultPalette.cs
+++ b/src/samples/MaterialSampleApp/RuntimeTests/Given_DefaultPalette.cs
@@ -67,8 +67,10 @@ public class Given_DefaultPalette
 		await UnitTestsUIContentHelper.WaitForIdle();
 
 		// Theme brushes only re-materialize when the root element's theme
-		// changes, so drive the XamlRoot content like an app theme switch.
-		var root = (FrameworkElement)container.XamlRoot!.Content!;
+		// changes — setting RequestedTheme on the container subtree is not
+		// enough — so drive the XamlRoot content like an app theme switch.
+		var root = container.XamlRoot?.Content as FrameworkElement;
+		Assert.IsNotNull(root, "The loaded container should expose the XamlRoot content");
 		var initialTheme = root.RequestedTheme;
 		try
 		{
@@ -100,13 +102,13 @@ public class Given_DefaultPalette
 	[RunsOnUIThread]
 	public void When_PrimarySeedExplicitlySet_Then_GenerationActivates()
 	{
-		// Seeding with the default primary itself must still produce generated
-		// tones (M3 tone steps), proving generation is opt-in rather than a
-		// pass-through of the seed. The exact generated value is intentionally
-		// not pinned so the algorithm can evolve.
+		// A seed far from the default palette guarantees the generated tones
+		// differ from the default primaries. The exact generated value is
+		// intentionally not pinned so the algorithm can evolve.
+		var seed = Color.FromArgb(0xFF, 0xFF, 0x00, 0x00);
 		var theme = new MaterialTheme
 		{
-			Colors = new ThemeColors { PrimarySeed = DefaultPrimaryLight },
+			Colors = new ThemeColors { PrimarySeed = seed },
 		};
 
 		var container = new Grid();


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.toolkit.ui/issues/1606

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Documentation content changes

## Description

On the 7.0 dev line, `MaterialTheme` resolved a different default Material primary than stable (`#5946D2`/`#C7BFFF` → `#594DB4`/`#C5BDFF`). The root cause is the combination of the built-in default primary seed (#1657) and the BaseTheme resource-management rework (#1680): the rework made the always-active default seed palette effectively take precedence over the default Material palette (`SharedColorPalette.xaml`), silently shifting every color role of apps that never opted into seed colors. This surfaced as the `ThemeInitTests.Override_Colors` failures on the Toolkit nightly builds (unoplatform/uno.toolkit.ui#1606).

This PR makes seed color generation opt-in for `MaterialTheme`, consistent with `SimpleTheme` (#1662):

- `MaterialTheme.DefaultPrimarySeed` now returns `null`; the generator only runs when `Colors.PrimarySeed` is explicitly set. Changes to the generation algorithm can therefore never shift the default palette.
- `SemanticThemeHelper.PrimarySeed = null` now reverts to the default palette instead of re-seeding.
- Added `Given_DefaultPalette` runtime tests guarding the default primary (resource-level and rendered `Button`, Light + Dark) and asserting that an explicit seed still activates generation.
- Updated `doc/seed-colors.md` and the seed-color spec to reflect the opt-in behavior for both themes.

## Other information

Verified with a full red/fix/green cycle on Skia Desktop:

- Without the fix, the new `Given_DefaultPalette` tests fail with the exact values from the Toolkit CI failure (`#FF594DB4` light / `#FFC5BDFF` dark).
- With the fix, the MaterialSampleApp runtime test suite passes (37/37).
- Cross-repo: the Toolkit's `ThemeInitTests` were run against a locally packed `Uno.Themes.WinUI`/`Uno.Material.WinUI` containing this fix — they pass, on the same package line that fails with `7.0.0-dev.40`.

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
