### PR TITLE
docs: add v7 migration section to upgrading guide

### DIFF
--- a/doc/design-tokens.md
+++ b/doc/design-tokens.md
@@ -1,3 +1,7 @@
+---
+uid: Uno.Themes.DesignTokens
+---
+
 # Design Tokens & Override Surface
 
 Uno.Themes exposes a set of **shared design tokens** — semantic XAML resources for typography, spacing, shape (corner radius), and density (control height / icon size). These tokens are consumed by all control templates, so overriding a single token key globally affects every control that references it.

--- a/doc/material-migration.md
+++ b/doc/material-migration.md
@@ -24,34 +24,11 @@ Cupertino styles are unchanged in v7.
 
 ### Packages and dependencies
 
-#### UWP-lineage packages discontinued
-
-The legacy UWP package IDs are no longer produced as of 7.0:
-
-| Discontinued Package | Replacement           |
-| -------------------- | --------------------- |
-| `Uno.Themes`         | `Uno.Themes.WinUI`    |
-| `Uno.Material`       | `Uno.Material.WinUI`  |
-| `Uno.Cupertino`      | `Uno.Cupertino.WinUI` |
-
-Apps using the Uno SDK with `UnoFeatures` (for example `<UnoFeatures>Material</UnoFeatures>`) already reference the WinUI packages and are unaffected. The legacy IDs were last published as stable in the 5.x line (5.7.3), and the remaining UWP support was removed from the codebase in 7.0 — resource keys that shipped exclusively in the UWP packages (the `MaterialWUX*` NavigationView styles, among others) are gone with it. UWP-only consumers should stay on the last published 5.x packages.
-
-#### Minimum dependency versions
-
-The libraries are now built with the Uno SDK. If your app uses the Uno SDK with `UnoFeatures`, package versions are managed automatically and no action is needed. Apps pinning package versions manually should note the new minimums:
-
-| Dependency                                            | 6.1.x  | 7.0.x   |
-| ----------------------------------------------------- | ------ | ------- |
-| `Uno.WinUI`                                           | 5.0.19 | 6.4.229 |
-| `SkiaSharp.Views.Uno.WinUI` (Material and Cupertino)  | —      | 3.119.1 |
-| `Uno.Fonts.Roboto` (Material)                         | —      | 2.2.2   |
+Uno Themes 7.0 requires Uno.WinUI 6.4.229 or later. If your app uses the Uno SDK with `UnoFeatures` (for example `<UnoFeatures>Material</UnoFeatures>`), package versions are managed automatically and no action is needed; apps pinning package versions manually should update `Uno.WinUI` accordingly.
 
 #### macOS and Mac Catalyst targets removed
 
 The 6.1 packages shipped `net9.0-macos` and `net9.0-maccatalyst` binaries; 7.0 does not. Apps with macOS or Mac Catalyst heads will now resolve the plain `net9.0` assets. Move these heads to the Skia Desktop target (`net9.0-desktop`) instead.
-
-> [!NOTE]
-> Lottie animations (used by the Material `ProgressRing`) are now referenced through the `Lottie` UnoFeature internally. `Uno.WinUI.Lottie` still flows transitively to your app — no action is needed.
 
 ### BaseTheme API changes
 
@@ -88,9 +65,7 @@ protected override void AddThemeSpecificResources()
 }
 ```
 
-### Color configuration changes
-
-#### `ColorOverrideSource` and `ColorOverrideDictionary` deprecated
+### `ColorOverrideSource` and `ColorOverrideDictionary` deprecated
 
 Color configuration is now grouped on the new `Colors` property, a `ThemeColors` object that also hosts the seed color properties. The legacy properties are deprecated but still work — they write through to the corresponding `Colors` members internally:
 
@@ -120,30 +95,17 @@ After:
 > [!NOTE]
 > `FontOverrideSource` and `FontOverrideDictionary` are not deprecated and keep working unchanged. Avoid mixing the legacy color properties with `Colors` on the same theme instance — they share the same underlying override slots and the last one set wins.
 
-#### Color override precedence
-
-With seed color generation in the pipeline, the final palette is assembled in the following precedence order (highest wins):
-
-1. **`ThemeColors.OverrideDictionary`** (or `OverrideSource`) — explicit overrides, including values set through the deprecated legacy properties
-2. **Seed-generated palette** — only when a seed color is explicitly set
-3. **Theme base colors** — Material's built-in defaults or Simple's grayscale palette
-4. **`SharedColorPalette`** — library defaults
-
 > [!IMPORTANT]
-> Seed generation is opt-in and no theme sets a default seed, so an upgraded app renders with exactly the same colors as 6.1, and explicit color overrides keep winning over everything else — including seed-generated palettes.
-
-For details, see [Color Precedence](seed-colors.md#color-precedence).
+> Seed generation is opt-in and no theme sets a default seed, so an upgraded app renders with exactly the same colors as 6.1, and explicit color overrides keep winning over everything else — including seed-generated palettes. For the full precedence order, see [Color Precedence](seed-colors.md#color-precedence).
 
 ### Typography and font overrides
 
-The type scale (`DisplayLarge*` through `LabelSmall*`) now ships in the base Uno Themes library, together with two new root typeface tokens that cascade through the whole scale:
+Existing Material font overrides (`MaterialRegularFontFamily` / `MaterialMediumFontFamily`) continue to work. For overrides meant to apply across design systems, prefer the new root typeface tokens, which cascade through the whole type scale — see [Typography](semantic-styles.md#typography):
 
 | Legacy key (Material-specific) | Portable token  | Cascades to                 |
 | ------------------------------ | --------------- | --------------------------- |
 | `MaterialRegularFontFamily`    | `TypefacePlain` | Display, Headline           |
 | `MaterialMediumFontFamily`     | `TypefaceBrand` | Title, Label, Body, Caption |
-
-Existing font overrides that redefine `MaterialRegularFontFamily` / `MaterialMediumFontFamily` (for example via `FontOverrideSource`) continue to work for Material. For new code — or overrides meant to apply across design systems — prefer overriding `TypefacePlain` and `TypefaceBrand`. See [Typography](semantic-styles.md#typography) and [Design Tokens](design-tokens.md).
 
 ### Material style changes
 
@@ -180,15 +142,9 @@ Material v2 sizing, spacing, and corner-radius resources are no longer hard-code
 
 Roughly forty keys across all Material v2 controls follow this pattern. Because the values are now derived, the new `DefaultDensity` (`Compact` / `Regular` / `Comfy`) and `DefaultCornerRadius` theme properties reshape every Material control globally. See [Design Tokens](design-tokens.md).
 
-### Converter behavior changes
+### `StringFormatConverter` is now culture-aware
 
-- `StringFormatConverter` now formats using the binding's `ConverterLanguage` (a BCP-47 tag), falling back to `CultureInfo.CurrentCulture` — previously it used the invariant culture. Culture-sensitive formats such as `{0:d}` now render localized; set `ConverterLanguage` on the binding to pin a specific culture.
-- `FromBoolToValueConverter` now converts its input with `CultureInfo.InvariantCulture` explicitly.
-
-### Other notable changes
-
-- `ResourceDictionary` instances you add to a theme instance's `MergedDictionaries` now survive theme rebuilds. In 6.1, changing any theme property cleared and rebuilt all merged dictionaries, discarding consumer-added entries.
-- Theme resources now participate in XAML Hot Reload: edits to theme resource dictionaries are applied to running apps.
+`StringFormatConverter` now formats using the binding's `ConverterLanguage` (a BCP-47 tag), falling back to `CultureInfo.CurrentCulture` — previously it used the invariant culture. Culture-sensitive formats such as `{0:d}` now render localized; set `ConverterLanguage` on the binding to pin a specific culture.
 
 ## Upgrading to Uno Themes v5
 

--- a/doc/material-migration.md
+++ b/doc/material-migration.md
@@ -7,6 +7,189 @@ uid: Uno.Themes.Material.Migration
 > [!IMPORTANT]
 > UnoFeatures: **Material** — add `<UnoFeatures>Material</UnoFeatures>` to your app's `.csproj` to include Uno Material resources.
 
+## Upgrading to Uno Themes v7
+
+Uno Themes 7.0 introduces the Simple design system, the theme-agnostic Semantic Design Language, design tokens, and opt-in seed color generation. Visual defaults are unchanged — no semantic color or brush resource key was renamed or removed, and seed generation is off unless you enable it — so most apps upgrade without code changes. The sections below cover the changes that may require action.
+
+### What's new in v7
+
+- **Simple theme**: new `Uno.Simple.WinUI` and `Uno.Simple.WinUI.Markup` packages providing a minimal, density-driven design system. See [Simple - Getting Started](simple-getting-started.md).
+- **Semantic Design Language**: design-system-agnostic style aliases (`FilledButtonStyle`, `OutlinedTextBoxStyle`, …) shared by Material and Simple, so apps can switch design systems without changing style keys. See [Semantic Design Language](semantic-styles.md).
+- **Design tokens**: spacing (`Space*`), shape (`Radius*`), and density (`ControlHeight*`, `IconSize*`) tokens, driven globally by the new `DefaultDensity` and `DefaultCornerRadius` theme properties. See [Design Tokens](design-tokens.md).
+- **Seed color generation** (opt-in): generate a full palette from one or more seed colors via the new `Colors` property (`ThemeColors`) and `SemanticThemeHelper`. See [Seed Color Palette](seed-colors.md).
+- **Control extensions**: new `ControlExtensions.LeadingIcon` and `ControlExtensions.TrailingIcon` attached properties; `ControlExtensions.Icon` keeps working and now forwards its value to `LeadingIcon`. See [Control Extensions](themes-control-extensions.md).
+- **XAML Hot Reload**: theme resources now participate in Hot Reload.
+
+Cupertino styles are unchanged in v7.
+
+### Packages and dependencies
+
+#### UWP-lineage packages discontinued
+
+The legacy UWP package IDs are no longer produced as of 7.0:
+
+| Discontinued Package | Replacement           |
+| -------------------- | --------------------- |
+| `Uno.Themes`         | `Uno.Themes.WinUI`    |
+| `Uno.Material`       | `Uno.Material.WinUI`  |
+| `Uno.Cupertino`      | `Uno.Cupertino.WinUI` |
+
+Apps using the Uno SDK with `UnoFeatures` (for example `<UnoFeatures>Material</UnoFeatures>`) already reference the WinUI packages and are unaffected. The legacy IDs were last published as stable in the 5.x line (5.7.3), and the remaining UWP support was removed from the codebase in 7.0 — resource keys that shipped exclusively in the UWP packages (the `MaterialWUX*` NavigationView styles, among others) are gone with it. UWP-only consumers should stay on the last published 5.x packages.
+
+#### Minimum dependency versions
+
+The libraries are now built with the Uno SDK. If your app uses the Uno SDK with `UnoFeatures`, package versions are managed automatically and no action is needed. Apps pinning package versions manually should note the new minimums:
+
+| Dependency                                            | 6.1.x  | 7.0.x   |
+| ----------------------------------------------------- | ------ | ------- |
+| `Uno.WinUI`                                           | 5.0.19 | 6.4.229 |
+| `SkiaSharp.Views.Uno.WinUI` (Material and Cupertino)  | —      | 3.119.1 |
+| `Uno.Fonts.Roboto` (Material)                         | —      | 2.2.2   |
+
+#### macOS and Mac Catalyst targets removed
+
+The 6.1 packages shipped `net9.0-macos` and `net9.0-maccatalyst` binaries; 7.0 does not. Apps with macOS or Mac Catalyst heads will now resolve the plain `net9.0` assets. Move these heads to the Skia Desktop target (`net9.0-desktop`) instead.
+
+> [!NOTE]
+> Lottie animations (used by the Material `ProgressRing`) are now referenced through the `Lottie` UnoFeature internally. `Uno.WinUI.Lottie` still flows transitively to your app — no action is needed.
+
+### BaseTheme API changes
+
+> [!IMPORTANT]
+> This section only affects code that subclasses `BaseTheme` to build a custom design system (for example, toolkit themes). Apps consuming `MaterialTheme`, `CupertinoTheme`, or `SimpleTheme` from XAML are not affected.
+
+`GenerateSpecificResources()` has been removed. Static control styles are now loaded once from the URI provided by `DefaultStylesSource`, and dynamic resource layers are appended via `AddThemeDictionary` inside `AddThemeSpecificResources()`, which is called at the end of every rebuild pass (theme property change or Hot Reload).
+
+Before:
+
+```csharp
+protected override ResourceDictionary GenerateSpecificResources()
+{
+    return new ResourceDictionary
+    {
+        Source = new Uri("ms-appx:///MyTheme/Generated/mergedpages.xaml")
+    };
+}
+```
+
+After:
+
+```csharp
+protected override string DefaultStylesSource =>
+    "ms-appx:///MyTheme/Generated/mergedpages.xaml";
+
+protected override void AddThemeSpecificResources()
+{
+    base.AddThemeSpecificResources();
+
+    // Only dictionaries that must shadow the static base layer belong here,
+    // e.g. a consumer-supplied font override.
+    AddThemeDictionary(myOverrides);
+}
+```
+
+### Color configuration changes
+
+#### `ColorOverrideSource` and `ColorOverrideDictionary` deprecated
+
+Color configuration is now grouped on the new `Colors` property, a `ThemeColors` object that also hosts the seed color properties. The legacy properties are deprecated but still work — they write through to the corresponding `Colors` members internally:
+
+| Deprecated member                    | Replacement                                  |
+| ------------------------------------ | -------------------------------------------- |
+| `BaseTheme.ColorOverrideSource`      | `OverrideSource` on `Colors` (`ThemeColors`) |
+| `BaseTheme.ColorOverrideDictionary`  | `OverrideDictionary` on `Colors` (`ThemeColors`) |
+
+Before:
+
+```xml
+<MaterialTheme xmlns="using:Uno.Material"
+               ColorOverrideSource="ms-appx:///Styles/ColorPaletteOverride.xaml" />
+```
+
+After:
+
+```xml
+<MaterialTheme xmlns="using:Uno.Material">
+    <MaterialTheme.Colors>
+        <ut:ThemeColors xmlns:ut="using:Uno.Themes"
+                        OverrideSource="ms-appx:///Styles/ColorPaletteOverride.xaml" />
+    </MaterialTheme.Colors>
+</MaterialTheme>
+```
+
+> [!NOTE]
+> `FontOverrideSource` and `FontOverrideDictionary` are not deprecated and keep working unchanged. Avoid mixing the legacy color properties with `Colors` on the same theme instance — they share the same underlying override slots and the last one set wins.
+
+#### Color override precedence
+
+With seed color generation in the pipeline, the final palette is assembled in the following precedence order (highest wins):
+
+1. **`ThemeColors.OverrideDictionary`** (or `OverrideSource`) — explicit overrides, including values set through the deprecated legacy properties
+2. **Seed-generated palette** — only when a seed color is explicitly set
+3. **Theme base colors** — Material's built-in defaults or Simple's grayscale palette
+4. **`SharedColorPalette`** — library defaults
+
+> [!IMPORTANT]
+> Seed generation is opt-in and no theme sets a default seed, so an upgraded app renders with exactly the same colors as 6.1, and explicit color overrides keep winning over everything else — including seed-generated palettes.
+
+For details, see [Color Precedence](seed-colors.md#color-precedence).
+
+### Typography and font overrides
+
+The type scale (`DisplayLarge*` through `LabelSmall*`) now ships in the base Uno Themes library, together with two new root typeface tokens that cascade through the whole scale:
+
+| Legacy key (Material-specific) | Portable token  | Cascades to                 |
+| ------------------------------ | --------------- | --------------------------- |
+| `MaterialRegularFontFamily`    | `TypefacePlain` | Display, Headline           |
+| `MaterialMediumFontFamily`     | `TypefaceBrand` | Title, Label, Body, Caption |
+
+Existing font overrides that redefine `MaterialRegularFontFamily` / `MaterialMediumFontFamily` (for example via `FontOverrideSource`) continue to work for Material. For new code — or overrides meant to apply across design systems — prefer overriding `TypefacePlain` and `TypefaceBrand`. See [Typography](semantic-styles.md#typography) and [Design Tokens](design-tokens.md).
+
+### Material style changes
+
+#### Native mobile styles removed
+
+The Material v1 styles no longer template to native platform controls on iOS and Android:
+
+- `MaterialToggleSwitchStyle` and `MaterialSecondaryToggleSwitchStyle` (v1) previously rendered the native platform switch on iOS and Android; they now use the same XAML template on all platforms.
+- `MaterialCommandBarStyle` (v1) no longer templates to the native navigation bar on iOS and Android; command bars now render the XAML template on all platforms.
+
+| Removed Resource Key     |
+| ------------------------ |
+| NativeCommandBarTemplate |
+
+The XAML templates replace the native controls; their appearance and behavior are close to, but not pixel-identical with, the removed native representations.
+
+#### `AppBarButton` layout and text wrapping
+
+The Material `AppBarButton` content now stretches horizontally and its label wraps by default (long labels previously stayed on a single centered line), and the ripple effect now honors the control's `CornerRadius`. To restore the previous single-line behavior, override the new `AppBarButtonTextWrapping` resource via [Lightweight Styling](lightweight-styling.md):
+
+```xml
+<TextWrapping x:Key="AppBarButtonTextWrapping">NoWrap</TextWrapping>
+```
+
+#### Sizing resources are now design-token aliases
+
+Material v2 sizing, spacing, and corner-radius resources are no longer hard-coded literals — they alias the new global design tokens. All values are numerically identical to 6.1 at the default settings, and per-key [Lightweight Styling](lightweight-styling.md) overrides keep working. Representative examples:
+
+| Resource Key         | 6.1 value | Now aliases                   | Default value |
+| -------------------- | --------- | ----------------------------- | ------------- |
+| `ButtonMinHeight`    | `40`      | `ControlHeightMedium`         | `40`          |
+| `ButtonPadding`      | `16,0`    | `Space400HorizontalThickness` | `16,0`        |
+| `ButtonCornerRadius` | `20`      | `Radius500CornerRadius`       | `20`          |
+
+Roughly forty keys across all Material v2 controls follow this pattern. Because the values are now derived, the new `DefaultDensity` (`Compact` / `Regular` / `Comfy`) and `DefaultCornerRadius` theme properties reshape every Material control globally. See [Design Tokens](design-tokens.md).
+
+### Converter behavior changes
+
+- `StringFormatConverter` now formats using the binding's `ConverterLanguage` (a BCP-47 tag), falling back to `CultureInfo.CurrentCulture` — previously it used the invariant culture. Culture-sensitive formats such as `{0:d}` now render localized; set `ConverterLanguage` on the binding to pin a specific culture.
+- `FromBoolToValueConverter` now converts its input with `CultureInfo.InvariantCulture` explicitly.
+
+### Other notable changes
+
+- `ResourceDictionary` instances you add to a theme instance's `MergedDictionaries` now survive theme rebuilds. In 6.1, changing any theme property cleared and rebuilt all merged dictionaries, discarding consumer-added entries.
+- Theme resources now participate in XAML Hot Reload: edits to theme resource dictionaries are applied to running apps.
+
 ## Upgrading to Uno Themes v5
 
 The Uno Material v5 packages introduce a new dependency on the [Uno Themes](https://www.nuget.org/packages/Uno.Themes.WinUI) package. Uno Themes is the base library for all design system implementations going forward. As a result, the following changes have been made:

--- a/doc/material-migration.md
+++ b/doc/material-migration.md
@@ -26,44 +26,11 @@ Cupertino styles are unchanged in v7.
 
 Uno Themes 7.0 requires Uno.WinUI 6.4.229 or later. If your app uses the Uno SDK with `UnoFeatures` (for example `<UnoFeatures>Material</UnoFeatures>`), package versions are managed automatically and no action is needed; apps pinning package versions manually should update `Uno.WinUI` accordingly.
 
-#### macOS and Mac Catalyst targets removed
-
-The 6.1 packages shipped `net9.0-macos` and `net9.0-maccatalyst` binaries; 7.0 does not. Apps with macOS or Mac Catalyst heads will now resolve the plain `net9.0` assets. Move these heads to the Skia Desktop target (`net9.0-desktop`) instead.
+The packages no longer include macOS and Mac Catalyst (`net9.0-macos` / `net9.0-maccatalyst`) binaries. Move these heads to the Skia Desktop target (`net9.0-desktop`) instead.
 
 ### BaseTheme API changes
 
-> [!IMPORTANT]
-> This section only affects code that subclasses `BaseTheme` to build a custom design system (for example, toolkit themes). Apps consuming `MaterialTheme`, `CupertinoTheme`, or `SimpleTheme` from XAML are not affected.
-
-`GenerateSpecificResources()` has been removed. Static control styles are now loaded once from the URI provided by `DefaultStylesSource`, and dynamic resource layers are appended via `AddThemeDictionary` inside `AddThemeSpecificResources()`, which is called at the end of every rebuild pass (theme property change or Hot Reload).
-
-Before:
-
-```csharp
-protected override ResourceDictionary GenerateSpecificResources()
-{
-    return new ResourceDictionary
-    {
-        Source = new Uri("ms-appx:///MyTheme/Generated/mergedpages.xaml")
-    };
-}
-```
-
-After:
-
-```csharp
-protected override string DefaultStylesSource =>
-    "ms-appx:///MyTheme/Generated/mergedpages.xaml";
-
-protected override void AddThemeSpecificResources()
-{
-    base.AddThemeSpecificResources();
-
-    // Only dictionaries that must shadow the static base layer belong here,
-    // e.g. a consumer-supplied font override.
-    AddThemeDictionary(myOverrides);
-}
-```
+This only affects code that subclasses `BaseTheme` to build a custom design system — apps consuming `MaterialTheme`, `CupertinoTheme`, or `SimpleTheme` from XAML are unaffected. `GenerateSpecificResources()` has been removed: provide the static styles URI through the new `DefaultStylesSource` property, and append dynamic resource dictionaries with `AddThemeDictionary()` from an `AddThemeSpecificResources()` override.
 
 ### `ColorOverrideSource` and `ColorOverrideDictionary` deprecated
 
@@ -93,7 +60,7 @@ After:
 ```
 
 > [!NOTE]
-> `FontOverrideSource` and `FontOverrideDictionary` are not deprecated and keep working unchanged. Avoid mixing the legacy color properties with `Colors` on the same theme instance — they share the same underlying override slots and the last one set wins.
+> `FontOverrideSource` and `FontOverrideDictionary` are not deprecated and keep working unchanged.
 
 > [!IMPORTANT]
 > Seed generation is opt-in and no theme sets a default seed, so an upgraded app renders with exactly the same colors as 6.1, and explicit color overrides keep winning over everything else — including seed-generated palettes. For the full precedence order, see [Color Precedence](seed-colors.md#color-precedence).
@@ -111,16 +78,7 @@ Existing Material font overrides (`MaterialRegularFontFamily` / `MaterialMediumF
 
 #### Native mobile styles removed
 
-The Material v1 styles no longer template to native platform controls on iOS and Android:
-
-- `MaterialToggleSwitchStyle` and `MaterialSecondaryToggleSwitchStyle` (v1) previously rendered the native platform switch on iOS and Android; they now use the same XAML template on all platforms.
-- `MaterialCommandBarStyle` (v1) no longer templates to the native navigation bar on iOS and Android; command bars now render the XAML template on all platforms.
-
-| Removed Resource Key     |
-| ------------------------ |
-| NativeCommandBarTemplate |
-
-The XAML templates replace the native controls; their appearance and behavior are close to, but not pixel-identical with, the removed native representations.
+On iOS and Android, the Material v1 `ToggleSwitch` styles and `MaterialCommandBarStyle` no longer render the native platform controls — they now use the same XAML templates as all other platforms, which are close to, but not pixel-identical with, the native look. The `NativeCommandBarTemplate` resource key has been removed.
 
 #### `AppBarButton` layout and text wrapping
 

--- a/doc/material-migration.md
+++ b/doc/material-migration.md
@@ -59,8 +59,7 @@ After:
 </MaterialTheme>
 ```
 
-> [!NOTE]
-> `FontOverrideSource` and `FontOverrideDictionary` are not deprecated and keep working unchanged.
+`FontOverrideSource` and `FontOverrideDictionary` are not deprecated and keep working unchanged.
 
 > [!IMPORTANT]
 > Seed generation is opt-in and no theme sets a default seed, so an upgraded app renders with exactly the same colors as 6.1, and explicit color overrides keep winning over everything else — including seed-generated palettes. For the full precedence order, see [Color Precedence](seed-colors.md#color-precedence).
@@ -78,7 +77,7 @@ Existing Material font overrides (`MaterialRegularFontFamily` / `MaterialMediumF
 
 #### Native mobile styles removed
 
-On iOS and Android, the Material v1 `ToggleSwitch` styles and `MaterialCommandBarStyle` no longer render the native platform controls — they now use the same XAML templates as all other platforms, which are close to, but not pixel-identical with, the native look. The `NativeCommandBarTemplate` resource key has been removed.
+On iOS and Android, the Material v1 `ToggleSwitch` styles and `MaterialCommandBarStyle` no longer render the native platform controls — they now use the same XAML templates as all other platforms, which are close to, but not pixel-identical to, the native look. The `NativeCommandBarTemplate` resource key has been removed.
 
 #### `AppBarButton` layout and text wrapping
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1689

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## Description

Adds an "Upgrading to Uno Themes v7" section to the migration guide (`doc/material-migration.md`), documenting the 6.1 → 7.0 changes:

- UWP-lineage packages (`Uno.Themes`, `Uno.Material`, `Uno.Cupertino`) discontinued in favor of the `*.WinUI` IDs
- New minimum dependency versions (Uno.WinUI 5.0.19 → 6.4.229) and removal of the macOS / Mac Catalyst targets
- `BaseTheme.GenerateSpecificResources()` replaced by `DefaultStylesSource` / `AddThemeSpecificResources()` / `AddThemeDictionary()`
- `ColorOverrideSource` / `ColorOverrideDictionary` deprecated in favor of `Colors` (`ThemeColors`), plus the color override precedence order with opt-in seed generation
- Typography guidance for the new `TypefacePlain` / `TypefaceBrand` tokens (legacy Material font-override keys keep working)
- Material style changes: native mobile ToggleSwitch/CommandBar styles removed, `AppBarButton` text wrapping (with `AppBarButtonTextWrapping` opt-out), sizing resources now design-token aliases driven by `DefaultDensity` / `DefaultCornerRadius`
- Converter culture behavior changes and a short "What's new in v7" overview linking the Simple, Semantic Styles, Design Tokens, and Seed Colors docs

Also adds the missing `uid:` front-matter to `doc/design-tokens.md`.

## Other information

Documentation-only change. Should also be brought to `release/stable/7.0` so the stable docs site picks it up. A companion correction to the Toolkit 9.0 migration guide is being submitted in uno.toolkit.ui.
