### PR TITLE
Version bump after 7.1 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "7.1-dev.{height}",
+  "version": "7.2-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "7.1-dev.{height}",
+  "version": "7.1",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1689

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## Description

Adds an "Upgrading to Uno Themes v7" section to the migration guide (`doc/material-migration.md`), documenting the 6.1 → 7.0 changes:

- UWP-lineage packages (`Uno.Themes`, `Uno.Material`, `Uno.Cupertino`) discontinued in favor of the `*.WinUI` IDs
- New minimum dependency versions (Uno.WinUI 5.0.19 → 6.4.229) and removal of the macOS / Mac Catalyst targets
- `BaseTheme.GenerateSpecificResources()` replaced by `DefaultStylesSource` / `AddThemeSpecificResources()` / `AddThemeDictionary()`
- `ColorOverrideSource` / `ColorOverrideDictionary` deprecated in favor of `Colors` (`ThemeColors`), plus the color override precedence order with opt-in seed generation
- Typography guidance for the new `TypefacePlain` / `TypefaceBrand` tokens (legacy Material font-override keys keep working)
- Material style changes: native mobile ToggleSwitch/CommandBar styles removed, `AppBarButton` text wrapping (with `AppBarButtonTextWrapping` opt-out), sizing resources now design-token aliases driven by `DefaultDensity` / `DefaultCornerRadius`
- Converter culture behavior changes and a short "What's new in v7" overview linking the Simple, Semantic Styles, Design Tokens, and Seed Colors docs

Also adds the missing `uid:` front-matter to `doc/design-tokens.md`.

## Other information

Documentation-only change. Should also be brought to `release/stable/7.0` so the stable docs site picks it up. A companion correction to the Toolkit 9.0 migration guide is being submitted in uno.toolkit.ui.

This is an automated version bump of the  **master** branch after the creation of the release branch release/stable/7.1, based on #1690