### PR TITLE
fix(deps): Pin Uno.Fonts.Inter to stable 2.9.4 for 6.6 SR2

### DIFF
--- a/src/library/Directory.Packages.props
+++ b/src/library/Directory.Packages.props
@@ -14,7 +14,7 @@
 		<PackageVersion Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
 		<PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
 		<PackageVersion Include="Uno.Extensions.Markup.Generators" Version="5.2.0-dev.61" />
-		<PackageVersion Include="Uno.Fonts.Inter" Version="2.9.0-dev.12" />
+		<PackageVersion Include="Uno.Fonts.Inter" Version="2.9.4" />
 		<PackageVersion Include="Uno.Fonts.Roboto" Version="2.2.2" />
 		<PackageVersion Include="Uno.WinUI.Markup" Version="5.2.0-dev.61" />
 		<PackageVersion Include="Uno.XamlMerge.Task" Version="$(_Uno_XamlMerge_Task_Version)" />


### PR DESCRIPTION
## Summary

Pin `Uno.Fonts.Inter` from the dev `2.9.0-dev.12` to the stable **`2.9.4`** on `release/stable/7.0`, for the **6.6 SR2** Simple design system.

`Uno.Fonts.Inter` is Simple's typeface and is referenced as a plain `PackageReference` in `src/library/Uno.Simple.WinUI/simple-common.props` (no `PrivateAssets`), so it **flows to consumer apps** that use Simple. Shipping a stable Themes `7.0.x` with a `-dev` font dependency would surface a dev package in released apps — this pins it to the stable `Uno.Fonts.Inter 2.9.4` published from `uno.fonts` [`release/stable/2.9`](https://github.com/unoplatform/uno.fonts/tree/release/stable/2.9).

## Scope

Only `Uno.Fonts.Inter` is changed. The other `-dev` pins in `src/library/Directory.Packages.props` are intentionally left as-is, matching the previous stable [`release/stable/6.1`](https://github.com/unoplatform/Uno.Themes/tree/release/stable/6.1):

- `Uno.Extensions.Markup.Generators` and `Uno.XamlMerge.Task` are referenced with `PrivateAssets="All"` (build-time only, do not flow to apps).
- `Uno.WinUI.Markup 5.2.0-dev.61` is published on nuget.org (resolvable) and unchanged from what `6.1` shipped.

_(If the team wants `Uno.WinUI.Markup` / `Uno.Extensions.Markup.Generators` finalized to the SR2 C# Markup stable as well, that's a separate call — the SR2 markup `6.6.31` isn't on nuget.org yet, latest published stable is `6.6.29`.)_

Related to https://github.com/unoplatform/private/issues/1102