### PR TITLE
Material and Simple TimePicker/DatePicker

### DIFF
--- a/doc/lightweight-styling.md
+++ b/doc/lightweight-styling.md
@@ -227,6 +227,7 @@ For more information about the lightweight styling resource keys used in each co
 - [Slider](styles/Slider.md)
 - [TextBlock](styles/TextBlock.md)
 - [TextBox](styles/TextBox.md)
+- [TimePicker](styles/TimePicker.md)
 - [ToggleButton](styles/ToggleButton.md)
 - [ToggleSwitch](styles/ToggleSwitch.md)
 

--- a/doc/material-controls-styles.md
+++ b/doc/material-controls-styles.md
@@ -74,6 +74,8 @@ uid: Uno.Themes.Material.Styles
 | `TextBlock`               | `CaptionSmall`                  |                  |
 | `TextBox`                 | `FilledTextBoxStyle`            |                  |
 | `TextBox`                 | `OutlinedTextBoxStyle`          | True             |
+| `TimePicker`              | `TimePickerStyle`               | True             |
+| `TimePickerFlyoutPresenter` | `TimePickerFlyoutPresenterStyle` | True          |
 | `ToggleButton`            | `TextToggleButtonStyle`         |                  |
 | `ToggleButton`            | `IconToggleButtonStyle`         | True             |
 | `ToggleSwitch`            | `ToggleSwitchStyle`             | True             |

--- a/doc/semantic-styles.md
+++ b/doc/semantic-styles.md
@@ -173,6 +173,13 @@ FAB is a Material-specific concept. Under Simple theme, FAB keys resolve to exis
 |---|---|---|---|
 | `DatePickerStyle` | `MaterialDatePickerStyle` | `SimpleDatePickerStyle` | Direct match |
 
+### TimePicker
+
+| Semantic Key | Material | Simple | Notes |
+|---|---|---|---|
+| `TimePickerStyle` | `MaterialTimePickerStyle` | `SimpleTimePickerStyle` | Direct match |
+| `TimePickerFlyoutPresenterStyle` | `MaterialTimePickerFlyoutPresenterStyle` | `SimpleTimePickerFlyoutPresenterStyle` | Direct match |
+
 ### MediaPlayerElement
 
 | Semantic Key | Material | Simple | Notes |

--- a/doc/semantic-styles.md
+++ b/doc/semantic-styles.md
@@ -172,6 +172,7 @@ FAB is a Material-specific concept. Under Simple theme, FAB keys resolve to exis
 | Semantic Key | Material | Simple | Notes |
 |---|---|---|---|
 | `DatePickerStyle` | `MaterialDatePickerStyle` | `SimpleDatePickerStyle` | Direct match |
+| `DatePickerFlyoutPresenterStyle` | `MaterialDatePickerFlyoutPresenterStyle` | `SimpleDatePickerFlyoutPresenterStyle` | Direct match |
 
 ### TimePicker
 

--- a/doc/simple-controls-styles.md
+++ b/doc/simple-controls-styles.md
@@ -90,6 +90,11 @@ uid: Uno.Themes.Simple.Styles
 | `TextBox`                   | `SimpleFilledTextBoxStyle`           |                  |
 | `TextBox`                   | `SimpleTextBoxErrorStyle`            |                  |
 | `TextBox`                   | `SimpleTextBoxSmallStyle`            |                  |
+| `TimePicker`                | `SimpleTimePickerStyle`                   |                  |
+| `TimePicker`                | `SimpleDefaultTimePickerStyle`            | True             |
+| `TimePickerFlyoutPresenter` | `SimpleTimePickerFlyoutPresenterStyle`    |                  |
+| `TimePickerFlyoutPresenter` | `SimpleDefaultTimePickerFlyoutPresenterStyle` | True       |
+| `Button`                    | `SimpleTimePickerFlyoutButtonStyle`       |                  |
 | `ToggleButton`              | `SimpleDefaultToggleButtonStyle`          | True             |
 | `ToggleButton`              | `SimpleTextToggleButtonStyle`             |                  |
 | `ToggleButton`              | `SimpleIconToggleButtonStyle`             |                  |
@@ -190,6 +195,8 @@ The Simple theme also provides well-known style key aliases for compatibility wi
 | `AppBarButtonStyle`                    | `SimpleAppBarButtonStyle`                  |
 | `CalendarDatePickerStyle`              | `SimpleCalendarDatePickerStyle`            |
 | `DatePickerStyle`                      | `SimpleDatePickerStyle`                    |
+| `TimePickerStyle`                      | `SimpleTimePickerStyle`                    |
+| `TimePickerFlyoutPresenterStyle`       | `SimpleTimePickerFlyoutPresenterStyle`     |
 | `AutoSuggestBoxStyle`                  | `SimpleAutoSuggestBoxStyle`                |
 | `ToggleButtonStyle`                    | `SimpleDefaultToggleButtonStyle`           |
 | `DisplayLarge`                         | `SimpleDisplayLarge`                       |

--- a/doc/styles/DatePicker.md
+++ b/doc/styles/DatePicker.md
@@ -55,8 +55,22 @@ IsDefaultStyle\*: Styles in this column will be set as the default implicit styl
 | `DatePickerButtonBottomBorderHeight`                   | `Double`          | 2                               |
 | `DatePickerButtonContentHeight`                        | `Double`          | 24                              |
 | `DatePickerButtonHeaderMargin`                         | `Thickness`       | 10,8,10,0                       |
-| `DatePickerButtonPlaceholderMargin`                    | `Thickness`       | 4,0,0,0                         |
+| `DatePickerHeaderFloatTranslateY`                      | `Double`          | `-11`                           |
+| `DatePickerHeaderFloatScale`                           | `Double`          | `0.7`                           |
+| `DatePickerButtonPlaceholderMargin`                    | `Thickness`       | 10,0,10,0                         |
 | `DatePickerButtonContentMargin`                        | `Thickness`       | 6,24,10,0                       |
 | `DatePickerHostPadding`                                | `Thickness`       | 24,24,8,8                       |
 | `DatePickerFlyoutButtonPadding`                        | `Thickness`       | 0                               |
 | `DatePickerCornerRadius`                               | `CornerRadius`    | 4,4,0,0                         |
+
+> [!NOTE]
+> The field sizes to content and is left-aligned, like the Fluent `DatePicker`, with
+> `DatePickerFlyoutPresenterMinWidth` as its floor. This also governs the flyout: `DatePickerFlyout` sizes the
+> presenter to the target's `ActualWidth` on opening, so a stretched field produces a stretched flyout. Set
+> `HorizontalAlignment="Stretch"` on the control to fill its container instead.
+
+> [!NOTE]
+> `Header` is a floating label, as in the Material `TextBox`: it rests at the value's position and reads as the
+> placeholder while no date is set, then animates up and shrinks once one is picked. It is the only element
+> rendering the header — there is no separate header-bound placeholder. Tune the motion with
+> `DatePickerHeaderFloatTranslateY` / `DatePickerHeaderFloatScale`.

--- a/doc/styles/DatePicker.md
+++ b/doc/styles/DatePicker.md
@@ -54,11 +54,10 @@ IsDefaultStyle\*: Styles in this column will be set as the default implicit styl
 | `DatePickerFlyoutPresenterHighlightHeight`             | `Double`          | 40                              |
 | `DatePickerButtonBottomBorderHeight`                   | `Double`          | 2                               |
 | `DatePickerButtonContentHeight`                        | `Double`          | 24                              |
-| `DatePickerButtonHeaderMargin`                         | `Thickness`       | 10,8,10,0                       |
-| `DatePickerHeaderFloatTranslateY`                      | `Double`          | `-11`                           |
+| `DatePickerButtonHeaderMargin` *(deprecated)*          | `Thickness`       | 10,8,10,0                       |
 | `DatePickerHeaderFloatScale`                           | `Double`          | `0.7`                           |
-| `DatePickerButtonPlaceholderMargin`                    | `Thickness`       | 10,0,10,0                         |
-| `DatePickerButtonContentMargin`                        | `Thickness`       | 6,24,10,0                       |
+| `DatePickerButtonPlaceholderMargin`                    | `Thickness`       | 10,0,10,0                       |
+| `DatePickerButtonContentMargin`                        | `Thickness`       | 10,0,10,0                       |
 | `DatePickerHostPadding`                                | `Thickness`       | 24,24,8,8                       |
 | `DatePickerFlyoutButtonPadding`                        | `Thickness`       | 0                               |
 | `DatePickerCornerRadius`                               | `CornerRadius`    | 4,4,0,0                         |
@@ -68,9 +67,14 @@ IsDefaultStyle\*: Styles in this column will be set as the default implicit styl
 > `DatePickerFlyoutPresenterMinWidth` as its floor. This also governs the flyout: `DatePickerFlyout` sizes the
 > presenter to the target's `ActualWidth` on opening, so a stretched field produces a stretched flyout. Set
 > `HorizontalAlignment="Stretch"` on the control to fill its container instead.
-
-> [!NOTE]
-> `Header` is a floating label, as in the Material `TextBox`: it rests at the value's position and reads as the
-> placeholder while no date is set, then animates up and shrinks once one is picked. It is the only element
-> rendering the header — there is no separate header-bound placeholder. Tune the motion with
-> `DatePickerHeaderFloatTranslateY` / `DatePickerHeaderFloatScale`.
+>
+> `Header` is a floating label, as in the Material `TextBox`. It and the value occupy two `Auto` rows centred in
+> the field: with no `Header` the label collapses and the value centres, with a `Header` but no date the label
+> centres and reads as the placeholder, and with both they stack. It is the only element rendering the header —
+> there is no separate header-bound placeholder. `HeaderTemplate` is honoured. `DatePickerHeaderFloatScale` sets
+> how far the label shrinks once it floats; the vertical movement is layout-driven, so there is no offset key to
+> keep in sync with the field height.
+>
+> `DatePickerButtonHeaderMargin` is **deprecated**: it positioned the separate header line, which no longer
+> exists. It still resolves — and `Uno.Themes.WinUI.Markup` still exposes it as `DatePicker.Button.HeaderMargin`
+> — but overriding it has no effect. Use `DatePickerButtonPlaceholderMargin` to inset the header instead.

--- a/doc/styles/TimePicker.md
+++ b/doc/styles/TimePicker.md
@@ -51,11 +51,10 @@ IsDefaultStyle\*: Styles in this column will be set as the default implicit styl
 | `TimePickerFlyoutPresenterHighlightHeight`            | `Double`          | `ControlHeightMedium`           |
 | `TimePickerButtonBottomBorderHeight`                  | `Double`          | `2`                             |
 | `TimePickerButtonContentHeight`                       | `Double`          | `IconSizeMedium`                |
-| `TimePickerButtonHeaderMargin`                        | `Thickness`       | `10,8,10,0`                     |
 | `TimePickerButtonPlaceholderMargin`                   | `Thickness`       | `10,0,10,0`                     |
-| `TimePickerHeaderFloatTranslateY`                     | `Double`          | `-11`                           |
 | `TimePickerHeaderFloatScale`                          | `Double`          | `0.7`                           |
-| `TimePickerButtonContentMargin`                       | `Thickness`       | `10,24,10,0`                    |
+| `TimePickerButtonContentMargin`                       | `Thickness`       | `10,0,10,0`                     |
+| `TimePickerFlyoutPresenterMaxWidth`                   | `Double`          | `456`                           |
 | `TimePickerColumnDividerMargin`                       | `Thickness`       | `2,0,2,0`                       |
 | `TimePickerFlyoutPresenterTitleMargin`                | `Thickness`       | `16,12,16,4`                    |
 | `TimePickerFlyoutButtonPadding`                       | `Thickness`       | `0`                             |
@@ -66,24 +65,24 @@ IsDefaultStyle\*: Styles in this column will be set as the default implicit styl
 > `TimePickerFlyoutPresenterMinWidth` as its floor. This also governs the flyout: `TimePickerFlyout` sizes the
 > presenter to the target's `ActualWidth` on opening, so a stretched field produces a stretched flyout. Set
 > `HorizontalAlignment="Stretch"` on the control to fill its container instead.
-
-> [!NOTE]
-> The field renders the selected time as a single left-aligned value (`9:41 AM`), like the `DatePicker` field.
-> The hour / minute / period text remains owned by the control, so culture ordering, `MinuteIncrement` and a
-> 24-hour `ClockIdentifier` all still apply; `TimePickerColumnDividerMargin` spaces the `:` separator and the
-> period, and `TimePickerSpacerFill` colors the separator. `TimePickerColumnDividerWidth` is kept for
-> back-compat but is no longer used by the default template (the separator is text, not a rule).
-
-> [!NOTE]
+>
+> The hour / minute / period text stays owned by the control, so culture ordering, `MinuteIncrement` and a
+> 24-hour `ClockIdentifier` all still apply. The columns are separated by neutral rules styled with
+> `TimePickerColumnDividerWidth`, `TimePickerColumnDividerMargin` and `TimePickerSpacerFill`. They are rules
+> rather than a `:` glyph on purpose: the control reorders the hour / minute / period hosts per culture but
+> never moves the dividers, so a literal separator is correct only while the hour happens to come first — in a
+> period-first culture such as `ko-KR` it would land between the period and the hour.
+>
 > `TimePicker` only reports the `Normal` / `Disabled` and `HasTime` / `HasNoTime` visual states — it has no
 > `PointerOver` or `Pressed` state of its own (unlike `DatePicker`). Pressed and disabled feedback comes from the
 > `TimePickerFlyoutButtonOpacity*` keys applied to the flyout button that wraps the field.
-
-> [!NOTE]
-> `Header` is a floating label, as in the Material `TextBox`: it rests at the value's position and reads as the
-> placeholder while no time is set, then animates up and shrinks once one is picked. It is the only element
-> rendering the header — there is no separate header-bound placeholder. Tune the motion with
-> `TimePickerHeaderFloatTranslateY` / `TimePickerHeaderFloatScale`.
+>
+> `Header` is a floating label, as in the Material `TextBox`. It and the value occupy two `Auto` rows centred in
+> the field: with no `Header` the label collapses and the value centres, with a `Header` but no time the label
+> centres and reads as the placeholder, and with both they stack. It is the only element rendering the header —
+> there is no separate header-bound placeholder. `HeaderTemplate` is honoured. `TimePickerHeaderFloatScale` sets
+> how far the label shrinks once it floats; the vertical movement is layout-driven, so there is no offset key to
+> keep in sync with the field height.
 
 ## See also
 

--- a/doc/styles/TimePicker.md
+++ b/doc/styles/TimePicker.md
@@ -1,0 +1,91 @@
+---
+uid: Uno.Themes.Styles.TimePicker
+---
+
+# TimePicker Control
+
+## Styles
+
+| Style Key                            | IsDefaultStyle\* |
+|--------------------------------------|------------------|
+| `TimePickerStyle`                    | True             |
+| `TimePickerFlyoutPresenterStyle`     | True             |
+
+IsDefaultStyle\*: Styles in this column will be set as the default implicit style for the matching control
+
+## Lightweight Styling
+
+| Key                                                   | Type              | Value                           |
+|-------------------------------------------------------|-------------------|---------------------------------|
+| `TimePickerFlyoutButtonBackground`                    | `SolidColorBrush` | `SystemControlTransparentBrush` |
+| `TimePickerFlyoutPresenterBackground`                 | `SolidColorBrush` | `SurfaceBrush`                  |
+| `TimePickerFlyoutPresenterForeground`                 | `SolidColorBrush` | `OnSurfaceBrush`                |
+| `TimePickerFlyoutPresenterBorderBrush`                | `SolidColorBrush` | `OnSurfaceFocusedBrush`         |
+| `TimePickerFlyoutPresenterSpacerFill`                 | `SolidColorBrush` | `OnSurfaceFocusedBrush`         |
+| `TimePickerFlyoutPresenterHighlightFill`              | `SolidColorBrush` | `PrimarySelectedBrush`          |
+| `TimePickerFlyoutPresenterCornerRadius`               | `CornerRadius`    | `OverlayCornerRadius`           |
+| `TimePickerButtonBackground`                          | `SolidColorBrush` | `SurfaceVariantBrush`           |
+| `TimePickerButtonBackgroundDisabled`                  | `SolidColorBrush` | `PrimaryFocusedBrush`           |
+| `TimePickerHeaderForeground`                          | `SolidColorBrush` | `PrimaryBrush`                  |
+| `TimePickerHeaderForegroundDisabled`                  | `SolidColorBrush` | `OnSurfaceLowBrush`             |
+| `TimePickerButtonTimeTextForeground`                  | `SolidColorBrush` | `OnSurfaceVariantBrush`         |
+| `TimePickerButtonTimeTextForegroundDisabled`          | `SolidColorBrush` | `OnSurfaceLowBrush`             |
+| `TimePickerPlaceholderTextForeground`                 | `SolidColorBrush` | `OnSurfaceLowBrush`             |
+| `TimePickerButtonBorderBrush`                         | `SolidColorBrush` | `PrimaryBrush`                  |
+| `TimePickerButtonBorderBrushDisabled`                 | `SolidColorBrush` | `OnSurfaceLowBrush`             |
+| `TimePickerSpacerFill`                                | `SolidColorBrush` | `OnSurfaceVariantBrush`         |
+| `TimePickerSpacerFillDisabled`                        | `SolidColorBrush` | `OnSurfaceLowBrush`             |
+| `TimePickerFlyoutPresenterFontFamily`                 | `FontFamily`      | `MaterialRegularFontFamily`     |
+| `TimePickerFlyoutPresenterFontSize`                   | `Double`          | `ControlContentThemeFontSize`   |
+| `TimePickerFlyoutBorderThickness`                     | `Double`          | `1`                             |
+| `TimePickerSpacerThemeWidth`                          | `Double`          | `1`                             |
+| `TimePickerColumnDividerWidth`                        | `Double`          | `1`                             |
+| `TimePickerHeight`                                    | `Double`          | `53`                            |
+| `TimePickerFlyoutElevation`                           | `Double`          | `8`                             |
+| `TimePickerFlyoutButtonOpacityPressed`                | `Double`          | `0.65`                          |
+| `TimePickerFlyoutButtonOpacityDisabled`               | `Double`          | `0.65`                          |
+| `TimePickerFlyoutPresenterWidth`                      | `Double`          | `242`                           |
+| `TimePickerFlyoutPresenterMinWidth`                   | `Double`          | `242`                           |
+| `TimePickerFlyoutPresenterMaxHeight`                  | `Double`          | `398`                           |
+| `TimePickerFlyoutPresenterAcceptDismissHostGridHeight`| `Double`          | `41`                            |
+| `TimePickerFlyoutPresenterHighlightHeight`            | `Double`          | `ControlHeightMedium`           |
+| `TimePickerButtonBottomBorderHeight`                  | `Double`          | `2`                             |
+| `TimePickerButtonContentHeight`                       | `Double`          | `IconSizeMedium`                |
+| `TimePickerButtonHeaderMargin`                        | `Thickness`       | `10,8,10,0`                     |
+| `TimePickerButtonPlaceholderMargin`                   | `Thickness`       | `10,0,10,0`                     |
+| `TimePickerHeaderFloatTranslateY`                     | `Double`          | `-11`                           |
+| `TimePickerHeaderFloatScale`                          | `Double`          | `0.7`                           |
+| `TimePickerButtonContentMargin`                       | `Thickness`       | `10,24,10,0`                    |
+| `TimePickerColumnDividerMargin`                       | `Thickness`       | `2,0,2,0`                       |
+| `TimePickerFlyoutPresenterTitleMargin`                | `Thickness`       | `16,12,16,4`                    |
+| `TimePickerFlyoutButtonPadding`                       | `Thickness`       | `0`                             |
+| `TimePickerCornerRadius`                              | `CornerRadius`    | `4,4,0,0`                       |
+
+> [!NOTE]
+> The field sizes to content and is left-aligned, like the Fluent `TimePicker`, with
+> `TimePickerFlyoutPresenterMinWidth` as its floor. This also governs the flyout: `TimePickerFlyout` sizes the
+> presenter to the target's `ActualWidth` on opening, so a stretched field produces a stretched flyout. Set
+> `HorizontalAlignment="Stretch"` on the control to fill its container instead.
+
+> [!NOTE]
+> The field renders the selected time as a single left-aligned value (`9:41 AM`), like the `DatePicker` field.
+> The hour / minute / period text remains owned by the control, so culture ordering, `MinuteIncrement` and a
+> 24-hour `ClockIdentifier` all still apply; `TimePickerColumnDividerMargin` spaces the `:` separator and the
+> period, and `TimePickerSpacerFill` colors the separator. `TimePickerColumnDividerWidth` is kept for
+> back-compat but is no longer used by the default template (the separator is text, not a rule).
+
+> [!NOTE]
+> `TimePicker` only reports the `Normal` / `Disabled` and `HasTime` / `HasNoTime` visual states — it has no
+> `PointerOver` or `Pressed` state of its own (unlike `DatePicker`). Pressed and disabled feedback comes from the
+> `TimePickerFlyoutButtonOpacity*` keys applied to the flyout button that wraps the field.
+
+> [!NOTE]
+> `Header` is a floating label, as in the Material `TextBox`: it rests at the value's position and reads as the
+> placeholder while no time is set, then animates up and shrinks once one is picked. It is the only element
+> rendering the header — there is no separate header-bound placeholder. Tune the motion with
+> `TimePickerHeaderFloatTranslateY` / `TimePickerHeaderFloatScale`.
+
+## See also
+
+- [DatePicker](DatePicker.md)
+- [Lightweight Styling](xref:Uno.Themes.LightweightStyling)

--- a/doc/styles/simple/DatePicker.md
+++ b/doc/styles/simple/DatePicker.md
@@ -113,9 +113,11 @@ IsDefaultStyle\*: Styles in this column will be set as the default implicit styl
 > `DatePickerFlyoutPresenterMinWidth` as its floor. This also governs the flyout: `DatePickerFlyout` sizes the
 > presenter to the target's `ActualWidth` on opening, so a stretched field produces a stretched flyout. Set
 > `HorizontalAlignment="Stretch"` on the control to fill its container instead.
-
-> [!NOTE]
+>
 > `Header` renders **only** as the in-field placeholder, the way the Simple `TextBox` shows `PlaceholderText` —
-> there is no separate header line above the field. `DatePickerHeaderForeground` therefore applies to the value,
-> and `DatePickerPlaceholderTextForeground` to the header while no date is set. `DatePickerHeaderMargin` is kept
-> for back-compat but is no longer used by the default template.
+> there is no separate header line above the field, and `HeaderTemplate` is honoured. The placeholder is
+> coloured by `DatePickerPlaceholderTextForeground`; the value uses `DatePickerButtonDateTextForeground`.
+>
+> `DatePickerHeaderForeground`, `DatePickerHeaderForegroundDisabled` and `DatePickerHeaderMargin` are
+> **deprecated**: they styled the separate header line, which no longer exists. They still resolve, but
+> overriding them has no effect.

--- a/doc/styles/simple/DatePicker.md
+++ b/doc/styles/simple/DatePicker.md
@@ -35,7 +35,7 @@ IsDefaultStyle\*: Styles in this column will be set as the default implicit styl
 | `DatePickerFlyoutPresenterBackground`               | `SolidColorBrush` | `SurfaceBrush`                  |
 | `DatePickerFlyoutPresenterBorderBrush`              | `SolidColorBrush` | `OutlineBrush`                  |
 | `DatePickerFlyoutPresenterSpacerFill`               | `SolidColorBrush` | `OutlineBrush`                  |
-| `DatePickerFlyoutPresenterHighlightFill`            | `SolidColorBrush` | `PrimaryVariantLightBrush`      |
+| `DatePickerFlyoutPresenterHighlightFill`            | `SolidColorBrush` | `SurfaceVariantBrush`           |
 | `DatePickerFlyoutPresenterCornerRadius`             | `StaticResource`  | `SimpleRadius400CornerRadius`   |
 | `DatePickerFlyoutPresenterWidth`                    | `Double`          | 296                             |
 | `DatePickerFlyoutPresenterMinWidth`                 | `Double`          | 296                             |
@@ -107,3 +107,15 @@ IsDefaultStyle\*: Styles in this column will be set as the default implicit styl
 | `SimpleDatePickerCornerRadius`                      | `StaticResource` | `DatePickerCornerRadius`                 |
 | `SimpleDatePickerBorderThemeThickness`              | `StaticResource` | `DatePickerBorderThemeThickness`         |
 | `SimpleDatePickerFlyoutButtonPadding`               | `StaticResource` | `DatePickerFlyoutButtonPadding`          |
+
+> [!NOTE]
+> The field sizes to content and is left-aligned, like the Fluent `DatePicker`, with
+> `DatePickerFlyoutPresenterMinWidth` as its floor. This also governs the flyout: `DatePickerFlyout` sizes the
+> presenter to the target's `ActualWidth` on opening, so a stretched field produces a stretched flyout. Set
+> `HorizontalAlignment="Stretch"` on the control to fill its container instead.
+
+> [!NOTE]
+> `Header` renders **only** as the in-field placeholder, the way the Simple `TextBox` shows `PlaceholderText` —
+> there is no separate header line above the field. `DatePickerHeaderForeground` therefore applies to the value,
+> and `DatePickerPlaceholderTextForeground` to the header while no date is set. `DatePickerHeaderMargin` is kept
+> for back-compat but is no longer used by the default template.

--- a/doc/styles/simple/TimePicker.md
+++ b/doc/styles/simple/TimePicker.md
@@ -19,7 +19,7 @@ IsDefaultStyle\*: Styles in this column will be set as the default implicit styl
 ## Lightweight Styling
 
 Every visual-state brush and dimension is exposed as a semantic `TimePicker*` key in the style's
-`ThemeDictionaries`, so an app can override any single key without retemplating.
+`ThemeDictionaries`, so an app can override any single key without replacing the template.
 
 ### FlyoutButton
 
@@ -70,9 +70,8 @@ Every visual-state brush and dimension is exposed as a semantic `TimePicker*` ke
 | `TimePickerButtonTimeTextForeground`         | `SolidColorBrush` | `OnSurfaceBrush`               |
 | `TimePickerButtonTimeTextForegroundDisabled` | `SolidColorBrush` | `OnSurfaceDisabledBrush`       |
 | `TimePickerPlaceholderTextForeground`        | `SolidColorBrush` | `OnSurfaceLowBrush`            |
-| `TimePickerHeaderForeground`                 | `SolidColorBrush` | `OnSurfaceBrush`               |
+| `TimePickerHeaderForeground`                 | `SolidColorBrush` | `OnSurfaceLowBrush`            |
 | `TimePickerHeaderForegroundDisabled`         | `SolidColorBrush` | `OnSurfaceDisabledBrush`       |
-| `TimePickerHeaderMargin`                     | `Thickness`       | `Space100BottomThickness`      |
 | `TimePickerSpacerFill`                       | `SolidColorBrush` | `OnSurfaceVariantBrush`        |
 | `TimePickerSpacerFillDisabled`               | `SolidColorBrush` | `OutlineDisabledBrush`         |
 | `TimePickerColumnDividerWidth`               | `Double`          | `SimpleStrokeBorder`           |
@@ -83,25 +82,23 @@ Every visual-state brush and dimension is exposed as a semantic `TimePicker*` ke
 > `TimePickerFlyoutPresenterMinWidth` as its floor. This also governs the flyout: `TimePickerFlyout` sizes the
 > presenter to the target's `ActualWidth` on opening, so a stretched field produces a stretched flyout. Set
 > `HorizontalAlignment="Stretch"` on the control to fill its container instead.
-
-> [!NOTE]
-> The field renders the selected time as a single left-aligned value (`9:41 AM`), like the `DatePicker`
-> field. The hour / minute / period text remains owned by the control, so culture ordering, `MinuteIncrement`
-> and a 24-hour `ClockIdentifier` all still apply; `TimePickerColumnDividerMargin` spaces the `:` separator
-> and the period, and `TimePickerSpacerFill` colors the separator. `TimePickerColumnDividerWidth` is kept for
-> back-compat but is no longer used by the default template (the separator is text, not a rule).
-
-> [!NOTE]
+>
+> The hour / minute / period text stays owned by the control, so culture ordering, `MinuteIncrement` and a
+> 24-hour `ClockIdentifier` all still apply. The columns are separated by neutral rules styled with
+> `TimePickerColumnDividerWidth`, `TimePickerColumnDividerMargin` and `TimePickerSpacerFill`. They are rules
+> rather than a `:` glyph on purpose: the control reorders the hour / minute / period hosts per culture but
+> never moves the dividers, so a literal separator is correct only while the hour happens to come first — in a
+> period-first culture such as `ko-KR` it would land between the period and the hour.
+>
 > `TimePicker` only reports the `Normal` / `Disabled` and `HasTime` / `HasNoTime` visual states — it has no
 > `PointerOver` or `Pressed` state of its own (unlike `DatePicker`), so there are no `*PointerOver` / `*Pressed`
 > brush keys. Pressed and disabled feedback comes from the `TimePickerFlyoutButtonOpacity*` keys.
-
-> [!NOTE]
+>
 > `Header` renders **only** as the in-field placeholder, the way the Simple `TextBox` shows `PlaceholderText` —
-> there is no separate header line above the field. `TimePickerHeaderForeground` therefore applies to the value,
-> and `TimePickerPlaceholderTextForeground` to the header while no time is set. `TimePickerHeaderMargin` is kept
-> for back-compat but is no longer used by the default template. With no `Header`, the control's own
-> `hour : minute AM` run stays visible as the placeholder instead.
+> there is no separate header line above the field, and `HeaderTemplate` is honoured. The placeholder is
+> coloured by `TimePickerHeaderForeground`, and by `TimePickerHeaderForegroundDisabled` when the control is
+> disabled; `TimePickerPlaceholderTextForeground` dims the control's own hour / minute / period run. With no
+> `Header`, that run stays visible as the placeholder instead.
 
 ## Example
 

--- a/doc/styles/simple/TimePicker.md
+++ b/doc/styles/simple/TimePicker.md
@@ -1,0 +1,120 @@
+---
+uid: Uno.Themes.Simple.Styles.TimePicker
+---
+
+# TimePicker Control
+
+## Styles
+
+| Style Key                                      | IsDefaultStyle\* |
+|------------------------------------------------|------------------|
+| `SimpleTimePickerStyle`                        |                  |
+| `SimpleDefaultTimePickerStyle`                 | True             |
+| `SimpleTimePickerFlyoutPresenterStyle`         |                  |
+| `SimpleDefaultTimePickerFlyoutPresenterStyle`  | True             |
+| `SimpleTimePickerFlyoutButtonStyle`            |                  |
+
+IsDefaultStyle\*: Styles in this column will be set as the default implicit style for the matching control
+
+## Lightweight Styling
+
+Every visual-state brush and dimension is exposed as a semantic `TimePicker*` key in the style's
+`ThemeDictionaries`, so an app can override any single key without retemplating.
+
+### FlyoutButton
+
+| Key                                     | Type              | Value                           |
+|-----------------------------------------|-------------------|---------------------------------|
+| `TimePickerFlyoutButtonBackground`      | `SolidColorBrush` | `SystemControlTransparentBrush` |
+| `TimePickerFlyoutButtonPadding`         | `Thickness`       | `SimpleSpace0Thickness`         |
+| `TimePickerFlyoutButtonOpacityPressed`  | `Double`          | `0.8`                           |
+| `TimePickerFlyoutButtonOpacityDisabled` | `Double`          | `0.5`                           |
+
+### FlyoutPresenter
+
+| Key                                                   | Type              | Value                          |
+|-------------------------------------------------------|-------------------|--------------------------------|
+| `TimePickerFlyoutPresenterBackground`                 | `SolidColorBrush` | `SurfaceBrush`                 |
+| `TimePickerFlyoutPresenterForeground`                 | `SolidColorBrush` | `OnSurfaceBrush`               |
+| `TimePickerFlyoutPresenterBorderBrush`                | `SolidColorBrush` | `OutlineBrush`                 |
+| `TimePickerFlyoutPresenterSpacerFill`                 | `SolidColorBrush` | `OutlineBrush`                 |
+| `TimePickerFlyoutPresenterHighlightFill`              | `SolidColorBrush` | `SurfaceVariantBrush`          |
+| `TimePickerFlyoutPresenterCornerRadius`               | `CornerRadius`    | `SimpleRadius400CornerRadius`  |
+| `TimePickerFlyoutPresenterFontFamily`                 | `FontFamily`      | `SimpleFontFamily`             |
+| `TimePickerFlyoutPresenterWidth`                      | `Double`          | `242`                          |
+| `TimePickerFlyoutPresenterMinWidth`                   | `Double`          | `242`                          |
+| `TimePickerFlyoutPresenterMaxHeight`                  | `Double`          | `398`                          |
+| `TimePickerFlyoutPresenterHighlightHeight`            | `Double`          | `SimpleIconLarge`              |
+| `TimePickerFlyoutPresenterAcceptDismissHostGridHeight`| `Double`          | `52`                           |
+| `TimePickerFlyoutPresenterTitleMargin`                | `Thickness`       | `16,12,16,4`                   |
+| `TimePickerFlyoutBorderThickness`                     | `Double`          | `SimpleStrokeBorder`           |
+| `TimePickerSpacerThemeWidth`                          | `Double`          | `SimpleStrokeBorder`           |
+
+### Field
+
+| Key                                          | Type              | Value                          |
+|-----------------------------------------------|-------------------|--------------------------------|
+| `TimePickerButtonBackground`                 | `SolidColorBrush` | `SurfaceBrush`                 |
+| `TimePickerButtonBackgroundDisabled`         | `SolidColorBrush` | `OnSurfaceDisabledBrush`       |
+| `TimePickerButtonBorderBrush`                | `SolidColorBrush` | `OutlineBrush`                 |
+| `TimePickerButtonBorderBrushDisabled`        | `SolidColorBrush` | `OutlineDisabledBrush`         |
+| `TimePickerCornerRadius`                     | `CornerRadius`    | `SimpleRadius200CornerRadius`  |
+| `TimePickerBorderThemeThickness`             | `Thickness`       | `SimpleStrokeBorderThickness`  |
+| `TimePickerContentMargin`                    | `Thickness`       | `16,10,16,10`                  |
+| `TimePickerMinHeight`                        | `Double`          | `ControlHeightMediumLarge`     |
+
+### Time text / header / dividers
+
+| Key                                          | Type              | Value                          |
+|-----------------------------------------------|-------------------|--------------------------------|
+| `TimePickerButtonTimeTextForeground`         | `SolidColorBrush` | `OnSurfaceBrush`               |
+| `TimePickerButtonTimeTextForegroundDisabled` | `SolidColorBrush` | `OnSurfaceDisabledBrush`       |
+| `TimePickerPlaceholderTextForeground`        | `SolidColorBrush` | `OnSurfaceLowBrush`            |
+| `TimePickerHeaderForeground`                 | `SolidColorBrush` | `OnSurfaceBrush`               |
+| `TimePickerHeaderForegroundDisabled`         | `SolidColorBrush` | `OnSurfaceDisabledBrush`       |
+| `TimePickerHeaderMargin`                     | `Thickness`       | `Space100BottomThickness`      |
+| `TimePickerSpacerFill`                       | `SolidColorBrush` | `OnSurfaceVariantBrush`        |
+| `TimePickerSpacerFillDisabled`               | `SolidColorBrush` | `OutlineDisabledBrush`         |
+| `TimePickerColumnDividerWidth`               | `Double`          | `SimpleStrokeBorder`           |
+| `TimePickerColumnDividerMargin`              | `Thickness`       | `2,0,2,0`                      |
+
+> [!NOTE]
+> The field sizes to content and is left-aligned, like the Fluent `TimePicker`, with
+> `TimePickerFlyoutPresenterMinWidth` as its floor. This also governs the flyout: `TimePickerFlyout` sizes the
+> presenter to the target's `ActualWidth` on opening, so a stretched field produces a stretched flyout. Set
+> `HorizontalAlignment="Stretch"` on the control to fill its container instead.
+
+> [!NOTE]
+> The field renders the selected time as a single left-aligned value (`9:41 AM`), like the `DatePicker`
+> field. The hour / minute / period text remains owned by the control, so culture ordering, `MinuteIncrement`
+> and a 24-hour `ClockIdentifier` all still apply; `TimePickerColumnDividerMargin` spaces the `:` separator
+> and the period, and `TimePickerSpacerFill` colors the separator. `TimePickerColumnDividerWidth` is kept for
+> back-compat but is no longer used by the default template (the separator is text, not a rule).
+
+> [!NOTE]
+> `TimePicker` only reports the `Normal` / `Disabled` and `HasTime` / `HasNoTime` visual states — it has no
+> `PointerOver` or `Pressed` state of its own (unlike `DatePicker`), so there are no `*PointerOver` / `*Pressed`
+> brush keys. Pressed and disabled feedback comes from the `TimePickerFlyoutButtonOpacity*` keys.
+
+> [!NOTE]
+> `Header` renders **only** as the in-field placeholder, the way the Simple `TextBox` shows `PlaceholderText` —
+> there is no separate header line above the field. `TimePickerHeaderForeground` therefore applies to the value,
+> and `TimePickerPlaceholderTextForeground` to the header while no time is set. `TimePickerHeaderMargin` is kept
+> for back-compat but is no longer used by the default template. With no `Header`, the control's own
+> `hour : minute AM` run stays visible as the placeholder instead.
+
+## Example
+
+```xml
+<Page.Resources>
+    <!-- Tint just the field border, everything else stays on the Simple palette -->
+    <SolidColorBrush x:Key="TimePickerButtonBorderBrush" Color="#7C3AED" />
+</Page.Resources>
+
+<TimePicker Header="Start Time" ClockIdentifier="24HourClock" />
+```
+
+## See also
+
+- [DatePicker](DatePicker.md)
+- [Simple Controls Styles](xref:Uno.Themes.Simple.Styles)

--- a/specs/lessons.md
+++ b/specs/lessons.md
@@ -4,6 +4,41 @@ Domain lessons and postmortems for the Uno.Themes repo. Append new entries at th
 
 ---
 
+## A `<StaticResource>` alias hands back a *copy* — asserting `AreSame` on a semantic style key tests the resource system, not the alias
+
+**Context:** TimePicker styles. `Given_TimePickerStyles` and `Given_MaterialPickerStyles` asserted the
+semantic aliases with `Assert.AreSame(Resources["SimpleTimePickerStyle"], Resources["TimePickerStyle"])`.
+Both went red in CI (3 of the 4 failing jobs on the PR) while the aliases were, in fact, correct.
+
+**Root cause:** `<StaticResource x:Key="TimePickerStyle" ResourceKey="SimpleTimePickerStyle" />` resolves
+to an **independent copy** of the referenced `Style` — a different `Style` instance carrying a different
+`ControlTemplate` instance, though with an identical setter list. Measured directly: two lookups of the
+*same* key return the same instance (`sameKeyTwice=True`), but the alias key never matches the key it
+points at (`semanticVsSimple=False`) — and that is equally true of the long-shipped `DatePickerStyle`
+alias, which no test had ever asserted this way. The assertion encoded a guarantee Uno does not make.
+
+**How to apply:**
+- Never assert reference identity across two resource **keys**. Identity holds for repeated lookups of
+  one key; it does not survive a `<StaticResource>` alias. This also rules out comparing the styles'
+  `ControlTemplate` values, which are copied along with the style.
+- Assert what the styles **set**, not what they *are*: compare `TargetType` plus every setter's property
+  and value. That is the contract `doc/semantic-styles.md` publishes ("Direct match"), and it still fails
+  if an alias points at the wrong style or is missing entirely (leaving the Fluent default in place).
+  `Given_SemanticStyles` does the stronger version for buttons — apply both styles to real controls and
+  compare rendered values — but that is not available for every key: `TimePickerFlyoutPresenter` (like
+  the other flyout presenters) has **no public parameterless constructor**, so a test cannot instantiate
+  one. Style-level comparison is the form that covers both a control style and a presenter style.
+- When comparing values, stringify rather than compare references: `FontFamily` and friends are reference
+  types with no cross-instance equality guarantee. Compare `SolidColorBrush` by `Color`, and skip
+  `Template` / `Style`-valued setters — those are the copied references, not observable styling.
+- **Before rewriting an assertion that fails, measure which half is wrong.** Two rounds were burned here
+  guessing at a stronger identity check; one throwaway test that printed the four reference-equality
+  facts (and compared against the shipped `DatePicker` alias as a control) settled it in a single run.
+  When a new test fails, check the equivalent shipped feature first — if it behaves identically, the test
+  is wrong, not the feature.
+
+---
+
 ## A design-token "mode" (density) must be a factor over the scale's base unit, never a competing source of the base value
 
 **Context:** Spec 07 (`DefaultSpacing`, issue #1688). The first implementation gave `Density` enum members base-unit pixel values (`Compact = 3`, `Regular = 4`, `Comfy = 5`) and made `DefaultSpacing` an *override* that beat the preset ("override-beats-preset, like the color stack"). The user rejected this: density is a **mode** the consumer picks (Compact / Regular / Comfy), not an alternate spelling of a pixel value.

--- a/specs/lessons.md
+++ b/specs/lessons.md
@@ -168,3 +168,33 @@ Domain lessons and postmortems for the Uno.Themes repo. Append new entries at th
 
 **Verification trap (the more important lesson):** these font tests **passed in the minimal dedicated `Uno.Themes.RuntimeTests` host but failed in `SimpleSampleApp`** (and therefore in CI). The dedicated host merges `<SimpleTheme/>` app-wide, which "warms" the ambient resolution scope so the fragile `<StaticResource>` aliases happen to resolve to the right weight — a **false positive**. The real consumer-like host (`SimpleSampleApp`, also what CI runs) exposed the bug.
 - **Always verify font/typography/resource-precedence changes in `SimpleSampleApp` (the CI host), not only in a minimal host.** A minimal single-theme host can mask cross-dictionary resolution and merge-order bugs. If two hosts disagree, trust the one that matches CI.
+
+---
+
+## Named columns and dividers belong to the control, not the template — the picker templates cannot own ordering
+
+**Context:** PR #1692 (`dev/sb/time-picker`), new Material v2 / Simple `TimePicker` styles. A revision rendered the field as `9:41 AM` by putting a literal `:` in `FirstColumnDivider` and declaring the `*TextBlockColumn` widths as `Auto`. Review (and Uno's source) showed both were wrong, and the runtime test that "proved" the layout was green for an unrelated reason.
+
+**Root causes, both in `TimePicker.UpdateOrderAndLayout` (`TimePicker.partial.mux.cs`):**
+1. The method reparents the hour / minute / period `TextBlock`s between `First|Second|ThirdPickerHost` to reorder per culture, but it only toggles the **visibility** of `First|SecondColumnDivider` — it never moves them. `GetOrder` has a `periodOrder == 0` branch, so in `ko-KR` / `zh-CN` / `ja-JP` the period occupies `FirstPickerHost` and a fixed colon lands between the period and the hour, leaving hour and minute unseparated. Fluent's neutral `Rectangle` divider is immune by construction.
+2. The same pass assigns `1*` to every populated `*TextBlockColumn` and `0` to the rest, overwriting whatever width the template declared. An `Auto` width in the template is dead markup, so any layout behaviour attributed to it does not exist at runtime.
+
+**How to apply:**
+- In a picker template, treat every part the control looks up by name as **the control's**, not the template's. Before attaching meaning to one (a glyph, a width, an alignment), read what the control does to it in `OnApplyTemplate` and its layout pass. "The part is typed `UIElement`, so I can put anything in it" is a type-safety argument, not a behavioural one.
+- Never encode reading order in a fixed template position. If a separator's correctness depends on which value sits beside it, it is wrong in some culture — use a neutral rule, or derive the whole string from the culture.
+- Match the framework's own template shape (`*` columns, `Rectangle` dividers) unless there is a specific reason to diverge; divergence here bought nothing and cost correctness.
+
+**Verification trap:** the compactness test passed because the assertion (`content.ActualWidth < picker.ActualWidth / 2`) happened to hold for a reason the author had not identified, and the divider assertion only checked the en-US ordering. A test can be green, deterministic, and still prove nothing about the mechanism it claims to guard. When a test protects a layout mechanism, assert the mechanism (the column widths the control assigned; the divider's *type*), not a rendering that one locale produces.
+
+---
+
+## `RequestedTheme` on a container does not change what the `ResourceDictionary` indexer returns
+
+**Context:** Same PR. `Given_TimePickerStyles` was parameterized `[DataRow(ElementTheme.Light)] [DataRow(ElementTheme.Dark)]` over lookups of the form `container.Resources[key]`, where `container` was a `Grid { RequestedTheme = theme }`. The selection-band contrast fix (`PrimaryVariantLightBrush` → `SurfaceVariantBrush`, invisible in Dark) was guarded this way.
+
+**Root cause:** the `ResourceDictionary` indexer resolves `ThemeDictionaries` against the **application** theme and ignores `FrameworkElement.RequestedTheme`. Both rows therefore asserted the same value. Because the Light palette already contrasted (`#F5F5F5` vs `#FFFFFF`), the test **passed on `master`** — it never reproduced the Dark bug it was written for, so the fix shipped with no red/fix/green evidence at all.
+
+**How to apply:**
+- A Light/Dark `[DataRow]` pair over an indexer lookup is a coverage illusion. To resolve a key as an element under a given theme would see it, bind it through a **loaded element** in a container with that `RequestedTheme` (e.g. a `Border` whose `Background` is `{ThemeResource Key}`, built with `XamlReader.Load`) and read the resolved value back.
+- When adding a theme-parameterized test, sanity-check it against `master` first: if it passes there, it is not guarding the bug. This is the cheapest possible red/fix/green check and it catches exactly this class of fake coverage.
+- Note also that `ColumnDefinition` is not a visual-tree child — a `VisualTreeHelper` walk cannot find `x:Name`d columns. Assert them through the owning `Grid.ColumnDefinitions` (or, better, through the widths the control assigned).

--- a/specs/lessons.md
+++ b/specs/lessons.md
@@ -70,6 +70,31 @@ Domain lessons and postmortems for the Uno.Themes repo. Append new entries at th
 
 ---
 
+## XamlStyler reformats whole files to spaces — re-tabify, and never run it repo-wide for a small change
+
+**Context:** TimePicker style work. Running the documented command (`dotnet dnx XamlStyler.Console -c Settings.XamlStyler -f <files>`) on three XAML files reindented every line with **4 spaces**, turning a 2-line change to `Uno.Simple.WinUI/Styles/Controls/DatePicker.xaml` into a 992-line diff.
+
+**Root cause:** `Settings.XamlStyler` at the repo root does not set `IndentWithTabs`, so XamlStyler defaults to spaces — but `.editorconfig` and every checked-in `.xaml` use **tabs**. The formatter and the repo convention disagree.
+
+**How to apply:**
+- After running XamlStyler on any file, re-tabify before committing: `sed -E -i ':a; s/^(\t*)    /\1\t/; ta' <file>`, then confirm with `grep -nE '^\t* {2,}<' <file>` (must be empty).
+- Never run it with `-r -d "."` to tidy a handful of files — it rewrites the whole tree.
+- If a tracked file gets mangled, `git checkout -- <file>` and re-apply the real edit rather than trying to hand-fix the reformat.
+- Root fix, if approved: add `"IndentWithTabs": true` to `Settings.XamlStyler` so the documented command matches `.editorconfig`.
+
+---
+
+## A theme brush that equals the surface it sits on is invisible — assert contrast, not resolution
+
+**Context:** The Simple `TimePicker`/`DatePicker` flyout selection band used `PrimaryVariantLightBrush`, which is `#F5F5F5` in Light but **`#1E1E1E` in Dark — exactly `SurfaceColor`**. The selected row was completely invisible in Dark; every existing test passed because they only asserted that the key *resolved*.
+
+**How to apply:**
+- For any brush painted directly on another themed brush (selection bands, highlights, dividers, scrims), add a runtime assertion that the two resolve to **different colors**, not merely that both resolve.
+- When picking a highlight in the Simple palette, prefer `SurfaceVariantBrush` (`#F5F5F5` Light / `#2C2C2C` Dark) over any `Primary*` key — Simple's primary collapses onto the surface in one theme by design (it is a grayscale palette).
+- Gotcha when writing such tests: `container.Resources["Key"]` resolves `ThemeDictionaries` against the **application** theme and ignores `RequestedTheme` on the container, so `[DataRow(ElementTheme.Light)]` on a dictionary-indexer lookup does **not** test the Light palette. Only values resolved through an applied template honor the element theme.
+
+---
+
 ## An app that loads assemblies by reflection cannot be trimmed — ILLink strips facade type-forwarders, and rooting is a treadmill
 
 **Context:** ThemesSampleApp ALC wrapper (spec 05). In the browser, every guest died at `Assembly.GetTypes()` with `TypeLoadException: Could not resolve type with token 010003c9 from typeref (expected class 'System.IO.StringWriter' in assembly 'System.Runtime')`. An earlier investigation had noted that pre-loading `System.Runtime` merely advanced the failure to the next typeref (`System.IAsyncDisposable`) and concluded "rooting types one at a time is a treadmill" without identifying why.

--- a/specs/timepicker-styles/timepicker-styles.md
+++ b/specs/timepicker-styles/timepicker-styles.md
@@ -193,3 +193,40 @@ all. New guards worth calling out:
 - Divider type (`not a TextBlock`) and control-assigned `1*` column widths, pinning the two behaviours
   that the culture and layout defects above turned on.
 - Header-less vertical centring, the case the float offset broke.
+
+## Rebase onto master, and the semantic-alias assertion that was wrong
+
+Rebased onto `master` past `DefaultSpacing`/`Density` (#1701) and seed-color fidelity (#1697). The only
+conflict was `specs/lessons.md`, where both sides had appended independent entries — kept both. The
+picker styles use no density or spacing tokens, so the `Density` breaking change does not interact.
+
+Three CI jobs were red, and only one cause was in this branch's product code — none, in fact:
+
+- **`Validate Conventional Commits`.** commitsar 0.11.2 requires a `!`-marked commit's body to *start*
+  with `BREAKING CHANGE:`; ours carried it as the last paragraph. Body reordered, content unchanged.
+- **`deploy`.** Azure Static Web Apps rejected the upload: *"This Static Web App already has the maximum
+  number of staging environments."* Infrastructure quota, not a code failure — needs stale staging
+  environments pruned. The same workflow is green on `master`.
+- **Both runtime-test jobs.** `Given_TimePickerStyles` and `Given_MaterialPickerStyles` asserted the
+  semantic aliases with `Assert.AreSame`. Measured: a `<StaticResource>` alias resolves to an
+  independent **copy** of the referenced style — different `Style`, different `ControlTemplate`,
+  identical setters — and the long-shipped `DatePickerStyle` alias behaves exactly the same. The
+  aliases were correct; the assertion was testing Uno's resource-lookup internals. Now compared by
+  `TargetType` plus setter property/value pairs, which still fails if an alias points at the wrong
+  style or is missing. See `specs/lessons.md`.
+
+`TimePickerFlyoutPresenter` has no public parameterless constructor, so the presenter alias cannot be
+verified by applying the style to an instance the way `Given_SemanticStyles` does for buttons — hence
+the style-level comparison, which covers the control style and the presenter style uniformly.
+
+### Results after the rebase (net10.0-desktop, Release)
+
+- `Uno.Themes-packages.slnf` — **build succeeded**, no new warnings.
+- `SimpleSampleApp` — **203 passed, 0 failed, 1 skipped** (the pre-existing `[Ignore]` on
+  `Given_HotReload.When_BaseThemeIsCollected_Then_HotReloadHandlerDoesNotResurrectIt`).
+- `MaterialSampleApp` — **58 passed, 0 failed**.
+
+Local note: these samples do not restore on a machine with the `maui` workload installed —
+`Microsoft.NETCore.App.Runtime.Mono.win-x64` 10.0.1 has no 10.x release on nuget.org, so restore fails
+with NU1102. It reproduces on a clean `master` worktree, i.e. it is environmental. `-p:UseMonoRuntime=false`
+works around it without touching the workload install.

--- a/specs/timepicker-styles/timepicker-styles.md
+++ b/specs/timepicker-styles/timepicker-styles.md
@@ -1,0 +1,156 @@
+# TimePicker styles for Material v2 and Simple
+
+**Branch:** `dev/sb/time-picker`
+
+## Problem
+
+`TimePicker` had no style in Material v2, Simple, or Cupertino. The only coverage was
+`src/library/Uno.Material/Styles/Controls/v1/TimePicker.xaml`, which:
+
+- lives in the v1 merged dictionary only (`mergedpages.v1.xaml`);
+- binds v1-only brushes (`MaterialPrimaryBrush`, `TextBoxFilledBackgroundColorBrush`,
+  `MaterialBody2`) that no longer exist in v2;
+- has no `ThemeDictionaries` block, so nothing is lightweight-stylable;
+- exposes `MaterialTimePickerFlyoutPresenterStyle` as an `<ios:Style>` — the flyout presenter is
+  unstyled on every non-iOS target;
+- omits the named template parts Uno's `TimePicker` drives
+  (`First|Second|ThirdPickerHost`, `First|Second|ThirdTextBlockColumn`,
+  `First|SecondColumnDivider`, `HeaderContentPresenter`), so culture-driven hour/minute/period
+  reordering and 24-hour column collapse do not work.
+
+Scope of this change: Material v2 and Simple. Cupertino and Material v1 are untouched.
+
+## Reference used for the template contract
+
+Part names and visual states were taken from Uno's WinUI port, not guessed:
+
+- `Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.partial.mux.cs` — `GetTemplateChild<Border>("FirstPickerHost")`,
+  `GetTemplateChild<ColumnDefinition>("FirstTextBlockColumn")`, `GetTemplateChild<UIElement>("FirstColumnDivider")`, …
+  States: `Normal` / `Disabled`, `HasTime` / `HasNoTime`. **No `PointerOver` / `Pressed`** — unlike `DatePicker`.
+- `Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyoutPresenter.partial.mux.cs` — `Background`, `TitlePresenter`,
+  `ContentPanel`, `First|Second|ThirdPickerHost`, `First|Second|ThirdPickerHostColumn`,
+  `First|SecondPickerSpacing`, `AcceptDismissHostGrid`, `AcceptButton`, `DismissButton`.
+- Windows SDK `generic.xaml` (10.0.26100.0, lines 11867 and 14894) for the reference layout.
+
+## Work items
+
+- [x] `src/library/Uno.Material/Styles/Controls/v2/TimePicker.xaml`
+      — `MaterialTimePickerStyle`, `MaterialTimePickerFlyoutPresenterStyle`,
+      `MaterialTimePickerFlyoutButtonStyle`, `MaterialDefaultTimePickerStyle`,
+      `MaterialDefaultTimePickerFlyoutPresenterStyle`, plus Light/Default `ThemeDictionaries`.
+      Layout mirrors `v2/DatePicker.xaml` (filled field, bottom border, `ElevatedView` flyout).
+- [x] `src/library/Uno.Simple.WinUI/Styles/Controls/TimePicker.xaml`
+      — `Simple*` equivalents on SDS tokens, layout mirroring `Simple/DatePicker.xaml`
+      (header above an outlined field, plain `Border` flyout).
+- [x] `v2/_Resources.xaml` — implicit styles for `TimePicker` / `TimePickerFlyoutPresenter`;
+      semantic aliases `TimePickerStyle`, `TimePickerFlyoutPresenterStyle`.
+- [x] Simple `Controls/_Resources.xaml` — same two implicit styles and two semantic aliases.
+- [x] Sample: `TimePickerSamplePage.xaml` gains `M3MaterialTemplate` and `SimpleTemplate`
+      (default / 24-hour / minute-increment / disabled); `SupportedDesigns` gains `Design.Simple`.
+      The v1 `MaterialTemplate` is left as-is.
+- [x] Runtime tests: `src/samples/SimpleSampleApp/RuntimeTests/Given_TimePickerStyles.cs`.
+- [x] Docs: `doc/material-controls-styles.md`, `doc/simple-controls-styles.md`,
+      `doc/semantic-styles.md`, `doc/lightweight-styling.md`, `doc/styles/TimePicker.md`,
+      `doc/styles/simple/TimePicker.md`.
+
+## Decisions
+
+**Rectangle dividers, not a hardcoded `:`.** v1 rendered a literal colon `TextBlock` between hour and
+minute. Uno reorders the hour / minute / period hosts per culture, and in period-first cultures
+(`zh`, `ja`, `ko`) a fixed colon would land between the period and the hour. Both new styles use the
+WinUI-shaped `Rectangle` dividers (`First|SecondColumnDivider`), themed via `TimePickerSpacerFill` /
+`TimePickerColumnDividerWidth`, which stay correct in every culture and collapse automatically with
+the column they separate.
+
+**No `*PointerOver` / `*Pressed` lightweight keys.** `TimePicker` never enters those states, so such
+keys would be dead API. Pressed/disabled feedback comes from the flyout-button opacity keys, matching
+how `DatePicker`'s flyout button already works in both themes.
+
+**No `FlyoutPresenterStyle` setter.** `DatePicker` sets `not_win:FlyoutPresenterStyle`, but
+`TimePicker` has no such property (`TimePicker.Properties.cs` declares only `ClockIdentifier`,
+`Header`, `HeaderTemplate`, `LightDismissOverlayMode`, `MinuteIncrement`, `SelectedTime`, `Time`).
+The presenter is styled through the implicit `TimePickerFlyoutPresenter` style in `_Resources.xaml`
+instead — the same mechanism that already covers `DatePickerFlyoutPresenter`.
+
+**`TitlePresenter` included.** The repo's `DatePickerFlyoutPresenter` styles omit it; including it
+here costs six lines and makes `TimePickerFlyout.Title` actually render. Uno null-guards the lookup,
+so its absence was silent rather than fatal — which is why it was easy to miss.
+
+## Known gaps / follow-ups
+
+- **Cupertino** still has no `TimePicker` style. Out of scope for this change.
+- **Material v1** is unchanged; its `TimePicker.xaml` keeps the colon divider, the iOS-only presenter
+  style, and the missing named parts.
+- `TimePickerSamplePage.xaml.cs` still carries a `#if !__WASM__ && !__MACOS__` guard predating this
+  change. It was left in place because re-enabling it could not be verified on those heads here.
+
+## Verification
+
+- `dotnet build Uno.Themes-packages.slnf -c Debug` → **0 errors**; warnings all pre-existing
+  (`Uno0001` not-implemented notices and `CS0618` obsolete-`MaterialResources` notices), none
+  referencing TimePicker.
+- `dotnet build src/samples/SimpleSampleApp/SimpleSampleApp.csproj -c Debug -f net10.0-desktop`
+  → **0 errors**.
+- `dotnet build src/samples/MaterialSampleApp/MaterialSampleApp.csproj -c Debug -f net10.0-desktop`
+  → **0 errors**.
+- Merged dictionaries confirmed to include both new files
+  (`Uno.Material/Generated/mergedpages.v2.xaml`, `Uno.Simple.WinUI/Generated/mergedpages.xaml`).
+- Runtime tests, desktop head, filtered to `Given_TimePickerStyles`: **18/18 passed**.
+- Full runtime-test suite: **111 passed, 0 failed, 1 skipped**. The skip is the pre-existing
+  `Given_HotReload.When_BaseThemeIsCollected_Then_HotReloadHandlerDoesNotResurrectIt`, which carries
+  an `[Ignore]` attribute predating this change.
+
+### Running the tests locally on Windows
+
+`build/scripts/linux-skia-desktop-runtime-tests.sh` is Linux-only (`xvfb-run`). On Windows, run the
+built DLL directly — and note that **`--runtime-tests=<path>` alone is not enough** for engine
+2.0.0-dev.60: `RuntimeTestEmbeddedRunner.AutoStartTests` reads `UNO_RUNTIME_TESTS_OUTPUT_PATH` /
+`UNO_RUNTIME_TESTS_OUTPUT_URL`, and without one it logs
+"Application has not been configured with output destination, aborting runtime-test embedded runner"
+and just opens the app.
+
+```bash
+cd src/samples/SimpleSampleApp/bin/Debug/net10.0-desktop
+export DOTNET_MODIFIABLE_ASSEMBLIES=debug
+export UNO_RUNTIME_TESTS_RUN_TESTS='{"Filter":{"Value":"Given_TimePickerStyles"},"Attempts":1}'
+export UNO_RUNTIME_TESTS_OUTPUT_PATH='results.xml'
+dotnet SimpleSampleApp.dll
+```
+
+The app does not exit after writing results — kill it before the next build or the output DLLs stay
+locked (`MSB3027`).
+
+### XamlStyler caveat
+
+`Settings.XamlStyler` does not set `IndentWithTabs`, so the documented
+`dotnet dnx XamlStyler.Console …` command reformats `.xaml` to **4 spaces**, contradicting
+`.editorconfig` (`[*.xaml] indent_style = tab`). The three XAML files here were re-tabbed after
+styling (N leading spaces → N/4 tabs + N%4 spaces, which preserves attribute alignment) to match
+every other file in the repo. Worth fixing in `Settings.XamlStyler` separately.
+
+## Follow-up session — review feedback
+
+Changes made after the first visual review of the sample apps:
+
+1. **Dark selection band invisible.** Simple's `*FlyoutPresenterHighlightFill` used
+   `PrimaryVariantLightBrush`, which is `#1E1E1E` in Dark — identical to `SurfaceColor`, i.e. the band
+   painted itself onto the flyout background. Both `TimePicker` and `DatePicker` now use
+   `SurfaceVariantBrush` (`#F5F5F5` Light, unchanged appearance / `#2C2C2C` Dark).
+2. **Field reads as a single value.** The hour / minute / period run is laid out with `Auto` columns in
+   a left-aligned grid, and `First|SecondColumnDivider` (typed `UIElement` in the control contract)
+   carry the `:` separator instead of a vertical rule. The parts stay owned by the control, so culture
+   ordering, `MinuteIncrement` and 24-hour `ClockIdentifier` still apply.
+3. **Pickers size to content.** `HorizontalAlignment` `Stretch` → `Left` on all four picker styles, with
+   `*FlyoutPresenterMinWidth` as the floor. This also fixes the full-width flyout:
+   `TimePickerFlyout` / `DatePickerFlyout` assign `presenter.Width = target.ActualWidth` on opening.
+4. **Header no longer rendered twice.** Material: the header is a floating label (Material TextBox
+   behaviour) — resting at body size, centered in the field, animating up and scaling to 0.7 once a
+   value is set; the separate header-bound placeholder is gone. Simple: the header renders only as the
+   in-field placeholder, as `SimpleTextBox` does with `PlaceholderText`; with no header, the control's
+   own `hour : minute AM` run remains as the fallback placeholder.
+
+Runtime tests: `Given_TimePickerStyles` and `Given_PickerFieldLayout` (sizing + header-renders-once,
+both pickers). Full `SimpleSampleApp` suite: 121 passed / 0 failed.
+
+Not verified by tests: the Material floating-label geometry (`*HeaderFloatTranslateY` = -11,
+`*HeaderFloatScale` = 0.7) is computed from the 53px field metrics and needs a visual check.

--- a/specs/timepicker-styles/timepicker-styles.md
+++ b/specs/timepicker-styles/timepicker-styles.md
@@ -66,11 +66,13 @@ the column they separate.
 keys would be dead API. Pressed/disabled feedback comes from the flyout-button opacity keys, matching
 how `DatePicker`'s flyout button already works in both themes.
 
-**No `FlyoutPresenterStyle` setter.** `DatePicker` sets `not_win:FlyoutPresenterStyle`, but
-`TimePicker` has no such property (`TimePicker.Properties.cs` declares only `ClockIdentifier`,
-`Header`, `HeaderTemplate`, `LightDismissOverlayMode`, `MinuteIncrement`, `SelectedTime`, `Time`).
-The presenter is styled through the implicit `TimePickerFlyoutPresenter` style in `_Resources.xaml`
-instead — the same mechanism that already covers `DatePickerFlyoutPresenter`.
+**`FlyoutPresenterStyle` setter — required after all.** An earlier revision of this spec claimed
+`TimePicker` had no such property, having looked only at `TimePicker.Properties.cs`. It is declared in
+`TimePicker.Flyout.cs:56` as an Uno-only DP, exactly mirroring `DatePicker.FlyoutPresenterStyle`, and
+`TimePicker.Flyout.cs:97` forwards it to `TimePickerFlyout.TimePickerFlyoutPresenterStyle`. Without the
+setter an explicitly-styled `TimePicker` on non-Windows targets falls back to the Fluent presenter and
+the entire `TimePickerFlyoutPresenter*` key family is dead. Both new styles now carry
+`not_win:Setter Property="FlyoutPresenterStyle"`, matching their `DatePicker` siblings.
 
 **`TitlePresenter` included.** The repo's `DatePickerFlyoutPresenter` styles omit it; including it
 here costs six lines and makes `TimePickerFlyout.Title` actually render. Uno null-guards the lookup,
@@ -136,21 +138,58 @@ Changes made after the first visual review of the sample apps:
    `PrimaryVariantLightBrush`, which is `#1E1E1E` in Dark — identical to `SurfaceColor`, i.e. the band
    painted itself onto the flyout background. Both `TimePicker` and `DatePicker` now use
    `SurfaceVariantBrush` (`#F5F5F5` Light, unchanged appearance / `#2C2C2C` Dark).
-2. **Field reads as a single value.** The hour / minute / period run is laid out with `Auto` columns in
-   a left-aligned grid, and `First|SecondColumnDivider` (typed `UIElement` in the control contract)
-   carry the `:` separator instead of a vertical rule. The parts stay owned by the control, so culture
-   ordering, `MinuteIncrement` and 24-hour `ClockIdentifier` still apply.
+2. **Field columns follow the control, not the template.** An intermediate revision drifted from the
+   "Rectangle dividers" decision above and shipped a literal `:` in `FirstColumnDivider` plus `Auto`
+   column widths. Review caught both:
+   - `UpdateOrderAndLayout` only toggles divider *visibility*; it never repositions them. With
+     `periodOrder == 0` (ko-KR / zh-CN / ja-JP) the period occupies `FirstPickerHost`, so the colon
+     rendered between period and hour and the hour/minute pair had none.
+   - The same method assigns `1*` to every populated `*TextBlockColumn` on each pass, so the `Auto`
+     widths — and the "single compact value" behaviour attributed to them — never existed at runtime.
+
+   Restored to the original decision: neutral `Rectangle` dividers and `*` columns, matching Fluent.
+   The parts stay owned by the control, so culture ordering, `MinuteIncrement` and 24-hour
+   `ClockIdentifier` still apply.
 3. **Pickers size to content.** `HorizontalAlignment` `Stretch` → `Left` on all four picker styles, with
    `*FlyoutPresenterMinWidth` as the floor. This also fixes the full-width flyout:
    `TimePickerFlyout` / `DatePickerFlyout` assign `presenter.Width = target.ActualWidth` on opening.
 4. **Header no longer rendered twice.** Material: the header is a floating label (Material TextBox
-   behaviour) — resting at body size, centered in the field, animating up and scaling to 0.7 once a
-   value is set; the separate header-bound placeholder is gone. Simple: the header renders only as the
+   behaviour); the separate header-bound placeholder is gone. Simple: the header renders only as the
    in-field placeholder, as `SimpleTextBox` does with `PlaceholderText`; with no header, the control's
-   own `hour : minute AM` run remains as the fallback placeholder.
+   own hour / minute / period run remains as the fallback placeholder. Both themes render the header
+   through a `ContentPresenter`, so a non-string `Header` and `HeaderTemplate` are honoured rather than
+   silently `ToString()`-ed and dropped.
 
-Runtime tests: `Given_TimePickerStyles` and `Given_PickerFieldLayout` (sizing + header-renders-once,
-both pickers). Full `SimpleSampleApp` suite: 121 passed / 0 failed.
+5. **Header float is layout-driven, not a magic offset.** The first attempt translated the label by a
+   hand-computed `-11` derived from the 53px field height, which was never pixel-verified and broke the
+   header-less case: with `ContentMargin` `10,24,10,0` and `VerticalAlignment="Top"`, a bare
+   `<TimePicker />` rendered its value against the bottom edge. Header and value now occupy two `Auto`
+   rows centred in the field, so all three combinations fall out of layout — no header (label collapses,
+   value centres), header without value (label centres as the placeholder), and both (they stack).
+   `*HeaderFloatTranslateY` is gone; only `*HeaderFloatScale` remains, and it lives at dictionary scope
+   because the Storyboard reads it through `StaticResource`, which does not re-resolve per
+   `ThemeDictionary`.
 
-Not verified by tests: the Material floating-label geometry (`*HeaderFloatTranslateY` = -11,
-`*HeaderFloatScale` = 0.7) is computed from the 53px field metrics and needs a visual check.
+## Declined findings
+
+**Deduplicating the four flyout-button / flyout-presenter styles.** Review flagged
+`Material|Simple {Date,Time}PickerFlyoutButtonStyle` as near-identical copies differing only by key
+prefix. They must stay separate: each reads its own `{Date,Time}PickerFlyoutButton*` key family, and a
+shared `BasedOn` base would have to pick one family, silently breaking per-control lightweight styling —
+the documented contract in `doc/lightweight-styling.md`. The duplication is the contract, not an
+accident. The same applies to the two float Storyboards, which read `{Date,Time}PickerHeaderFloatScale`.
+
+## Verification
+
+Runtime tests: `Given_TimePickerStyles` and `Given_PickerFieldLayout` (SimpleSampleApp), and
+`Given_MaterialPickerStyles` (MaterialSampleApp) — the Material templates previously had no coverage at
+all. New guards worth calling out:
+
+- Selection-band contrast is now asserted under Light **and** Dark by resolving the brushes through a
+  themed, loaded element. The previous version used the `ResourceDictionary` indexer, which resolves
+  ThemeDictionaries against the *application* theme — both `DataRow`s asserted the same value, and
+  because Light already contrasted (`#F5F5F5` vs `#FFFFFF`) the test passed on `master` and never
+  reproduced the Dark bug it was written for.
+- Divider type (`not a TextBlock`) and control-assigned `1*` column widths, pinning the two behaviours
+  that the culture and layout defects above turned on.
+- Header-less vertical centring, the case the float offset broke.

--- a/src/library/Uno.Material/Styles/Controls/v2/DatePicker.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/DatePicker.xaml
@@ -58,8 +58,13 @@
 			<x:Double x:Key="DatePickerButtonBottomBorderHeight">2</x:Double>
 			<StaticResource x:Key="DatePickerButtonContentHeight" ResourceKey="IconSizeMedium" />
 			<Thickness x:Key="DatePickerButtonHeaderMargin">10,8,10,0</Thickness>
-			<Thickness x:Key="DatePickerButtonPlaceholderMargin">4,0,0,0</Thickness>
-			<Thickness x:Key="DatePickerButtonContentMargin">6,24,10,0</Thickness>
+			<!-- Floating label: distance and scale from the value position up to the header position -->
+			<x:Double x:Key="DatePickerHeaderFloatTranslateY">-11</x:Double>
+			<x:Double x:Key="DatePickerHeaderFloatScale">0.7</x:Double>
+			<!-- Resting (placeholder) position of the floating header — centered, inset like the header -->
+			<Thickness x:Key="DatePickerButtonPlaceholderMargin">10,0,10,0</Thickness>
+			<!-- Left inset matches DatePickerButtonHeaderMargin so the value lines up under the header -->
+			<Thickness x:Key="DatePickerButtonContentMargin">10,24,10,0</Thickness>
 			<Thickness x:Key="DatePickerHostPadding">24,24,8,8</Thickness>
 			<Thickness x:Key="DatePickerFlyoutButtonPadding">0</Thickness>
 			<CornerRadius x:Key="DatePickerCornerRadius">4,4,0,0</CornerRadius>
@@ -114,8 +119,13 @@
 			<x:Double x:Key="DatePickerButtonBottomBorderHeight">2</x:Double>
 			<StaticResource x:Key="DatePickerButtonContentHeight" ResourceKey="IconSizeMedium" />
 			<Thickness x:Key="DatePickerButtonHeaderMargin">10,8,10,0</Thickness>
-			<Thickness x:Key="DatePickerButtonPlaceholderMargin">4,0,0,0</Thickness>
-			<Thickness x:Key="DatePickerButtonContentMargin">6,24,10,0</Thickness>
+			<!-- Floating label: distance and scale from the value position up to the header position -->
+			<x:Double x:Key="DatePickerHeaderFloatTranslateY">-11</x:Double>
+			<x:Double x:Key="DatePickerHeaderFloatScale">0.7</x:Double>
+			<!-- Resting (placeholder) position of the floating header — centered, inset like the header -->
+			<Thickness x:Key="DatePickerButtonPlaceholderMargin">10,0,10,0</Thickness>
+			<!-- Left inset matches DatePickerButtonHeaderMargin so the value lines up under the header -->
+			<Thickness x:Key="DatePickerButtonContentMargin">10,24,10,0</Thickness>
 			<Thickness x:Key="DatePickerHostPadding">24,24,8,8</Thickness>
 			<Thickness x:Key="DatePickerFlyoutButtonPadding">0</Thickness>
 			<CornerRadius x:Key="DatePickerCornerRadius">4,4,0,0</CornerRadius>
@@ -273,7 +283,9 @@
 		<Setter Property="Background" Value="{ThemeResource DatePickerButtonBackground}" />
 		<Setter Property="Foreground" Value="{ThemeResource DatePickerButtonForeground}" />
 		<Setter Property="BorderBrush" Value="{ThemeResource DatePickerButtonBorderBrush}" />
-		<Setter Property="HorizontalAlignment" Value="Stretch" />
+		<!-- Sizes to content like the Fluent DatePicker (the field's MinWidth sets the floor) — a stretched field
+			 also stretches the flyout, which DatePickerFlyout sizes to the target's ActualWidth on opening. -->
+		<Setter Property="HorizontalAlignment" Value="Left" />
 		<Setter Property="Height" Value="{ThemeResource DatePickerHeight}" />
 		<Setter Property="CornerRadius" Value="{ThemeResource DatePickerCornerRadius}" />
 		<not_win:Setter Property="FlyoutPresenterStyle"
@@ -304,15 +316,26 @@
 										   VerticalAlignment="Bottom"
 										   Fill="{TemplateBinding BorderBrush}" />
 
-								<!-- Header -->
+								<!--
+									Floating label, as in the Material TextBox: the header rests where the value
+									sits and reads as the placeholder while there is no date, then animates up and
+									shrinks once a date is picked (HasDate). It is the only element rendering the
+									header — a separate header line plus a header-bound placeholder showed the same
+									text twice.
+								-->
 								<TextBlock x:Name="HeaderTextBlock"
-										   Margin="{ThemeResource DatePickerButtonHeaderMargin}"
+										   Margin="{ThemeResource DatePickerButtonPlaceholderMargin}"
 										   HorizontalAlignment="Stretch"
-										   VerticalAlignment="Top"
-										   Foreground="{TemplateBinding Foreground}"
-										   Style="{StaticResource MaterialBodySmall}"
+										   VerticalAlignment="Center"
+										   Foreground="{ThemeResource DatePickerPlaceholderTextForeground}"
+										   RenderTransformOrigin="0,0.5"
+										   Style="{StaticResource MaterialBodyLarge}"
 										   Text="{TemplateBinding Header}"
-										   TextWrapping="Wrap" />
+										   TextWrapping="Wrap">
+									<TextBlock.RenderTransform>
+										<CompositeTransform x:Name="HeaderTextBlock_CompositeTransform" />
+									</TextBlock.RenderTransform>
+								</TextBlock>
 
 								<Grid x:Name="FlyoutButtonContentGrid"
 									  Height="{ThemeResource DatePickerButtonContentHeight}"
@@ -322,16 +345,8 @@
 									<!-- DateText -->
 									<TextBlock x:Name="DateText"
 											   Foreground="{ThemeResource DatePickerButtonDateTextForeground}"
-											   Style="{StaticResource MaterialBodyMedium}"
-											   Text="{Binding SelectedDate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource StringFormatConverter}, ConverterParameter=' {0:d}'}" />
-
-									<!-- PlaceholderText -->
-									<TextBlock x:Name="PlaceholderText"
-											   Margin="{ThemeResource DatePickerButtonPlaceholderMargin}"
-											   Foreground="{ThemeResource DatePickerPlaceholderTextForeground}"
-											   Style="{StaticResource MaterialBodyMedium}"
-											   Text="{TemplateBinding Header}"
-											   Visibility="Collapsed" />
+											   Style="{StaticResource MaterialBodyLarge}"
+											   Text="{Binding SelectedDate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:d}'}" />
 
 									<!-- Removing this cause trouble with the DatePicker code -->
 									<TextBlock x:Name="DayTextBlock"
@@ -373,11 +388,35 @@
 							</VisualStateGroup>
 
 							<VisualStateGroup x:Name="HasDateStates">
-								<VisualState x:Name="HasDate" />
+								<!--
+									With a date picked the header floats above the value; without one it stays at
+									the value's position and reads as the placeholder.
+								-->
+								<VisualState x:Name="HasDate">
+									<VisualState.Setters>
+										<Setter Target="HeaderTextBlock.Foreground" Value="{ThemeResource DatePickerButtonForeground}" />
+									</VisualState.Setters>
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="HeaderTextBlock_CompositeTransform"
+														 Storyboard.TargetProperty="TranslateY"
+														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="{StaticResource DatePickerHeaderFloatTranslateY}" />
+										<DoubleAnimation Storyboard.TargetName="HeaderTextBlock_CompositeTransform"
+														 Storyboard.TargetProperty="ScaleX"
+														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="{StaticResource DatePickerHeaderFloatScale}" />
+										<DoubleAnimation Storyboard.TargetName="HeaderTextBlock_CompositeTransform"
+														 Storyboard.TargetProperty="ScaleY"
+														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="{StaticResource DatePickerHeaderFloatScale}" />
+									</Storyboard>
+								</VisualState>
 								<VisualState x:Name="HasNoDate">
 									<VisualState.Setters>
 										<Setter Target="DateText.Visibility" Value="Collapsed" />
-										<Setter Target="PlaceholderText.Visibility" Value="Visible" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>

--- a/src/library/Uno.Material/Styles/Controls/v2/DatePicker.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/DatePicker.xaml
@@ -57,14 +57,17 @@
 			<StaticResource x:Key="DatePickerFlyoutPresenterHighlightHeight" ResourceKey="ControlHeightMedium" />
 			<x:Double x:Key="DatePickerButtonBottomBorderHeight">2</x:Double>
 			<StaticResource x:Key="DatePickerButtonContentHeight" ResourceKey="IconSizeMedium" />
+			<!--
+				Deprecated: the header no longer renders as a separate line above the field, so
+				nothing reads this. Kept because it is published API (Uno.Themes.WinUI.Markup
+				exposes it as DatePicker.Button.HeaderMargin). Use DatePickerButtonPlaceholderMargin
+				to inset the header instead.
+			-->
 			<Thickness x:Key="DatePickerButtonHeaderMargin">10,8,10,0</Thickness>
-			<!-- Floating label: distance and scale from the value position up to the header position -->
-			<x:Double x:Key="DatePickerHeaderFloatTranslateY">-11</x:Double>
-			<x:Double x:Key="DatePickerHeaderFloatScale">0.7</x:Double>
-			<!-- Resting (placeholder) position of the floating header — centered, inset like the header -->
+			<!-- Inset of the header row; also the resting position of the floating label -->
 			<Thickness x:Key="DatePickerButtonPlaceholderMargin">10,0,10,0</Thickness>
-			<!-- Left inset matches DatePickerButtonHeaderMargin so the value lines up under the header -->
-			<Thickness x:Key="DatePickerButtonContentMargin">10,24,10,0</Thickness>
+			<!-- Inset of the value row, which sits under the header row -->
+			<Thickness x:Key="DatePickerButtonContentMargin">10,0,10,0</Thickness>
 			<Thickness x:Key="DatePickerHostPadding">24,24,8,8</Thickness>
 			<Thickness x:Key="DatePickerFlyoutButtonPadding">0</Thickness>
 			<CornerRadius x:Key="DatePickerCornerRadius">4,4,0,0</CornerRadius>
@@ -118,19 +121,32 @@
 			<StaticResource x:Key="DatePickerFlyoutPresenterHighlightHeight" ResourceKey="ControlHeightMedium" />
 			<x:Double x:Key="DatePickerButtonBottomBorderHeight">2</x:Double>
 			<StaticResource x:Key="DatePickerButtonContentHeight" ResourceKey="IconSizeMedium" />
+			<!--
+				Deprecated: the header no longer renders as a separate line above the field, so
+				nothing reads this. Kept because it is published API (Uno.Themes.WinUI.Markup
+				exposes it as DatePicker.Button.HeaderMargin). Use DatePickerButtonPlaceholderMargin
+				to inset the header instead.
+			-->
 			<Thickness x:Key="DatePickerButtonHeaderMargin">10,8,10,0</Thickness>
-			<!-- Floating label: distance and scale from the value position up to the header position -->
-			<x:Double x:Key="DatePickerHeaderFloatTranslateY">-11</x:Double>
-			<x:Double x:Key="DatePickerHeaderFloatScale">0.7</x:Double>
-			<!-- Resting (placeholder) position of the floating header — centered, inset like the header -->
+			<!-- Inset of the header row; also the resting position of the floating label -->
 			<Thickness x:Key="DatePickerButtonPlaceholderMargin">10,0,10,0</Thickness>
-			<!-- Left inset matches DatePickerButtonHeaderMargin so the value lines up under the header -->
-			<Thickness x:Key="DatePickerButtonContentMargin">10,24,10,0</Thickness>
+			<!-- Inset of the value row, which sits under the header row -->
+			<Thickness x:Key="DatePickerButtonContentMargin">10,0,10,0</Thickness>
 			<Thickness x:Key="DatePickerHostPadding">24,24,8,8</Thickness>
 			<Thickness x:Key="DatePickerFlyoutButtonPadding">0</Thickness>
 			<CornerRadius x:Key="DatePickerCornerRadius">4,4,0,0</CornerRadius>
 		</ResourceDictionary>
 	</ResourceDictionary.ThemeDictionaries>
+
+	<!--
+		Theme-invariant: declared at dictionary scope so the Storyboard below can read it.
+		Storyboard/Setter values resolve through StaticResource, which does not re-resolve
+		per ThemeDictionary — a key defined only inside ThemeDictionaries is not reliably
+		overridable from there. Consumers still override it from their own App resources.
+		The header's vertical movement is layout-driven (two Auto rows), so only the scale
+		is animated and there is no translate constant tied to the field height.
+	-->
+	<x:Double x:Key="DatePickerHeaderFloatScale">0.7</x:Double>
 
 	<!-- DatePicker Style -->
 	<Style x:Key="MaterialDatePickerFlyoutButtonStyle"
@@ -317,40 +333,59 @@
 										   Fill="{TemplateBinding BorderBrush}" />
 
 								<!--
-									Floating label, as in the Material TextBox: the header rests where the value
-									sits and reads as the placeholder while there is no date, then animates up and
-									shrinks once a date is picked (HasDate). It is the only element rendering the
-									header — a separate header line plus a header-bound placeholder showed the same
-									text twice.
+									Header and value stack in two Auto rows, centered as a block. The rows are what
+									moves the header, not a magic offset: with no Header the presenter collapses,
+									row 0 takes no height and the value centers in the field; with a Header and no
+									date the value row is empty and the header centers, reading as the placeholder;
+									with both, they stack and the header sits above the value. HasDate only scales
+									the header down, so there is no translate constant to keep in sync with the
+									field height.
 								-->
-								<TextBlock x:Name="HeaderTextBlock"
-										   Margin="{ThemeResource DatePickerButtonPlaceholderMargin}"
-										   HorizontalAlignment="Stretch"
-										   VerticalAlignment="Center"
-										   Foreground="{ThemeResource DatePickerPlaceholderTextForeground}"
-										   RenderTransformOrigin="0,0.5"
-										   Style="{StaticResource MaterialBodyLarge}"
-										   Text="{TemplateBinding Header}"
-										   TextWrapping="Wrap">
-									<TextBlock.RenderTransform>
-										<CompositeTransform x:Name="HeaderTextBlock_CompositeTransform" />
-									</TextBlock.RenderTransform>
-								</TextBlock>
+								<Grid VerticalAlignment="Center">
 
-								<Grid x:Name="FlyoutButtonContentGrid"
-									  Height="{ThemeResource DatePickerButtonContentHeight}"
-									  Margin="{ThemeResource DatePickerButtonContentMargin}"
-									  VerticalAlignment="Top">
+									<Grid.RowDefinitions>
+										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
+									</Grid.RowDefinitions>
 
-									<!-- DateText -->
-									<TextBlock x:Name="DateText"
-											   Foreground="{ThemeResource DatePickerButtonDateTextForeground}"
-											   Style="{StaticResource MaterialBodyLarge}"
-											   Text="{Binding SelectedDate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:d}'}" />
+									<!--
+										ContentPresenter rather than a TextBlock so a non-string Header and
+										HeaderTemplate both render (Header is typed object).
+									-->
+									<ContentPresenter x:Name="HeaderTextBlock"
+													  Grid.Row="0"
+													  Margin="{ThemeResource DatePickerButtonPlaceholderMargin}"
+													  HorizontalAlignment="Stretch"
+													  CharacterSpacing="{ThemeResource BodyLargeCharacterSpacing}"
+													  Content="{TemplateBinding Header}"
+													  ContentTemplate="{TemplateBinding HeaderTemplate}"
+													  FontFamily="{ThemeResource BodyLargeFontFamily}"
+													  FontSize="{ThemeResource BodyLargeFontSize}"
+													  FontWeight="{ThemeResource BodyLargeFontWeight}"
+													  Foreground="{ThemeResource DatePickerPlaceholderTextForeground}"
+													  RenderTransformOrigin="0,0.5"
+													  TextWrapping="Wrap"
+													  Visibility="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyOrNullToCollapsedConverter}}">
+										<ContentPresenter.RenderTransform>
+											<CompositeTransform x:Name="HeaderTextBlock_CompositeTransform" />
+										</ContentPresenter.RenderTransform>
+									</ContentPresenter>
 
-									<!-- Removing this cause trouble with the DatePicker code -->
-									<TextBlock x:Name="DayTextBlock"
-											   Opacity="0" />
+									<Grid x:Name="FlyoutButtonContentGrid"
+										  Grid.Row="1"
+										  Height="{ThemeResource DatePickerButtonContentHeight}"
+										  Margin="{ThemeResource DatePickerButtonContentMargin}">
+
+										<!-- DateText -->
+										<TextBlock x:Name="DateText"
+												   Foreground="{ThemeResource DatePickerButtonDateTextForeground}"
+												   Style="{StaticResource MaterialBodyLarge}"
+												   Text="{Binding SelectedDate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:d}'}" />
+
+										<!-- Removing this cause trouble with the DatePicker code -->
+										<TextBlock x:Name="DayTextBlock"
+												   Opacity="0" />
+									</Grid>
 								</Grid>
 							</Grid>
 						</Button>
@@ -389,19 +424,15 @@
 
 							<VisualStateGroup x:Name="HasDateStates">
 								<!--
-									With a date picked the header floats above the value; without one it stays at
-									the value's position and reads as the placeholder.
+									With a date picked the value row fills, so the header is pushed to the row above
+									and shrinks; with no date the value row is empty and the header sits centred,
+									reading as the placeholder.
 								-->
 								<VisualState x:Name="HasDate">
 									<VisualState.Setters>
 										<Setter Target="HeaderTextBlock.Foreground" Value="{ThemeResource DatePickerButtonForeground}" />
 									</VisualState.Setters>
 									<Storyboard>
-										<DoubleAnimation Storyboard.TargetName="HeaderTextBlock_CompositeTransform"
-														 Storyboard.TargetProperty="TranslateY"
-														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{StaticResource DatePickerHeaderFloatTranslateY}" />
 										<DoubleAnimation Storyboard.TargetName="HeaderTextBlock_CompositeTransform"
 														 Storyboard.TargetProperty="ScaleX"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"

--- a/src/library/Uno.Material/Styles/Controls/v2/TimePicker.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/TimePicker.xaml
@@ -1,0 +1,491 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:android="http://uno.ui/android"
+					xmlns:ios="http://uno.ui/ios"
+					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+					xmlns:not_win="http://uno.ui/not_win"
+					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:wasm="http://uno.ui/wasm"
+					mc:Ignorable="ios android wasm not_win">
+
+	<ResourceDictionary.ThemeDictionaries>
+		<ResourceDictionary x:Key="Default">
+			<!-- MaterialTimePickerFlyoutButtonStyle -->
+			<StaticResource x:Key="TimePickerFlyoutButtonBackground" ResourceKey="SystemControlTransparentBrush" />
+
+			<!-- MaterialTimePickerFlyoutPresenterStyle -->
+			<StaticResource x:Key="TimePickerFlyoutPresenterBackground" ResourceKey="SurfaceBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterBorderBrush" ResourceKey="OnSurfaceFocusedBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterSpacerFill" ResourceKey="OnSurfaceFocusedBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterHighlightFill" ResourceKey="PrimarySelectedBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterForeground" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterCornerRadius" ResourceKey="OverlayCornerRadius" />
+
+			<!-- MaterialTimePickerStyle -->
+			<StaticResource x:Key="TimePickerButtonBackground" ResourceKey="SurfaceVariantBrush" />
+			<StaticResource x:Key="TimePickerButtonBackgroundDisabled" ResourceKey="PrimaryFocusedBrush" />
+			<StaticResource x:Key="TimePickerHeaderForeground" ResourceKey="PrimaryBrush" />
+			<StaticResource x:Key="TimePickerHeaderForegroundDisabled" ResourceKey="OnSurfaceLowBrush" />
+			<StaticResource x:Key="TimePickerButtonTimeTextForeground" ResourceKey="OnSurfaceVariantBrush" />
+			<StaticResource x:Key="TimePickerButtonTimeTextForegroundDisabled" ResourceKey="OnSurfaceLowBrush" />
+			<StaticResource x:Key="TimePickerPlaceholderTextForeground" ResourceKey="OnSurfaceLowBrush" />
+			<StaticResource x:Key="TimePickerButtonBorderBrush" ResourceKey="PrimaryBrush" />
+			<StaticResource x:Key="TimePickerButtonBorderBrushDisabled" ResourceKey="OnSurfaceLowBrush" />
+			<StaticResource x:Key="TimePickerSpacerFill" ResourceKey="OnSurfaceVariantBrush" />
+			<StaticResource x:Key="TimePickerSpacerFillDisabled" ResourceKey="OnSurfaceLowBrush" />
+
+			<!--#region Typo-->
+			<StaticResource x:Key="TimePickerFlyoutPresenterFontFamily" ResourceKey="MaterialRegularFontFamily" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterFontSize" ResourceKey="ControlContentThemeFontSize" />
+			<!--#endregion-->
+
+			<x:Double x:Key="TimePickerFlyoutBorderThickness">1</x:Double>
+			<x:Double x:Key="TimePickerSpacerThemeWidth">1</x:Double>
+			<x:Double x:Key="TimePickerColumnDividerWidth">1</x:Double>
+			<x:Double x:Key="TimePickerHeight">53</x:Double>
+			<x:Double x:Key="TimePickerFlyoutElevation">8</x:Double>
+			<x:Double x:Key="TimePickerFlyoutButtonOpacityPressed">0.65</x:Double>
+			<x:Double x:Key="TimePickerFlyoutButtonOpacityDisabled">0.65</x:Double>
+			<x:Double x:Key="TimePickerFlyoutPresenterWidth">242</x:Double>
+			<x:Double x:Key="TimePickerFlyoutPresenterMinWidth">242</x:Double>
+			<x:Double x:Key="TimePickerFlyoutPresenterMaxHeight">398</x:Double>
+			<x:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">41</x:Double>
+			<StaticResource x:Key="TimePickerFlyoutPresenterHighlightHeight" ResourceKey="ControlHeightMedium" />
+			<x:Double x:Key="TimePickerButtonBottomBorderHeight">2</x:Double>
+			<StaticResource x:Key="TimePickerButtonContentHeight" ResourceKey="IconSizeMedium" />
+			<Thickness x:Key="TimePickerButtonHeaderMargin">10,8,10,0</Thickness>
+			<!-- Resting (placeholder) position of the floating header — centered, inset like the header -->
+			<Thickness x:Key="TimePickerButtonPlaceholderMargin">10,0,10,0</Thickness>
+			<!-- Floating label: distance and scale from the value position up to the header position -->
+			<x:Double x:Key="TimePickerHeaderFloatTranslateY">-11</x:Double>
+			<x:Double x:Key="TimePickerHeaderFloatScale">0.7</x:Double>
+			<!-- Left inset matches TimePickerButtonHeaderMargin so the value lines up under the header -->
+			<Thickness x:Key="TimePickerButtonContentMargin">10,24,10,0</Thickness>
+			<Thickness x:Key="TimePickerColumnDividerMargin">2,0,2,0</Thickness>
+			<Thickness x:Key="TimePickerFlyoutPresenterTitleMargin">16,12,16,4</Thickness>
+			<Thickness x:Key="TimePickerFlyoutButtonPadding">0</Thickness>
+			<CornerRadius x:Key="TimePickerCornerRadius">4,4,0,0</CornerRadius>
+		</ResourceDictionary>
+
+		<ResourceDictionary x:Key="Light">
+			<!-- MaterialTimePickerFlyoutButtonStyle -->
+			<StaticResource x:Key="TimePickerFlyoutButtonBackground" ResourceKey="SystemControlTransparentBrush" />
+
+			<!-- MaterialTimePickerFlyoutPresenterStyle -->
+			<StaticResource x:Key="TimePickerFlyoutPresenterBackground" ResourceKey="SurfaceBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterBorderBrush" ResourceKey="OnSurfaceFocusedBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterSpacerFill" ResourceKey="OnSurfaceFocusedBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterHighlightFill" ResourceKey="PrimarySelectedBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterForeground" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterCornerRadius" ResourceKey="OverlayCornerRadius" />
+
+			<!-- MaterialTimePickerStyle -->
+			<StaticResource x:Key="TimePickerButtonBackground" ResourceKey="SurfaceVariantBrush" />
+			<StaticResource x:Key="TimePickerButtonBackgroundDisabled" ResourceKey="PrimaryFocusedBrush" />
+			<StaticResource x:Key="TimePickerHeaderForeground" ResourceKey="PrimaryBrush" />
+			<StaticResource x:Key="TimePickerHeaderForegroundDisabled" ResourceKey="OnSurfaceLowBrush" />
+			<StaticResource x:Key="TimePickerButtonTimeTextForeground" ResourceKey="OnSurfaceVariantBrush" />
+			<StaticResource x:Key="TimePickerButtonTimeTextForegroundDisabled" ResourceKey="OnSurfaceLowBrush" />
+			<StaticResource x:Key="TimePickerPlaceholderTextForeground" ResourceKey="OnSurfaceLowBrush" />
+			<StaticResource x:Key="TimePickerButtonBorderBrush" ResourceKey="PrimaryBrush" />
+			<StaticResource x:Key="TimePickerButtonBorderBrushDisabled" ResourceKey="OnSurfaceLowBrush" />
+			<StaticResource x:Key="TimePickerSpacerFill" ResourceKey="OnSurfaceVariantBrush" />
+			<StaticResource x:Key="TimePickerSpacerFillDisabled" ResourceKey="OnSurfaceLowBrush" />
+
+			<!--#region Typo-->
+			<StaticResource x:Key="TimePickerFlyoutPresenterFontFamily" ResourceKey="MaterialRegularFontFamily" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterFontSize" ResourceKey="ControlContentThemeFontSize" />
+			<!--#endregion-->
+
+			<x:Double x:Key="TimePickerFlyoutBorderThickness">1</x:Double>
+			<x:Double x:Key="TimePickerSpacerThemeWidth">1</x:Double>
+			<x:Double x:Key="TimePickerColumnDividerWidth">1</x:Double>
+			<x:Double x:Key="TimePickerHeight">53</x:Double>
+			<x:Double x:Key="TimePickerFlyoutElevation">8</x:Double>
+			<x:Double x:Key="TimePickerFlyoutButtonOpacityPressed">0.65</x:Double>
+			<x:Double x:Key="TimePickerFlyoutButtonOpacityDisabled">0.65</x:Double>
+			<x:Double x:Key="TimePickerFlyoutPresenterWidth">242</x:Double>
+			<x:Double x:Key="TimePickerFlyoutPresenterMinWidth">242</x:Double>
+			<x:Double x:Key="TimePickerFlyoutPresenterMaxHeight">398</x:Double>
+			<x:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">41</x:Double>
+			<StaticResource x:Key="TimePickerFlyoutPresenterHighlightHeight" ResourceKey="ControlHeightMedium" />
+			<x:Double x:Key="TimePickerButtonBottomBorderHeight">2</x:Double>
+			<StaticResource x:Key="TimePickerButtonContentHeight" ResourceKey="IconSizeMedium" />
+			<Thickness x:Key="TimePickerButtonHeaderMargin">10,8,10,0</Thickness>
+			<!-- Resting (placeholder) position of the floating header — centered, inset like the header -->
+			<Thickness x:Key="TimePickerButtonPlaceholderMargin">10,0,10,0</Thickness>
+			<!-- Floating label: distance and scale from the value position up to the header position -->
+			<x:Double x:Key="TimePickerHeaderFloatTranslateY">-11</x:Double>
+			<x:Double x:Key="TimePickerHeaderFloatScale">0.7</x:Double>
+			<!-- Left inset matches TimePickerButtonHeaderMargin so the value lines up under the header -->
+			<Thickness x:Key="TimePickerButtonContentMargin">10,24,10,0</Thickness>
+			<Thickness x:Key="TimePickerColumnDividerMargin">2,0,2,0</Thickness>
+			<Thickness x:Key="TimePickerFlyoutPresenterTitleMargin">16,12,16,4</Thickness>
+			<Thickness x:Key="TimePickerFlyoutButtonPadding">0</Thickness>
+			<CornerRadius x:Key="TimePickerCornerRadius">4,4,0,0</CornerRadius>
+		</ResourceDictionary>
+	</ResourceDictionary.ThemeDictionaries>
+
+	<!-- TimePicker Style -->
+	<Style x:Key="MaterialTimePickerFlyoutButtonStyle"
+		   TargetType="Button">
+
+		<Setter Property="Background" Value="{ThemeResource TimePickerFlyoutButtonBackground}" />
+		<Setter Property="Padding" Value="{ThemeResource TimePickerFlyoutButtonPadding}" />
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="Button">
+
+					<Grid x:Name="RootGrid"
+						  Background="{TemplateBinding Background}">
+						<!-- Label -->
+						<ContentPresenter x:Name="ContentPresenter"
+										  Margin="{TemplateBinding Padding}"
+										  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Content="{TemplateBinding Content}"
+										  ContentTemplate="{TemplateBinding ContentTemplate}"
+										  ContentTransitions="{TemplateBinding ContentTransitions}" />
+
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal" />
+								<VisualState x:Name="PointerOver" />
+								<VisualState x:Name="Pressed">
+									<VisualState.Setters>
+										<Setter Target="RootGrid.Opacity" Value="{ThemeResource TimePickerFlyoutButtonOpacityPressed}" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="RootGrid.Opacity" Value="{ThemeResource TimePickerFlyoutButtonOpacityDisabled}" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style x:Key="MaterialTimePickerFlyoutPresenterStyle"
+		   TargetType="TimePickerFlyoutPresenter">
+		<Setter Property="Width" Value="{ThemeResource TimePickerFlyoutPresenterWidth}" />
+		<Setter Property="MinWidth" Value="{ThemeResource TimePickerFlyoutPresenterMinWidth}" />
+		<Setter Property="MaxHeight" Value="{ThemeResource TimePickerFlyoutPresenterMaxHeight}" />
+		<Setter Property="IsTabStop" Value="False" />
+		<Setter Property="FontFamily" Value="{ThemeResource TimePickerFlyoutPresenterFontFamily}" />
+		<Setter Property="FontWeight" Value="Normal" />
+		<Setter Property="FontSize" Value="{ThemeResource TimePickerFlyoutPresenterFontSize}" />
+		<Setter Property="Foreground" Value="{ThemeResource TimePickerFlyoutPresenterForeground}" />
+		<Setter Property="Background" Value="{ThemeResource TimePickerFlyoutPresenterBackground}" />
+		<Setter Property="AutomationProperties.AutomationId" Value="TimePickerFlyoutPresenter" />
+		<Setter Property="BorderThickness" Value="{ThemeResource TimePickerFlyoutBorderThickness}" />
+		<Setter Property="BorderBrush" Value="{ThemeResource TimePickerFlyoutPresenterBorderBrush}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource TimePickerFlyoutPresenterCornerRadius}" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="TimePickerFlyoutPresenter">
+					<toolkit:ElevatedView MaxHeight="{TemplateBinding MaxHeight}"
+										  Background="{TemplateBinding Background}"
+										  BorderBrush="{TemplateBinding BorderBrush}"
+										  BorderThickness="{TemplateBinding BorderThickness}"
+										  CornerRadius="{TemplateBinding CornerRadius}"
+										  Elevation="{ThemeResource TimePickerFlyoutElevation}"
+										  ShadowColor="{StaticResource ShadowColor}">
+						<Border x:Name="Background">
+							<Grid x:Name="ContentPanel">
+
+								<Grid.RowDefinitions>
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="*" />
+									<RowDefinition Height="Auto" />
+								</Grid.RowDefinitions>
+
+								<!-- Optional flyout title (TimePickerFlyout.Title) -->
+								<TextBlock x:Name="TitlePresenter"
+										   Grid.Row="0"
+										   Margin="{ThemeResource TimePickerFlyoutPresenterTitleMargin}"
+										   Foreground="{TemplateBinding Foreground}"
+										   Style="{StaticResource MaterialBodySmall}"
+										   TextWrapping="Wrap"
+										   Visibility="Collapsed" />
+
+								<Grid Grid.Row="1">
+
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition x:Name="FirstPickerHostColumn"
+														  Width="*" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition x:Name="SecondPickerHostColumn"
+														  Width="*" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition x:Name="ThirdPickerHostColumn"
+														  Width="*" />
+									</Grid.ColumnDefinitions>
+									<Rectangle x:Name="HighlightRect"
+											   Grid.Column="0"
+											   Grid.ColumnSpan="5"
+											   Height="{ThemeResource TimePickerFlyoutPresenterHighlightHeight}"
+											   VerticalAlignment="Center"
+											   Fill="{ThemeResource TimePickerFlyoutPresenterHighlightFill}" />
+									<Border x:Name="FirstPickerHost"
+											Grid.Column="0" />
+									<Rectangle x:Name="FirstPickerSpacing"
+											   Grid.Column="1"
+											   Width="{ThemeResource TimePickerSpacerThemeWidth}"
+											   HorizontalAlignment="Center"
+											   Fill="{ThemeResource TimePickerFlyoutPresenterSpacerFill}" />
+									<Border x:Name="SecondPickerHost"
+											Grid.Column="2" />
+									<Rectangle x:Name="SecondPickerSpacing"
+											   Grid.Column="3"
+											   Width="{ThemeResource TimePickerSpacerThemeWidth}"
+											   HorizontalAlignment="Center"
+											   Fill="{ThemeResource TimePickerFlyoutPresenterSpacerFill}" />
+									<Border x:Name="ThirdPickerHost"
+											Grid.Column="4" />
+								</Grid>
+
+								<Grid x:Name="AcceptDismissHostGrid"
+									  Grid.Row="2"
+									  Height="{ThemeResource TimePickerFlyoutPresenterAcceptDismissHostGridHeight}"
+									  VerticalAlignment="Bottom"
+									  Background="{TemplateBinding Background}">
+
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="*" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="Auto" />
+									</Grid.ColumnDefinitions>
+									<Rectangle Grid.ColumnSpan="3"
+											   Height="{ThemeResource TimePickerSpacerThemeWidth}"
+											   VerticalAlignment="Top"
+											   Fill="{ThemeResource TimePickerFlyoutPresenterSpacerFill}" />
+
+									<Button x:Name="DismissButton"
+											x:Uid="TimePickerFlyoutDismissButton"
+											Grid.Column="1"
+											HorizontalAlignment="Right"
+											Content="CANCEL"
+											Style="{StaticResource MaterialTextButtonStyle}" />
+
+									<Button x:Name="AcceptButton"
+											x:Uid="TimePickerFlyoutAcceptButton"
+											Grid.Column="2"
+											HorizontalAlignment="Right"
+											Content="OK"
+											Style="{StaticResource MaterialTextButtonStyle}" />
+								</Grid>
+							</Grid>
+						</Border>
+					</toolkit:ElevatedView>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style x:Key="MaterialTimePickerStyle"
+		   TargetType="TimePicker">
+
+		<Setter Property="Background" Value="{ThemeResource TimePickerButtonBackground}" />
+		<Setter Property="Foreground" Value="{ThemeResource TimePickerHeaderForeground}" />
+		<Setter Property="BorderBrush" Value="{ThemeResource TimePickerButtonBorderBrush}" />
+		<!-- Sizes to content like the Fluent TimePicker (the field's MinWidth sets the floor) — a stretched field
+			 also stretches the flyout, which TimePickerFlyout.OnOpening sizes to the target's ActualWidth. -->
+		<Setter Property="HorizontalAlignment" Value="Left" />
+		<Setter Property="Height" Value="{ThemeResource TimePickerHeight}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource TimePickerCornerRadius}" />
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="TimePicker">
+					<!-- Root Grid -->
+					<Grid x:Name="LayoutRoot">
+						<!-- Flyout Button -->
+						<Button x:Name="FlyoutButton"
+								MinWidth="{ThemeResource TimePickerFlyoutPresenterMinWidth}"
+								HorizontalAlignment="Stretch"
+								HorizontalContentAlignment="Stretch"
+								IsEnabled="{TemplateBinding IsEnabled}"
+								Style="{StaticResource MaterialTimePickerFlyoutButtonStyle}"
+								UseSystemFocusVisuals="{TemplateBinding UseSystemFocusVisuals}">
+
+							<Grid x:Name="ContentButton"
+								  Height="{TemplateBinding Height}"
+								  Background="{TemplateBinding Background}"
+								  CornerRadius="{TemplateBinding CornerRadius}">
+
+								<!-- Border -->
+								<Rectangle x:Name="BottomBorder"
+										   Height="{ThemeResource TimePickerButtonBottomBorderHeight}"
+										   VerticalAlignment="Bottom"
+										   Fill="{TemplateBinding BorderBrush}" />
+
+								<!--
+									Floating label, as in the Material TextBox: the header rests where the value
+									sits and reads as the placeholder while there is no time, then animates up and
+									shrinks once a time is picked (HasTime). It is the only element rendering the
+									header — a separate header line plus a header-bound placeholder showed the same
+									text twice.
+								-->
+								<TextBlock x:Name="HeaderTextBlock"
+										   Margin="{ThemeResource TimePickerButtonPlaceholderMargin}"
+										   HorizontalAlignment="Stretch"
+										   VerticalAlignment="Center"
+										   AutomationProperties.AccessibilityView="Raw"
+										   Foreground="{ThemeResource TimePickerPlaceholderTextForeground}"
+										   RenderTransformOrigin="0,0.5"
+										   Style="{StaticResource MaterialBodyLarge}"
+										   Text="{TemplateBinding Header}"
+										   TextWrapping="Wrap">
+									<TextBlock.RenderTransform>
+										<CompositeTransform x:Name="HeaderTextBlock_CompositeTransform" />
+									</TextBlock.RenderTransform>
+								</TextBlock>
+
+								<!--
+									The hour / minute / period parts stay under the control's ownership — it fills
+									them, reorders the hosts per culture and collapses the period column for a
+									24-hour ClockIdentifier. Auto columns and a left-aligned grid render them as a
+									single value ("9:41 AM") instead of three full-width cells, matching the
+									DatePicker field. First|SecondColumnDivider are typed UIElement in the control
+									contract, so they carry the time separator rather than a vertical rule.
+								-->
+								<Grid x:Name="FlyoutButtonContentGrid"
+									  Height="{ThemeResource TimePickerButtonContentHeight}"
+									  Margin="{ThemeResource TimePickerButtonContentMargin}"
+									  HorizontalAlignment="Left"
+									  VerticalAlignment="Top"
+									  Visibility="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyOrNullToVisibleConverter}}">
+
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition x:Name="FirstTextBlockColumn"
+														  Width="Auto" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition x:Name="SecondTextBlockColumn"
+														  Width="Auto" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition x:Name="ThirdTextBlockColumn"
+														  Width="Auto" />
+									</Grid.ColumnDefinitions>
+
+									<!-- Hours -->
+									<Border x:Name="FirstPickerHost"
+											Grid.Column="0">
+										<TextBlock x:Name="HourTextBlock"
+												   AutomationProperties.AccessibilityView="Raw"
+												   Foreground="{ThemeResource TimePickerButtonTimeTextForeground}"
+												   Style="{StaticResource MaterialBodyLarge}" />
+									</Border>
+
+									<!-- Time separator -->
+									<TextBlock x:Name="FirstColumnDivider"
+											   Grid.Column="1"
+											   Margin="{ThemeResource TimePickerColumnDividerMargin}"
+											   AutomationProperties.AccessibilityView="Raw"
+											   Foreground="{ThemeResource TimePickerSpacerFill}"
+											   Style="{StaticResource MaterialBodyLarge}"
+											   Text=":" />
+
+									<!-- Minutes -->
+									<Border x:Name="SecondPickerHost"
+											Grid.Column="2">
+										<TextBlock x:Name="MinuteTextBlock"
+												   AutomationProperties.AccessibilityView="Raw"
+												   Foreground="{ThemeResource TimePickerButtonTimeTextForeground}"
+												   Style="{StaticResource MaterialBodyLarge}" />
+									</Border>
+
+									<!-- Period spacing — collapsed by the control for a 24-hour clock -->
+									<TextBlock x:Name="SecondColumnDivider"
+											   Grid.Column="3"
+											   Margin="{ThemeResource TimePickerColumnDividerMargin}"
+											   AutomationProperties.AccessibilityView="Raw"
+											   Style="{StaticResource MaterialBodyLarge}" />
+
+									<!-- AM/PM -->
+									<Border x:Name="ThirdPickerHost"
+											Grid.Column="4">
+										<TextBlock x:Name="PeriodTextBlock"
+												   AutomationProperties.AccessibilityView="Raw"
+												   Foreground="{ThemeResource TimePickerButtonTimeTextForeground}"
+												   Style="{StaticResource MaterialBodyLarge}" />
+									</Border>
+								</Grid>
+							</Grid>
+						</Button>
+
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal" />
+
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="ContentButton.Background" Value="{ThemeResource TimePickerButtonBackgroundDisabled}" />
+										<Setter Target="BottomBorder.Fill" Value="{ThemeResource TimePickerButtonBorderBrushDisabled}" />
+										<Setter Target="HeaderTextBlock.Foreground" Value="{ThemeResource TimePickerHeaderForegroundDisabled}" />
+										<Setter Target="HourTextBlock.Foreground" Value="{ThemeResource TimePickerButtonTimeTextForegroundDisabled}" />
+										<Setter Target="MinuteTextBlock.Foreground" Value="{ThemeResource TimePickerButtonTimeTextForegroundDisabled}" />
+										<Setter Target="PeriodTextBlock.Foreground" Value="{ThemeResource TimePickerButtonTimeTextForegroundDisabled}" />
+										<Setter Target="FirstColumnDivider.Foreground" Value="{ThemeResource TimePickerSpacerFillDisabled}" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="HasTimeStates">
+								<!--
+									With a time picked the header floats above the value; without one it stays at
+									the value's position and reads as the placeholder. The value run is only shown
+									in that empty state when there is no header to act as the placeholder,
+									otherwise the two would overlap.
+								-->
+								<VisualState x:Name="HasTime">
+									<VisualState.Setters>
+										<Setter Target="FlyoutButtonContentGrid.Visibility" Value="Visible" />
+										<Setter Target="HeaderTextBlock.Foreground" Value="{ThemeResource TimePickerHeaderForeground}" />
+									</VisualState.Setters>
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="HeaderTextBlock_CompositeTransform"
+														 Storyboard.TargetProperty="TranslateY"
+														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="{StaticResource TimePickerHeaderFloatTranslateY}" />
+										<DoubleAnimation Storyboard.TargetName="HeaderTextBlock_CompositeTransform"
+														 Storyboard.TargetProperty="ScaleX"
+														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="{StaticResource TimePickerHeaderFloatScale}" />
+										<DoubleAnimation Storyboard.TargetName="HeaderTextBlock_CompositeTransform"
+														 Storyboard.TargetProperty="ScaleY"
+														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+														 To="{StaticResource TimePickerHeaderFloatScale}" />
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="HasNoTime">
+									<VisualState.Setters>
+										<Setter Target="HourTextBlock.Foreground" Value="{ThemeResource TimePickerPlaceholderTextForeground}" />
+										<Setter Target="MinuteTextBlock.Foreground" Value="{ThemeResource TimePickerPlaceholderTextForeground}" />
+										<Setter Target="PeriodTextBlock.Foreground" Value="{ThemeResource TimePickerPlaceholderTextForeground}" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style x:Key="MaterialDefaultTimePickerStyle"
+		   TargetType="TimePicker"
+		   BasedOn="{StaticResource MaterialTimePickerStyle}" />
+
+	<Style x:Key="MaterialDefaultTimePickerFlyoutPresenterStyle"
+		   TargetType="TimePickerFlyoutPresenter"
+		   BasedOn="{StaticResource MaterialTimePickerFlyoutPresenterStyle}" />
+</ResourceDictionary>

--- a/src/library/Uno.Material/Styles/Controls/v2/TimePicker.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/TimePicker.xaml
@@ -34,37 +34,10 @@
 			<StaticResource x:Key="TimePickerSpacerFill" ResourceKey="OnSurfaceVariantBrush" />
 			<StaticResource x:Key="TimePickerSpacerFillDisabled" ResourceKey="OnSurfaceLowBrush" />
 
-			<!--#region Typo-->
 			<StaticResource x:Key="TimePickerFlyoutPresenterFontFamily" ResourceKey="MaterialRegularFontFamily" />
 			<StaticResource x:Key="TimePickerFlyoutPresenterFontSize" ResourceKey="ControlContentThemeFontSize" />
-			<!--#endregion-->
-
-			<x:Double x:Key="TimePickerFlyoutBorderThickness">1</x:Double>
-			<x:Double x:Key="TimePickerSpacerThemeWidth">1</x:Double>
-			<x:Double x:Key="TimePickerColumnDividerWidth">1</x:Double>
-			<x:Double x:Key="TimePickerHeight">53</x:Double>
-			<x:Double x:Key="TimePickerFlyoutElevation">8</x:Double>
-			<x:Double x:Key="TimePickerFlyoutButtonOpacityPressed">0.65</x:Double>
-			<x:Double x:Key="TimePickerFlyoutButtonOpacityDisabled">0.65</x:Double>
-			<x:Double x:Key="TimePickerFlyoutPresenterWidth">242</x:Double>
-			<x:Double x:Key="TimePickerFlyoutPresenterMinWidth">242</x:Double>
-			<x:Double x:Key="TimePickerFlyoutPresenterMaxHeight">398</x:Double>
-			<x:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">41</x:Double>
 			<StaticResource x:Key="TimePickerFlyoutPresenterHighlightHeight" ResourceKey="ControlHeightMedium" />
-			<x:Double x:Key="TimePickerButtonBottomBorderHeight">2</x:Double>
 			<StaticResource x:Key="TimePickerButtonContentHeight" ResourceKey="IconSizeMedium" />
-			<Thickness x:Key="TimePickerButtonHeaderMargin">10,8,10,0</Thickness>
-			<!-- Resting (placeholder) position of the floating header — centered, inset like the header -->
-			<Thickness x:Key="TimePickerButtonPlaceholderMargin">10,0,10,0</Thickness>
-			<!-- Floating label: distance and scale from the value position up to the header position -->
-			<x:Double x:Key="TimePickerHeaderFloatTranslateY">-11</x:Double>
-			<x:Double x:Key="TimePickerHeaderFloatScale">0.7</x:Double>
-			<!-- Left inset matches TimePickerButtonHeaderMargin so the value lines up under the header -->
-			<Thickness x:Key="TimePickerButtonContentMargin">10,24,10,0</Thickness>
-			<Thickness x:Key="TimePickerColumnDividerMargin">2,0,2,0</Thickness>
-			<Thickness x:Key="TimePickerFlyoutPresenterTitleMargin">16,12,16,4</Thickness>
-			<Thickness x:Key="TimePickerFlyoutButtonPadding">0</Thickness>
-			<CornerRadius x:Key="TimePickerCornerRadius">4,4,0,0</CornerRadius>
 		</ResourceDictionary>
 
 		<ResourceDictionary x:Key="Light">
@@ -92,39 +65,41 @@
 			<StaticResource x:Key="TimePickerSpacerFill" ResourceKey="OnSurfaceVariantBrush" />
 			<StaticResource x:Key="TimePickerSpacerFillDisabled" ResourceKey="OnSurfaceLowBrush" />
 
-			<!--#region Typo-->
 			<StaticResource x:Key="TimePickerFlyoutPresenterFontFamily" ResourceKey="MaterialRegularFontFamily" />
 			<StaticResource x:Key="TimePickerFlyoutPresenterFontSize" ResourceKey="ControlContentThemeFontSize" />
-			<!--#endregion-->
-
-			<x:Double x:Key="TimePickerFlyoutBorderThickness">1</x:Double>
-			<x:Double x:Key="TimePickerSpacerThemeWidth">1</x:Double>
-			<x:Double x:Key="TimePickerColumnDividerWidth">1</x:Double>
-			<x:Double x:Key="TimePickerHeight">53</x:Double>
-			<x:Double x:Key="TimePickerFlyoutElevation">8</x:Double>
-			<x:Double x:Key="TimePickerFlyoutButtonOpacityPressed">0.65</x:Double>
-			<x:Double x:Key="TimePickerFlyoutButtonOpacityDisabled">0.65</x:Double>
-			<x:Double x:Key="TimePickerFlyoutPresenterWidth">242</x:Double>
-			<x:Double x:Key="TimePickerFlyoutPresenterMinWidth">242</x:Double>
-			<x:Double x:Key="TimePickerFlyoutPresenterMaxHeight">398</x:Double>
-			<x:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">41</x:Double>
 			<StaticResource x:Key="TimePickerFlyoutPresenterHighlightHeight" ResourceKey="ControlHeightMedium" />
-			<x:Double x:Key="TimePickerButtonBottomBorderHeight">2</x:Double>
 			<StaticResource x:Key="TimePickerButtonContentHeight" ResourceKey="IconSizeMedium" />
-			<Thickness x:Key="TimePickerButtonHeaderMargin">10,8,10,0</Thickness>
-			<!-- Resting (placeholder) position of the floating header — centered, inset like the header -->
-			<Thickness x:Key="TimePickerButtonPlaceholderMargin">10,0,10,0</Thickness>
-			<!-- Floating label: distance and scale from the value position up to the header position -->
-			<x:Double x:Key="TimePickerHeaderFloatTranslateY">-11</x:Double>
-			<x:Double x:Key="TimePickerHeaderFloatScale">0.7</x:Double>
-			<!-- Left inset matches TimePickerButtonHeaderMargin so the value lines up under the header -->
-			<Thickness x:Key="TimePickerButtonContentMargin">10,24,10,0</Thickness>
-			<Thickness x:Key="TimePickerColumnDividerMargin">2,0,2,0</Thickness>
-			<Thickness x:Key="TimePickerFlyoutPresenterTitleMargin">16,12,16,4</Thickness>
-			<Thickness x:Key="TimePickerFlyoutButtonPadding">0</Thickness>
-			<CornerRadius x:Key="TimePickerCornerRadius">4,4,0,0</CornerRadius>
 		</ResourceDictionary>
 	</ResourceDictionary.ThemeDictionaries>
+
+	<!--
+		Theme-invariant dimensions, declared at dictionary scope rather than duplicated
+		into every theme branch: the values are identical in Light and Dark, and a single
+		declaration keeps them resolvable from Storyboard/Setter values, which read through
+		StaticResource and do not re-resolve per ThemeDictionary.
+		Consumers still override them from their own App resources.
+	-->
+	<x:Double x:Key="TimePickerFlyoutBorderThickness">1</x:Double>
+	<x:Double x:Key="TimePickerSpacerThemeWidth">1</x:Double>
+	<x:Double x:Key="TimePickerColumnDividerWidth">1</x:Double>
+	<x:Double x:Key="TimePickerHeight">53</x:Double>
+	<x:Double x:Key="TimePickerFlyoutElevation">8</x:Double>
+	<x:Double x:Key="TimePickerFlyoutButtonOpacityPressed">0.65</x:Double>
+	<x:Double x:Key="TimePickerFlyoutButtonOpacityDisabled">0.65</x:Double>
+	<x:Double x:Key="TimePickerFlyoutPresenterWidth">242</x:Double>
+	<x:Double x:Key="TimePickerFlyoutPresenterMinWidth">242</x:Double>
+	<x:Double x:Key="TimePickerFlyoutPresenterMaxWidth">456</x:Double>
+	<x:Double x:Key="TimePickerFlyoutPresenterMaxHeight">398</x:Double>
+	<x:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">41</x:Double>
+	<x:Double x:Key="TimePickerButtonBottomBorderHeight">2</x:Double>
+	<!-- Scale of the header once it floats above the value; the vertical move is layout-driven -->
+	<x:Double x:Key="TimePickerHeaderFloatScale">0.7</x:Double>
+	<Thickness x:Key="TimePickerButtonPlaceholderMargin">10,0,10,0</Thickness>
+	<Thickness x:Key="TimePickerButtonContentMargin">10,0,10,0</Thickness>
+	<Thickness x:Key="TimePickerColumnDividerMargin">2,0,2,0</Thickness>
+	<Thickness x:Key="TimePickerFlyoutPresenterTitleMargin">16,12,16,4</Thickness>
+	<Thickness x:Key="TimePickerFlyoutButtonPadding">0</Thickness>
+	<CornerRadius x:Key="TimePickerCornerRadius">4,4,0,0</CornerRadius>
 
 	<!-- TimePicker Style -->
 	<Style x:Key="MaterialTimePickerFlyoutButtonStyle"
@@ -297,8 +272,11 @@
 		<!-- Sizes to content like the Fluent TimePicker (the field's MinWidth sets the floor) — a stretched field
 			 also stretches the flyout, which TimePickerFlyout.OnOpening sizes to the target's ActualWidth. -->
 		<Setter Property="HorizontalAlignment" Value="Left" />
-		<Setter Property="Height" Value="{ThemeResource TimePickerHeight}" />
+		<!-- MinHeight, not Height: a wrapped multi-line Header must be able to grow the field -->
+		<Setter Property="MinHeight" Value="{ThemeResource TimePickerHeight}" />
 		<Setter Property="CornerRadius" Value="{ThemeResource TimePickerCornerRadius}" />
+		<not_win:Setter Property="FlyoutPresenterStyle"
+						Value="{StaticResource MaterialTimePickerFlyoutPresenterStyle}" />
 
 		<Setter Property="Template">
 			<Setter.Value>
@@ -308,6 +286,7 @@
 						<!-- Flyout Button -->
 						<Button x:Name="FlyoutButton"
 								MinWidth="{ThemeResource TimePickerFlyoutPresenterMinWidth}"
+								MaxWidth="{ThemeResource TimePickerFlyoutPresenterMaxWidth}"
 								HorizontalAlignment="Stretch"
 								HorizontalContentAlignment="Stretch"
 								IsEnabled="{TemplateBinding IsEnabled}"
@@ -315,7 +294,7 @@
 								UseSystemFocusVisuals="{TemplateBinding UseSystemFocusVisuals}">
 
 							<Grid x:Name="ContentButton"
-								  Height="{TemplateBinding Height}"
+								  MinHeight="{TemplateBinding MinHeight}"
 								  Background="{TemplateBinding Background}"
 								  CornerRadius="{TemplateBinding CornerRadius}">
 
@@ -326,95 +305,123 @@
 										   Fill="{TemplateBinding BorderBrush}" />
 
 								<!--
-									Floating label, as in the Material TextBox: the header rests where the value
-									sits and reads as the placeholder while there is no time, then animates up and
-									shrinks once a time is picked (HasTime). It is the only element rendering the
-									header — a separate header line plus a header-bound placeholder showed the same
-									text twice.
+									Header and value stack in two Auto rows, centered as a block. The rows are what
+									moves the header, not a magic offset: with no Header the presenter collapses,
+									row 0 takes no height and the value centers in the field; with a Header and no
+									time the value row is empty and the header centers, reading as the placeholder;
+									with both, they stack and the header sits above the value. HasTime only scales
+									the header down, so there is no translate constant to keep in sync with the
+									field height.
 								-->
-								<TextBlock x:Name="HeaderTextBlock"
-										   Margin="{ThemeResource TimePickerButtonPlaceholderMargin}"
-										   HorizontalAlignment="Stretch"
-										   VerticalAlignment="Center"
-										   AutomationProperties.AccessibilityView="Raw"
-										   Foreground="{ThemeResource TimePickerPlaceholderTextForeground}"
-										   RenderTransformOrigin="0,0.5"
-										   Style="{StaticResource MaterialBodyLarge}"
-										   Text="{TemplateBinding Header}"
-										   TextWrapping="Wrap">
-									<TextBlock.RenderTransform>
-										<CompositeTransform x:Name="HeaderTextBlock_CompositeTransform" />
-									</TextBlock.RenderTransform>
-								</TextBlock>
+								<Grid VerticalAlignment="Center">
 
-								<!--
-									The hour / minute / period parts stay under the control's ownership — it fills
-									them, reorders the hosts per culture and collapses the period column for a
-									24-hour ClockIdentifier. Auto columns and a left-aligned grid render them as a
-									single value ("9:41 AM") instead of three full-width cells, matching the
-									DatePicker field. First|SecondColumnDivider are typed UIElement in the control
-									contract, so they carry the time separator rather than a vertical rule.
-								-->
-								<Grid x:Name="FlyoutButtonContentGrid"
-									  Height="{ThemeResource TimePickerButtonContentHeight}"
-									  Margin="{ThemeResource TimePickerButtonContentMargin}"
-									  HorizontalAlignment="Left"
-									  VerticalAlignment="Top"
-									  Visibility="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyOrNullToVisibleConverter}}">
+									<Grid.RowDefinitions>
+										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
+									</Grid.RowDefinitions>
 
-									<Grid.ColumnDefinitions>
-										<ColumnDefinition x:Name="FirstTextBlockColumn"
-														  Width="Auto" />
-										<ColumnDefinition Width="Auto" />
-										<ColumnDefinition x:Name="SecondTextBlockColumn"
-														  Width="Auto" />
-										<ColumnDefinition Width="Auto" />
-										<ColumnDefinition x:Name="ThirdTextBlockColumn"
-														  Width="Auto" />
-									</Grid.ColumnDefinitions>
+									<!--
+										ContentPresenter rather than a TextBlock so a non-string Header and
+										HeaderTemplate both render (Header is typed object).
+									-->
+									<ContentPresenter x:Name="HeaderTextBlock"
+													  Grid.Row="0"
+													  Margin="{ThemeResource TimePickerButtonPlaceholderMargin}"
+													  HorizontalAlignment="Stretch"
+													  AutomationProperties.AccessibilityView="Raw"
+													  CharacterSpacing="{ThemeResource BodyLargeCharacterSpacing}"
+													  Content="{TemplateBinding Header}"
+													  ContentTemplate="{TemplateBinding HeaderTemplate}"
+													  FontFamily="{ThemeResource BodyLargeFontFamily}"
+													  FontSize="{ThemeResource BodyLargeFontSize}"
+													  FontWeight="{ThemeResource BodyLargeFontWeight}"
+													  Foreground="{ThemeResource TimePickerPlaceholderTextForeground}"
+													  RenderTransformOrigin="0,0.5"
+													  TextWrapping="Wrap"
+													  Visibility="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyOrNullToCollapsedConverter}}">
+										<ContentPresenter.RenderTransform>
+											<CompositeTransform x:Name="HeaderTextBlock_CompositeTransform" />
+										</ContentPresenter.RenderTransform>
+									</ContentPresenter>
 
-									<!-- Hours -->
-									<Border x:Name="FirstPickerHost"
-											Grid.Column="0">
-										<TextBlock x:Name="HourTextBlock"
-												   AutomationProperties.AccessibilityView="Raw"
-												   Foreground="{ThemeResource TimePickerButtonTimeTextForeground}"
-												   Style="{StaticResource MaterialBodyLarge}" />
-									</Border>
+									<!--
+										The hour / minute / period parts stay under the control's ownership: it fills
+										the TextBlocks, reparents them between First|Second|ThirdPickerHost to reorder
+										per culture, and collapses the period host for a 24-hour ClockIdentifier.
 
-									<!-- Time separator -->
-									<TextBlock x:Name="FirstColumnDivider"
-											   Grid.Column="1"
-											   Margin="{ThemeResource TimePickerColumnDividerMargin}"
-											   AutomationProperties.AccessibilityView="Raw"
-											   Foreground="{ThemeResource TimePickerSpacerFill}"
-											   Style="{StaticResource MaterialBodyLarge}"
-											   Text=":" />
+										The dividers are neutral rules, not glyphs. UpdateOrderAndLayout only toggles
+										divider *visibility* — it never moves them — so a literal ":" in
+										FirstColumnDivider is only correct while the hour happens to come first. Under
+										a period-first culture (ko-KR / zh-CN / ja-JP put the period in
+										FirstPickerHost) it would render "오전 : 9  41", with the colon between period
+										and hour and none between hour and minute. A rule carries no ordering
+										assumption, so it is correct in every culture.
 
-									<!-- Minutes -->
-									<Border x:Name="SecondPickerHost"
-											Grid.Column="2">
-										<TextBlock x:Name="MinuteTextBlock"
-												   AutomationProperties.AccessibilityView="Raw"
-												   Foreground="{ThemeResource TimePickerButtonTimeTextForeground}"
-												   Style="{StaticResource MaterialBodyLarge}" />
-									</Border>
+										The star column widths match the control: UpdateOrderAndLayout assigns 1* to
+										every populated column and 0 to the rest, overwriting what the template declares.
+									-->
+									<Grid x:Name="FlyoutButtonContentGrid"
+										  Grid.Row="1"
+										  Height="{ThemeResource TimePickerButtonContentHeight}"
+										  Margin="{ThemeResource TimePickerButtonContentMargin}"
+										  Visibility="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyOrNullToVisibleConverter}}">
 
-									<!-- Period spacing — collapsed by the control for a 24-hour clock -->
-									<TextBlock x:Name="SecondColumnDivider"
-											   Grid.Column="3"
-											   Margin="{ThemeResource TimePickerColumnDividerMargin}"
-											   AutomationProperties.AccessibilityView="Raw"
-											   Style="{StaticResource MaterialBodyLarge}" />
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition x:Name="FirstTextBlockColumn"
+															  Width="*" />
+											<ColumnDefinition Width="Auto" />
+											<ColumnDefinition x:Name="SecondTextBlockColumn"
+															  Width="*" />
+											<ColumnDefinition Width="Auto" />
+											<ColumnDefinition x:Name="ThirdTextBlockColumn"
+															  Width="*" />
+										</Grid.ColumnDefinitions>
 
-									<!-- AM/PM -->
-									<Border x:Name="ThirdPickerHost"
-											Grid.Column="4">
-										<TextBlock x:Name="PeriodTextBlock"
-												   AutomationProperties.AccessibilityView="Raw"
-												   Foreground="{ThemeResource TimePickerButtonTimeTextForeground}"
-												   Style="{StaticResource MaterialBodyLarge}" />
-									</Border>
+										<!-- Hours -->
+										<Border x:Name="FirstPickerHost"
+												Grid.Column="0">
+											<TextBlock x:Name="HourTextBlock"
+													   HorizontalAlignment="Center"
+													   AutomationProperties.AccessibilityView="Raw"
+													   Foreground="{ThemeResource TimePickerButtonTimeTextForeground}"
+													   Style="{StaticResource MaterialBodyLarge}" />
+										</Border>
+
+										<Rectangle x:Name="FirstColumnDivider"
+												   Grid.Column="1"
+												   Width="{ThemeResource TimePickerColumnDividerWidth}"
+												   Margin="{ThemeResource TimePickerColumnDividerMargin}"
+												   HorizontalAlignment="Center"
+												   Fill="{ThemeResource TimePickerSpacerFill}" />
+
+										<!-- Minutes -->
+										<Border x:Name="SecondPickerHost"
+												Grid.Column="2">
+											<TextBlock x:Name="MinuteTextBlock"
+													   HorizontalAlignment="Center"
+													   AutomationProperties.AccessibilityView="Raw"
+													   Foreground="{ThemeResource TimePickerButtonTimeTextForeground}"
+													   Style="{StaticResource MaterialBodyLarge}" />
+										</Border>
+
+										<!-- Collapsed by the control for a 24-hour clock -->
+										<Rectangle x:Name="SecondColumnDivider"
+												   Grid.Column="3"
+												   Width="{ThemeResource TimePickerColumnDividerWidth}"
+												   Margin="{ThemeResource TimePickerColumnDividerMargin}"
+												   HorizontalAlignment="Center"
+												   Fill="{ThemeResource TimePickerSpacerFill}" />
+
+										<!-- AM/PM -->
+										<Border x:Name="ThirdPickerHost"
+												Grid.Column="4">
+											<TextBlock x:Name="PeriodTextBlock"
+													   HorizontalAlignment="Center"
+													   AutomationProperties.AccessibilityView="Raw"
+													   Foreground="{ThemeResource TimePickerButtonTimeTextForeground}"
+													   Style="{StaticResource MaterialBodyLarge}" />
+										</Border>
+									</Grid>
 								</Grid>
 							</Grid>
 						</Button>
@@ -431,17 +438,18 @@
 										<Setter Target="HourTextBlock.Foreground" Value="{ThemeResource TimePickerButtonTimeTextForegroundDisabled}" />
 										<Setter Target="MinuteTextBlock.Foreground" Value="{ThemeResource TimePickerButtonTimeTextForegroundDisabled}" />
 										<Setter Target="PeriodTextBlock.Foreground" Value="{ThemeResource TimePickerButtonTimeTextForegroundDisabled}" />
-										<Setter Target="FirstColumnDivider.Foreground" Value="{ThemeResource TimePickerSpacerFillDisabled}" />
+										<Setter Target="FirstColumnDivider.Fill" Value="{ThemeResource TimePickerSpacerFillDisabled}" />
+										<Setter Target="SecondColumnDivider.Fill" Value="{ThemeResource TimePickerSpacerFillDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
 
 							<VisualStateGroup x:Name="HasTimeStates">
 								<!--
-									With a time picked the header floats above the value; without one it stays at
-									the value's position and reads as the placeholder. The value run is only shown
-									in that empty state when there is no header to act as the placeholder,
-									otherwise the two would overlap.
+									With a time picked the value row fills, so the header is pushed to the row above
+									and shrinks; with no time the value row is empty and the header sits centred,
+									reading as the placeholder. The value run is only shown in that empty state when
+									there is no header to act as the placeholder, otherwise the two would repeat.
 								-->
 								<VisualState x:Name="HasTime">
 									<VisualState.Setters>
@@ -449,11 +457,6 @@
 										<Setter Target="HeaderTextBlock.Foreground" Value="{ThemeResource TimePickerHeaderForeground}" />
 									</VisualState.Setters>
 									<Storyboard>
-										<DoubleAnimation Storyboard.TargetName="HeaderTextBlock_CompositeTransform"
-														 Storyboard.TargetProperty="TranslateY"
-														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"
-														 EasingFunction="{StaticResource MaterialEaseInOutFunction}"
-														 To="{StaticResource TimePickerHeaderFloatTranslateY}" />
 										<DoubleAnimation Storyboard.TargetName="HeaderTextBlock_CompositeTransform"
 														 Storyboard.TargetProperty="ScaleX"
 														 Duration="{StaticResource MaterialTextBoxAnimationDuration}"

--- a/src/library/Uno.Material/Styles/Controls/v2/_Resources.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/_Resources.xaml
@@ -41,6 +41,8 @@
 	<Style BasedOn="{StaticResource MaterialDefaultSliderStyle}" TargetType="Slider" />
 	<Style BasedOn="{StaticResource MaterialDefaultTextBlockStyle}" TargetType="TextBlock" />
 	<Style BasedOn="{StaticResource MaterialDefaultTextBoxStyle}" TargetType="TextBox" />
+	<Style BasedOn="{StaticResource MaterialDefaultTimePickerStyle}" TargetType="TimePicker" />
+	<Style BasedOn="{StaticResource MaterialDefaultTimePickerFlyoutPresenterStyle}" TargetType="TimePickerFlyoutPresenter" />
 	<Style BasedOn="{StaticResource MaterialDefaultToggleButtonStyle}" TargetType="ToggleButton" />
 	<Style BasedOn="{StaticResource MaterialDefaultToggleMenuFlyoutItemStyle}" TargetType="ToggleMenuFlyoutItem" />
 	<Style BasedOn="{StaticResource MaterialDefaultToggleSwitchStyle}" TargetType="ToggleSwitch" />
@@ -80,6 +82,8 @@
 	<StaticResource x:Key="RippleStyle"							ResourceKey="MaterialRippleStyle"				/>
 	<StaticResource x:Key="SliderStyle"							ResourceKey="MaterialSliderStyle"				/>
 	<StaticResource x:Key="RadioMenuFlyoutItemStyle"			ResourceKey="MaterialRadioMenuFlyoutItemStyle"	/>
+	<StaticResource x:Key="TimePickerStyle"						ResourceKey="MaterialTimePickerStyle"			/>
+	<StaticResource x:Key="TimePickerFlyoutPresenterStyle"		ResourceKey="MaterialTimePickerFlyoutPresenterStyle" />
 	<StaticResource x:Key="ToggleMenuFlyoutItemStyle"			ResourceKey="MaterialToggleMenuFlyoutItemStyle"	/>
 	<StaticResource x:Key="ToggleSwitchStyle"					ResourceKey="MaterialToggleSwitchStyle"			/>
 

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/DatePicker.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/DatePicker.xaml
@@ -44,7 +44,8 @@
 			<StaticResource x:Key="DatePickerFlyoutPresenterBackground" ResourceKey="SurfaceBrush" />
 			<StaticResource x:Key="DatePickerFlyoutPresenterBorderBrush" ResourceKey="OutlineBrush" />
 			<StaticResource x:Key="DatePickerFlyoutPresenterSpacerFill" ResourceKey="OutlineBrush" />
-			<StaticResource x:Key="DatePickerFlyoutPresenterHighlightFill" ResourceKey="PrimaryVariantLightBrush" />
+			<!-- Selection band: must contrast with DatePickerFlyoutPresenterBackground (SurfaceBrush) in both themes -->
+			<StaticResource x:Key="DatePickerFlyoutPresenterHighlightFill" ResourceKey="SurfaceVariantBrush" />
 			<StaticResource x:Key="DatePickerFlyoutPresenterCornerRadius" ResourceKey="SimpleRadius400CornerRadius" />
 			<x:Double x:Key="DatePickerFlyoutPresenterWidth">296</x:Double>
 			<x:Double x:Key="DatePickerFlyoutPresenterMinWidth">296</x:Double>
@@ -111,7 +112,8 @@
 			<StaticResource x:Key="DatePickerFlyoutPresenterBackground" ResourceKey="SurfaceBrush" />
 			<StaticResource x:Key="DatePickerFlyoutPresenterBorderBrush" ResourceKey="OutlineBrush" />
 			<StaticResource x:Key="DatePickerFlyoutPresenterSpacerFill" ResourceKey="OutlineBrush" />
-			<StaticResource x:Key="DatePickerFlyoutPresenterHighlightFill" ResourceKey="PrimaryVariantLightBrush" />
+			<!-- Selection band: must contrast with DatePickerFlyoutPresenterBackground (SurfaceBrush) in both themes -->
+			<StaticResource x:Key="DatePickerFlyoutPresenterHighlightFill" ResourceKey="SurfaceVariantBrush" />
 			<StaticResource x:Key="DatePickerFlyoutPresenterCornerRadius" ResourceKey="SimpleRadius400CornerRadius" />
 			<x:Double x:Key="DatePickerFlyoutPresenterWidth">296</x:Double>
 			<x:Double x:Key="DatePickerFlyoutPresenterMinWidth">296</x:Double>
@@ -349,7 +351,9 @@
 		<Setter Property="Foreground" Value="{ThemeResource DatePickerButtonForeground}" />
 		<Setter Property="BorderBrush" Value="{ThemeResource DatePickerButtonBorderBrush}" />
 		<Setter Property="BorderThickness" Value="{ThemeResource DatePickerBorderThemeThickness}" />
-		<Setter Property="HorizontalAlignment" Value="Stretch" />
+		<!-- Sizes to content like the Fluent DatePicker (DatePickerFlyoutPresenterMinWidth sets the floor) — a stretched
+			 field also stretches the flyout, which DatePickerFlyout sizes to the target's ActualWidth on opening. -->
+		<Setter Property="HorizontalAlignment" Value="Left" />
 		<Setter Property="MinHeight" Value="{ThemeResource DatePickerMinHeight}" />
 		<Setter Property="CornerRadius" Value="{ThemeResource DatePickerCornerRadius}" />
 		<Setter Property="FontFamily" Value="{ThemeResource BodyLargeFontFamily}" />
@@ -361,31 +365,16 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="DatePicker">
-					<!-- Root Grid -->
+					<!--
+						Root Grid — Header renders only as the in-field placeholder (PlaceholderText below),
+						the way the Simple TextBox shows PlaceholderText. A separate header line above the
+						field plus that header-bound placeholder showed the same text twice.
+					-->
 					<Grid x:Name="LayoutRoot">
-
-						<Grid.RowDefinitions>
-							<RowDefinition Height="Auto" />
-							<RowDefinition Height="Auto" />
-						</Grid.RowDefinitions>
-
-						<!-- Header (above the field) -->
-						<ContentPresenter x:Name="HeaderContentPresenter"
-										  Grid.Row="0"
-										  Content="{TemplateBinding Header}"
-										  ContentTemplate="{TemplateBinding HeaderTemplate}"
-										  Foreground="{ThemeResource DatePickerHeaderForeground}"
-										  FontSize="{ThemeResource BodyMediumFontSize}"
-										  FontFamily="{ThemeResource BodyLargeFontFamily}"
-										  FontWeight="SemiBold"
-										  TextWrapping="Wrap"
-										  Margin="{ThemeResource DatePickerHeaderMargin}"
-										  Visibility="Collapsed"
-										  AutomationProperties.AccessibilityView="Raw" />
 
 						<!-- Flyout Button -->
 						<Button x:Name="FlyoutButton"
-								Grid.Row="1"
+								MinWidth="{ThemeResource DatePickerFlyoutPresenterMinWidth}"
 								HorizontalAlignment="Stretch"
 								HorizontalContentAlignment="Stretch"
 								IsEnabled="{TemplateBinding IsEnabled}"
@@ -444,7 +433,6 @@
 										<Setter Target="Background.Background" Value="{ThemeResource DatePickerButtonBackgroundPointerOver}" />
 										<Setter Target="Background.BorderBrush" Value="{ThemeResource DatePickerButtonBorderBrushPointerOver}" />
 										<Setter Target="DateText.Foreground" Value="{ThemeResource DatePickerButtonDateTextForegroundPointerOver}" />
-										<Setter Target="HeaderContentPresenter.Foreground" Value="{ThemeResource DatePickerButtonForegroundPointerOver}" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -453,7 +441,6 @@
 										<Setter Target="Background.Background" Value="{ThemeResource DatePickerButtonBackgroundPressed}" />
 										<Setter Target="Background.BorderBrush" Value="{ThemeResource DatePickerButtonBorderBrushPressed}" />
 										<Setter Target="DateText.Foreground" Value="{ThemeResource DatePickerButtonDateTextForegroundPressed}" />
-										<Setter Target="HeaderContentPresenter.Foreground" Value="{ThemeResource DatePickerButtonForegroundPressed}" />
 									</VisualState.Setters>
 								</VisualState>
 
@@ -462,7 +449,6 @@
 										<Setter Target="Background.Background" Value="{ThemeResource DatePickerButtonBackgroundDisabled}" />
 										<Setter Target="Background.BorderBrush" Value="{ThemeResource DatePickerButtonBorderBrushDisabled}" />
 										<Setter Target="DateText.Foreground" Value="{ThemeResource DatePickerButtonDateTextForegroundDisabled}" />
-										<Setter Target="HeaderContentPresenter.Foreground" Value="{ThemeResource DatePickerHeaderForegroundDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/DatePicker.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/DatePicker.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_win="http://uno.ui/not_win"
@@ -39,7 +39,6 @@
 
 			<!-- ── FlyoutButton (transparent wrapper) — semantic keys (source of truth) ── -->
 			<StaticResource x:Key="DatePickerFlyoutButtonBackground" ResourceKey="SystemControlTransparentBrush" />
-			<!-- Backwards-compat alias -->
 			<!-- ── FlyoutPresenter — semantic keys (source of truth) ── -->
 			<StaticResource x:Key="DatePickerFlyoutPresenterBackground" ResourceKey="SurfaceBrush" />
 			<StaticResource x:Key="DatePickerFlyoutPresenterBorderBrush" ResourceKey="OutlineBrush" />
@@ -56,7 +55,6 @@
 			<StaticResource x:Key="DatePickerFlyoutBorderThickness" ResourceKey="SimpleStrokeBorder" />
 			<!-- Typography — semantic keys (source of truth) -->
 			<StaticResource x:Key="DatePickerFlyoutPresenterFontFamily" ResourceKey="SimpleFontFamily" />
-			<!-- Backwards-compat alias -->
 			<!-- ── DatePicker Button (field appearance) — semantic keys (source of truth) ── -->
 			<StaticResource x:Key="DatePickerButtonBackground" ResourceKey="SurfaceBrush" />
 			<StaticResource x:Key="DatePickerButtonBackgroundPointerOver" ResourceKey="SurfaceBrush" />
@@ -77,14 +75,15 @@
 			<StaticResource x:Key="DatePickerButtonDateTextForegroundPointerOver" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="DatePickerButtonDateTextForegroundPressed" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="DatePickerButtonDateTextForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
-			<!-- Backwards-compat aliases -->
 			<!-- ── Placeholder text — semantic key (source of truth) ── -->
 			<StaticResource x:Key="DatePickerPlaceholderTextForeground" ResourceKey="OnSurfaceLowBrush" />
-			<!-- Backwards-compat alias -->
 			<!-- ── Header — semantic keys (source of truth) ── -->
+			<!--
+				Deprecated: the header now renders as the in-field placeholder, which is coloured
+				by DatePickerPlaceholderTextForeground. Kept because both are published API.
+			-->
 			<StaticResource x:Key="DatePickerHeaderForeground" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="DatePickerHeaderForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
-			<!-- Backwards-compat aliases -->
 			<!-- ── Dimensions — semantic keys (source of truth) ── -->
 			<StaticResource x:Key="DatePickerCornerRadius" ResourceKey="SimpleRadius200CornerRadius" />
 			<StaticResource x:Key="DatePickerBorderThemeThickness" ResourceKey="SimpleStrokeBorderThickness" />
@@ -93,9 +92,9 @@
 			<StaticResource x:Key="DatePickerMinHeight" ResourceKey="ControlHeightMediumLarge" />
 			<x:Double x:Key="DatePickerFlyoutButtonOpacityPressed">0.8</x:Double>
 			<x:Double x:Key="DatePickerFlyoutButtonOpacityDisabled">0.5</x:Double>
+			<!-- Deprecated: no separate header line to space; use DatePickerContentMargin instead -->
 			<StaticResource x:Key="DatePickerHeaderMargin" ResourceKey="Space100BottomThickness" />
-			<!-- Backwards-compat aliases -->
-					<StaticResource x:Key="SimpleDatePickerFlyoutPresenterCornerRadius" ResourceKey="DatePickerFlyoutPresenterCornerRadius" />
+			<StaticResource x:Key="SimpleDatePickerFlyoutPresenterCornerRadius" ResourceKey="DatePickerFlyoutPresenterCornerRadius" />
 			<StaticResource x:Key="SimpleDatePickerFlyoutBorderThickness" ResourceKey="DatePickerFlyoutBorderThickness" />
 			<StaticResource x:Key="SimpleDatePickerCornerRadius" ResourceKey="DatePickerCornerRadius" />
 			<StaticResource x:Key="SimpleDatePickerBorderThemeThickness" ResourceKey="DatePickerBorderThemeThickness" />
@@ -107,7 +106,6 @@
 
 			<!-- ── FlyoutButton (transparent wrapper) — semantic keys (source of truth) ── -->
 			<StaticResource x:Key="DatePickerFlyoutButtonBackground" ResourceKey="SystemControlTransparentBrush" />
-			<!-- Backwards-compat alias -->
 			<!-- ── FlyoutPresenter — semantic keys (source of truth) ── -->
 			<StaticResource x:Key="DatePickerFlyoutPresenterBackground" ResourceKey="SurfaceBrush" />
 			<StaticResource x:Key="DatePickerFlyoutPresenterBorderBrush" ResourceKey="OutlineBrush" />
@@ -124,7 +122,6 @@
 			<StaticResource x:Key="DatePickerFlyoutBorderThickness" ResourceKey="SimpleStrokeBorder" />
 			<!-- Typography — semantic keys (source of truth) -->
 			<StaticResource x:Key="DatePickerFlyoutPresenterFontFamily" ResourceKey="SimpleFontFamily" />
-			<!-- Backwards-compat alias -->
 			<!-- ── DatePicker Button (field appearance) — semantic keys (source of truth) ── -->
 			<StaticResource x:Key="DatePickerButtonBackground" ResourceKey="SurfaceBrush" />
 			<StaticResource x:Key="DatePickerButtonBackgroundPointerOver" ResourceKey="SurfaceBrush" />
@@ -145,14 +142,15 @@
 			<StaticResource x:Key="DatePickerButtonDateTextForegroundPointerOver" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="DatePickerButtonDateTextForegroundPressed" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="DatePickerButtonDateTextForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
-			<!-- Backwards-compat aliases -->
 			<!-- ── Placeholder text — semantic key (source of truth) ── -->
 			<StaticResource x:Key="DatePickerPlaceholderTextForeground" ResourceKey="OnSurfaceLowBrush" />
-			<!-- Backwards-compat alias -->
 			<!-- ── Header — semantic keys (source of truth) ── -->
+			<!--
+				Deprecated: the header now renders as the in-field placeholder, which is coloured
+				by DatePickerPlaceholderTextForeground. Kept because both are published API.
+			-->
 			<StaticResource x:Key="DatePickerHeaderForeground" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="DatePickerHeaderForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
-			<!-- Backwards-compat aliases -->
 			<!-- ── Dimensions — semantic keys (source of truth) ── -->
 			<StaticResource x:Key="DatePickerCornerRadius" ResourceKey="SimpleRadius200CornerRadius" />
 			<StaticResource x:Key="DatePickerBorderThemeThickness" ResourceKey="SimpleStrokeBorderThickness" />
@@ -161,9 +159,9 @@
 			<StaticResource x:Key="DatePickerMinHeight" ResourceKey="ControlHeightMediumLarge" />
 			<x:Double x:Key="DatePickerFlyoutButtonOpacityPressed">0.8</x:Double>
 			<x:Double x:Key="DatePickerFlyoutButtonOpacityDisabled">0.5</x:Double>
+			<!-- Deprecated: no separate header line to space; use DatePickerContentMargin instead -->
 			<StaticResource x:Key="DatePickerHeaderMargin" ResourceKey="Space100BottomThickness" />
-			<!-- Backwards-compat aliases -->
-					<StaticResource x:Key="SimpleDatePickerFlyoutPresenterCornerRadius" ResourceKey="DatePickerFlyoutPresenterCornerRadius" />
+			<StaticResource x:Key="SimpleDatePickerFlyoutPresenterCornerRadius" ResourceKey="DatePickerFlyoutPresenterCornerRadius" />
 			<StaticResource x:Key="SimpleDatePickerFlyoutBorderThickness" ResourceKey="DatePickerFlyoutBorderThickness" />
 			<StaticResource x:Key="SimpleDatePickerCornerRadius" ResourceKey="DatePickerCornerRadius" />
 			<StaticResource x:Key="SimpleDatePickerBorderThemeThickness" ResourceKey="DatePickerBorderThemeThickness" />
@@ -392,34 +390,35 @@
 										MinHeight="{TemplateBinding MinHeight}" />
 
 								<!-- Content -->
-								<Grid Margin="{ThemeResource DatePickerContentMargin}"
+								<Grid x:Name="FlyoutButtonContentGrid"
+									  Margin="{ThemeResource DatePickerContentMargin}"
 									  VerticalAlignment="Center">
 
-									<!-- Date text row -->
-									<Grid x:Name="FlyoutButtonContentGrid"
-										  VerticalAlignment="Center">
+									<!-- Formatted date text -->
+									<TextBlock x:Name="DateText"
+											   Foreground="{ThemeResource DatePickerButtonDateTextForeground}"
+											   FontSize="{TemplateBinding FontSize}"
+											   FontFamily="{TemplateBinding FontFamily}"
+											   VerticalAlignment="Center"
+											   Text="{Binding SelectedDate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource SimpleDatePickerStringFormatConverter}, ConverterParameter=' {0:d}'}" />
 
-										<!-- Formatted date text -->
-										<TextBlock x:Name="DateText"
-												   Foreground="{ThemeResource DatePickerButtonDateTextForeground}"
-												   FontSize="{TemplateBinding FontSize}"
-												   FontFamily="{TemplateBinding FontFamily}"
-												   VerticalAlignment="Center"
-												   Text="{Binding SelectedDate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource SimpleDatePickerStringFormatConverter}, ConverterParameter=' {0:d}'}" />
+									<!--
+										Placeholder — the header, shown while no date is picked. A ContentPresenter
+										rather than a TextBlock so a non-string Header and HeaderTemplate both render
+										(Header is typed object).
+									-->
+									<ContentPresenter x:Name="PlaceholderText"
+													  VerticalAlignment="Center"
+													  Content="{TemplateBinding Header}"
+													  ContentTemplate="{TemplateBinding HeaderTemplate}"
+													  FontFamily="{TemplateBinding FontFamily}"
+													  FontSize="{TemplateBinding FontSize}"
+													  Foreground="{ThemeResource DatePickerPlaceholderTextForeground}"
+													  Visibility="Collapsed" />
 
-										<!-- Placeholder text (shown when no date) -->
-										<TextBlock x:Name="PlaceholderText"
-												   Foreground="{ThemeResource DatePickerPlaceholderTextForeground}"
-												   FontSize="{TemplateBinding FontSize}"
-												   FontFamily="{TemplateBinding FontFamily}"
-												   VerticalAlignment="Center"
-												   Text="{TemplateBinding Header}"
-												   Visibility="Collapsed" />
-
-										<!-- Hidden required named part -->
-										<TextBlock x:Name="DayTextBlock"
-												   Opacity="0" />
-									</Grid>
+									<!-- Hidden required named part -->
+									<TextBlock x:Name="DayTextBlock"
+											   Opacity="0" />
 								</Grid>
 							</Grid>
 						</Button>

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/TimePicker.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/TimePicker.xaml
@@ -1,0 +1,541 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+					xmlns:not_win="http://uno.ui/not_win"
+					mc:Ignorable="not_win">
+
+	<!--
+		Simple Design System — TimePicker Style
+		Mirrors the DatePicker field appearance with SDS design tokens.
+
+		Semantic resource layer:
+		TimePicker* = canonical semantic keys (source of truth)
+
+		Template part names follow the WinUI TimePicker contract
+		(LayoutRoot / FlyoutButton / FlyoutButtonContentGrid /
+		First|Second|ThirdPickerHost / First|Second|ThirdTextBlockColumn /
+		First|SecondColumnDivider) so the control can reorder hour / minute / period
+		per culture and collapse the period column for a 24-hour ClockIdentifier.
+
+		SDS TimePicker CSS mapping:
+		Field:       background-default-default bg, border-default-default border, radius-200 (8px), text-default-default
+		Hover:       same as normal (SDS field doesn't change on hover)
+		Disabled:    background-disabled-default, border-disabled-default, text-disabled-default
+		Placeholder: text-default-tertiary (the Header, shown when SelectedTime is null)
+		Flyout:      background-default-default, border-default-default, radius-400 (16px)
+
+		Lightweight styling pattern: every visual-state brush is exposed via
+		ThemeResource so consumers can override any individual key.
+	-->
+
+	<!-- ═══════════════════════════════════════════════════════════════════════ -->
+	<!-- Lightweight styling ThemeResource aliases -->
+	<!-- ═══════════════════════════════════════════════════════════════════════ -->
+	<ResourceDictionary.ThemeDictionaries>
+
+		<!-- ─── Light Theme ─── -->
+		<ResourceDictionary x:Key="Light">
+
+			<!-- ── FlyoutButton (transparent wrapper) ── -->
+			<StaticResource x:Key="TimePickerFlyoutButtonBackground" ResourceKey="SystemControlTransparentBrush" />
+
+			<!-- ── FlyoutPresenter ── -->
+			<StaticResource x:Key="TimePickerFlyoutPresenterBackground" ResourceKey="SurfaceBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterForeground" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterBorderBrush" ResourceKey="OutlineBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterSpacerFill" ResourceKey="OutlineBrush" />
+			<!-- Selection band: must contrast with TimePickerFlyoutPresenterBackground (SurfaceBrush) in both themes -->
+			<StaticResource x:Key="TimePickerFlyoutPresenterHighlightFill" ResourceKey="SurfaceVariantBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterCornerRadius" ResourceKey="SimpleRadius400CornerRadius" />
+			<x:Double x:Key="TimePickerFlyoutPresenterWidth">242</x:Double>
+			<x:Double x:Key="TimePickerFlyoutPresenterMinWidth">242</x:Double>
+			<x:Double x:Key="TimePickerFlyoutPresenterMaxHeight">398</x:Double>
+			<StaticResource x:Key="TimePickerFlyoutPresenterHighlightHeight" ResourceKey="SimpleIconLarge" />
+			<x:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">52</x:Double>
+			<StaticResource x:Key="TimePickerSpacerThemeWidth" ResourceKey="SimpleStrokeBorder" />
+			<StaticResource x:Key="TimePickerFlyoutBorderThickness" ResourceKey="SimpleStrokeBorder" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterFontFamily" ResourceKey="SimpleFontFamily" />
+
+			<!-- ── TimePicker Button (field appearance) ── -->
+			<StaticResource x:Key="TimePickerButtonBackground" ResourceKey="SurfaceBrush" />
+			<StaticResource x:Key="TimePickerButtonBackgroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+
+			<StaticResource x:Key="TimePickerButtonBorderBrush" ResourceKey="OutlineBrush" />
+			<StaticResource x:Key="TimePickerButtonBorderBrushDisabled" ResourceKey="OutlineDisabledBrush" />
+
+			<!-- ── Time text ── -->
+			<StaticResource x:Key="TimePickerButtonTimeTextForeground" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="TimePickerButtonTimeTextForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+
+			<!-- ── Placeholder text (the Header, shown when no time is selected) ── -->
+			<StaticResource x:Key="TimePickerPlaceholderTextForeground" ResourceKey="OnSurfaceLowBrush" />
+
+			<!-- ── Time separator ── -->
+			<StaticResource x:Key="TimePickerSpacerFill" ResourceKey="OnSurfaceVariantBrush" />
+			<StaticResource x:Key="TimePickerSpacerFillDisabled" ResourceKey="OutlineDisabledBrush" />
+
+			<!-- ── Header ── -->
+			<StaticResource x:Key="TimePickerHeaderForeground" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="TimePickerHeaderForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+
+			<!-- ── Dimensions ── -->
+			<StaticResource x:Key="TimePickerCornerRadius" ResourceKey="SimpleRadius200CornerRadius" />
+			<StaticResource x:Key="TimePickerBorderThemeThickness" ResourceKey="SimpleStrokeBorderThickness" />
+			<Thickness x:Key="TimePickerContentMargin">16,10,16,10</Thickness>
+			<StaticResource x:Key="TimePickerFlyoutButtonPadding" ResourceKey="SimpleSpace0Thickness" />
+			<StaticResource x:Key="TimePickerMinHeight" ResourceKey="ControlHeightMediumLarge" />
+			<x:Double x:Key="TimePickerFlyoutButtonOpacityPressed">0.8</x:Double>
+			<x:Double x:Key="TimePickerFlyoutButtonOpacityDisabled">0.5</x:Double>
+			<!-- Kept for back-compat: the header now renders as the in-field placeholder -->
+			<StaticResource x:Key="TimePickerHeaderMargin" ResourceKey="Space100BottomThickness" />
+			<!-- Kept for back-compat: the column separator is text, not a rule -->
+			<StaticResource x:Key="TimePickerColumnDividerWidth" ResourceKey="SimpleStrokeBorder" />
+			<Thickness x:Key="TimePickerColumnDividerMargin">2,0,2,0</Thickness>
+			<Thickness x:Key="TimePickerFlyoutPresenterTitleMargin">16,12,16,4</Thickness>
+		</ResourceDictionary>
+
+		<!-- ─── Dark Theme (Default) ─── -->
+		<ResourceDictionary x:Key="Default">
+
+			<!-- ── FlyoutButton (transparent wrapper) ── -->
+			<StaticResource x:Key="TimePickerFlyoutButtonBackground" ResourceKey="SystemControlTransparentBrush" />
+
+			<!-- ── FlyoutPresenter ── -->
+			<StaticResource x:Key="TimePickerFlyoutPresenterBackground" ResourceKey="SurfaceBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterForeground" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterBorderBrush" ResourceKey="OutlineBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterSpacerFill" ResourceKey="OutlineBrush" />
+			<!-- Selection band: must contrast with TimePickerFlyoutPresenterBackground (SurfaceBrush) in both themes -->
+			<StaticResource x:Key="TimePickerFlyoutPresenterHighlightFill" ResourceKey="SurfaceVariantBrush" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterCornerRadius" ResourceKey="SimpleRadius400CornerRadius" />
+			<x:Double x:Key="TimePickerFlyoutPresenterWidth">242</x:Double>
+			<x:Double x:Key="TimePickerFlyoutPresenterMinWidth">242</x:Double>
+			<x:Double x:Key="TimePickerFlyoutPresenterMaxHeight">398</x:Double>
+			<StaticResource x:Key="TimePickerFlyoutPresenterHighlightHeight" ResourceKey="SimpleIconLarge" />
+			<x:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">52</x:Double>
+			<StaticResource x:Key="TimePickerSpacerThemeWidth" ResourceKey="SimpleStrokeBorder" />
+			<StaticResource x:Key="TimePickerFlyoutBorderThickness" ResourceKey="SimpleStrokeBorder" />
+			<StaticResource x:Key="TimePickerFlyoutPresenterFontFamily" ResourceKey="SimpleFontFamily" />
+
+			<!-- ── TimePicker Button (field appearance) ── -->
+			<StaticResource x:Key="TimePickerButtonBackground" ResourceKey="SurfaceBrush" />
+			<StaticResource x:Key="TimePickerButtonBackgroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+
+			<StaticResource x:Key="TimePickerButtonBorderBrush" ResourceKey="OutlineBrush" />
+			<StaticResource x:Key="TimePickerButtonBorderBrushDisabled" ResourceKey="OutlineDisabledBrush" />
+
+			<!-- ── Time text ── -->
+			<StaticResource x:Key="TimePickerButtonTimeTextForeground" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="TimePickerButtonTimeTextForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+
+			<!-- ── Placeholder text (the Header, shown when no time is selected) ── -->
+			<StaticResource x:Key="TimePickerPlaceholderTextForeground" ResourceKey="OnSurfaceLowBrush" />
+
+			<!-- ── Time separator ── -->
+			<StaticResource x:Key="TimePickerSpacerFill" ResourceKey="OnSurfaceVariantBrush" />
+			<StaticResource x:Key="TimePickerSpacerFillDisabled" ResourceKey="OutlineDisabledBrush" />
+
+			<!-- ── Header ── -->
+			<StaticResource x:Key="TimePickerHeaderForeground" ResourceKey="OnSurfaceBrush" />
+			<StaticResource x:Key="TimePickerHeaderForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+
+			<!-- ── Dimensions ── -->
+			<StaticResource x:Key="TimePickerCornerRadius" ResourceKey="SimpleRadius200CornerRadius" />
+			<StaticResource x:Key="TimePickerBorderThemeThickness" ResourceKey="SimpleStrokeBorderThickness" />
+			<Thickness x:Key="TimePickerContentMargin">16,10,16,10</Thickness>
+			<StaticResource x:Key="TimePickerFlyoutButtonPadding" ResourceKey="SimpleSpace0Thickness" />
+			<StaticResource x:Key="TimePickerMinHeight" ResourceKey="ControlHeightMediumLarge" />
+			<x:Double x:Key="TimePickerFlyoutButtonOpacityPressed">0.8</x:Double>
+			<x:Double x:Key="TimePickerFlyoutButtonOpacityDisabled">0.5</x:Double>
+			<!-- Kept for back-compat: the header now renders as the in-field placeholder -->
+			<StaticResource x:Key="TimePickerHeaderMargin" ResourceKey="Space100BottomThickness" />
+			<!-- Kept for back-compat: the column separator is text, not a rule -->
+			<StaticResource x:Key="TimePickerColumnDividerWidth" ResourceKey="SimpleStrokeBorder" />
+			<Thickness x:Key="TimePickerColumnDividerMargin">2,0,2,0</Thickness>
+			<Thickness x:Key="TimePickerFlyoutPresenterTitleMargin">16,12,16,4</Thickness>
+		</ResourceDictionary>
+
+	</ResourceDictionary.ThemeDictionaries>
+
+	<!-- ═══════════════════════════════════════════════════════════════════════ -->
+	<!-- SimpleTimePickerFlyoutButtonStyle -->
+	<!-- Transparent wrapper — visual field is rendered by TimePicker template -->
+	<!-- ═══════════════════════════════════════════════════════════════════════ -->
+	<Style x:Key="SimpleTimePickerFlyoutButtonStyle"
+		   TargetType="Button">
+
+		<Setter Property="Background" Value="{ThemeResource TimePickerFlyoutButtonBackground}" />
+		<Setter Property="Padding" Value="{ThemeResource TimePickerFlyoutButtonPadding}" />
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="Button">
+					<Grid x:Name="RootGrid"
+						  Background="{TemplateBinding Background}">
+
+						<ContentPresenter x:Name="ContentPresenter"
+										  Margin="{TemplateBinding Padding}"
+										  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Content="{TemplateBinding Content}"
+										  ContentTemplate="{TemplateBinding ContentTemplate}"
+										  ContentTransitions="{TemplateBinding ContentTransitions}" />
+
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal" />
+								<VisualState x:Name="PointerOver" />
+								<VisualState x:Name="Pressed">
+									<VisualState.Setters>
+										<Setter Target="RootGrid.Opacity" Value="{ThemeResource TimePickerFlyoutButtonOpacityPressed}" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="RootGrid.Opacity" Value="{ThemeResource TimePickerFlyoutButtonOpacityDisabled}" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<!-- ═══════════════════════════════════════════════════════════════════════ -->
+	<!-- SimpleTimePickerFlyoutPresenterStyle -->
+	<!-- Flyout panel with hour/minute/period columns + accept/dismiss buttons -->
+	<!-- ═══════════════════════════════════════════════════════════════════════ -->
+	<Style x:Key="SimpleTimePickerFlyoutPresenterStyle"
+		   TargetType="TimePickerFlyoutPresenter">
+
+		<Setter Property="Width" Value="{ThemeResource TimePickerFlyoutPresenterWidth}" />
+		<Setter Property="MinWidth" Value="{ThemeResource TimePickerFlyoutPresenterMinWidth}" />
+		<Setter Property="MaxHeight" Value="{ThemeResource TimePickerFlyoutPresenterMaxHeight}" />
+		<Setter Property="IsTabStop" Value="False" />
+		<Setter Property="FontFamily" Value="{ThemeResource TimePickerFlyoutPresenterFontFamily}" />
+		<Setter Property="FontWeight" Value="Normal" />
+		<Setter Property="FontSize" Value="{ThemeResource BodyLargeFontSize}" />
+		<Setter Property="Foreground" Value="{ThemeResource TimePickerFlyoutPresenterForeground}" />
+		<Setter Property="Background" Value="{ThemeResource TimePickerFlyoutPresenterBackground}" />
+		<Setter Property="AutomationProperties.AutomationId" Value="TimePickerFlyoutPresenter" />
+		<Setter Property="BorderThickness" Value="{ThemeResource TimePickerFlyoutBorderThickness}" />
+		<Setter Property="BorderBrush" Value="{ThemeResource TimePickerFlyoutPresenterBorderBrush}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource TimePickerFlyoutPresenterCornerRadius}" />
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="TimePickerFlyoutPresenter">
+					<Border x:Name="Background"
+							MaxHeight="{TemplateBinding MaxHeight}"
+							Background="{TemplateBinding Background}"
+							BorderBrush="{TemplateBinding BorderBrush}"
+							BorderThickness="{TemplateBinding BorderThickness}"
+							CornerRadius="{TemplateBinding CornerRadius}">
+
+						<Grid x:Name="ContentPanel">
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="*" />
+								<RowDefinition Height="Auto" />
+							</Grid.RowDefinitions>
+
+							<!-- Optional flyout title (TimePickerFlyout.Title) -->
+							<TextBlock x:Name="TitlePresenter"
+									   Grid.Row="0"
+									   Margin="{ThemeResource TimePickerFlyoutPresenterTitleMargin}"
+									   FontFamily="{TemplateBinding FontFamily}"
+									   FontSize="{ThemeResource BodyMediumFontSize}"
+									   Foreground="{TemplateBinding Foreground}"
+									   TextWrapping="Wrap"
+									   Visibility="Collapsed" />
+
+							<!-- Picker columns -->
+							<Grid Grid.Row="1">
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition x:Name="FirstPickerHostColumn"
+													  Width="*" />
+									<ColumnDefinition Width="Auto" />
+									<ColumnDefinition x:Name="SecondPickerHostColumn"
+													  Width="*" />
+									<ColumnDefinition Width="Auto" />
+									<ColumnDefinition x:Name="ThirdPickerHostColumn"
+													  Width="*" />
+								</Grid.ColumnDefinitions>
+
+								<!-- Selection highlight -->
+								<Rectangle x:Name="HighlightRect"
+										   Grid.Column="0"
+										   Grid.ColumnSpan="5"
+										   Height="{ThemeResource TimePickerFlyoutPresenterHighlightHeight}"
+										   VerticalAlignment="Center"
+										   Fill="{ThemeResource TimePickerFlyoutPresenterHighlightFill}"
+										   RadiusX="8"
+										   RadiusY="8" />
+
+								<Border x:Name="FirstPickerHost"
+										Grid.Column="0" />
+
+								<Rectangle x:Name="FirstPickerSpacing"
+										   Grid.Column="1"
+										   Width="{ThemeResource TimePickerSpacerThemeWidth}"
+										   HorizontalAlignment="Center"
+										   Fill="{ThemeResource TimePickerFlyoutPresenterSpacerFill}" />
+
+								<Border x:Name="SecondPickerHost"
+										Grid.Column="2" />
+
+								<Rectangle x:Name="SecondPickerSpacing"
+										   Grid.Column="3"
+										   Width="{ThemeResource TimePickerSpacerThemeWidth}"
+										   HorizontalAlignment="Center"
+										   Fill="{ThemeResource TimePickerFlyoutPresenterSpacerFill}" />
+
+								<Border x:Name="ThirdPickerHost"
+										Grid.Column="4" />
+							</Grid>
+
+							<!-- Accept / Dismiss buttons -->
+							<Grid x:Name="AcceptDismissHostGrid"
+								  Grid.Row="2"
+								  Height="{ThemeResource TimePickerFlyoutPresenterAcceptDismissHostGridHeight}"
+								  VerticalAlignment="Bottom"
+								  Background="{TemplateBinding Background}">
+
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="*" />
+									<ColumnDefinition Width="Auto" />
+									<ColumnDefinition Width="Auto" />
+								</Grid.ColumnDefinitions>
+
+								<!-- Top separator line -->
+								<Rectangle Grid.ColumnSpan="3"
+										   Height="{ThemeResource TimePickerSpacerThemeWidth}"
+										   VerticalAlignment="Top"
+										   Fill="{ThemeResource TimePickerFlyoutPresenterSpacerFill}" />
+
+								<Button x:Name="DismissButton"
+										x:Uid="TimePickerFlyoutDismissButton"
+										Grid.Column="1"
+										HorizontalAlignment="Right"
+										VerticalAlignment="Center"
+										Content="Cancel"
+										Style="{StaticResource SimpleTextButtonStyle}" />
+
+								<Button x:Name="AcceptButton"
+										x:Uid="TimePickerFlyoutAcceptButton"
+										Grid.Column="2"
+										HorizontalAlignment="Right"
+										VerticalAlignment="Center"
+										Content="OK"
+										Style="{StaticResource SimpleTextButtonStyle}" />
+							</Grid>
+						</Grid>
+					</Border>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<!-- ═══════════════════════════════════════════════════════════════════════ -->
+	<!-- SimpleTimePickerStyle -->
+	<!-- Field-like appearance matching SimpleDatePickerStyle -->
+	<!-- ═══════════════════════════════════════════════════════════════════════ -->
+	<Style x:Key="SimpleTimePickerStyle"
+		   TargetType="TimePicker">
+
+		<Setter Property="Background" Value="{ThemeResource TimePickerButtonBackground}" />
+		<Setter Property="Foreground" Value="{ThemeResource TimePickerButtonTimeTextForeground}" />
+		<Setter Property="BorderBrush" Value="{ThemeResource TimePickerButtonBorderBrush}" />
+		<Setter Property="BorderThickness" Value="{ThemeResource TimePickerBorderThemeThickness}" />
+		<!-- Sizes to content like the Fluent TimePicker (TimePickerFlyoutPresenterMinWidth sets the floor) — a stretched
+			 field also stretches the flyout, which TimePickerFlyout.OnOpening sizes to the target's ActualWidth. -->
+		<Setter Property="HorizontalAlignment" Value="Left" />
+		<Setter Property="MinHeight" Value="{ThemeResource TimePickerMinHeight}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource TimePickerCornerRadius}" />
+		<Setter Property="FontFamily" Value="{ThemeResource BodyLargeFontFamily}" />
+		<Setter Property="FontSize" Value="{ThemeResource BodyLargeFontSize}" />
+		<Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="TimePicker">
+					<!--
+						Root Grid — Header renders only as the in-field placeholder (PlaceholderText below),
+						the way the Simple TextBox shows PlaceholderText. A separate header line above the
+						field plus that header-bound placeholder showed the same text twice.
+					-->
+					<Grid x:Name="LayoutRoot">
+
+						<!-- Flyout Button -->
+						<Button x:Name="FlyoutButton"
+								MinWidth="{ThemeResource TimePickerFlyoutPresenterMinWidth}"
+								HorizontalAlignment="Stretch"
+								HorizontalContentAlignment="Stretch"
+								IsEnabled="{TemplateBinding IsEnabled}"
+								Style="{StaticResource SimpleTimePickerFlyoutButtonStyle}"
+								UseSystemFocusVisuals="{TemplateBinding UseSystemFocusVisuals}">
+
+							<Grid x:Name="ContentButton">
+
+								<!-- Field border -->
+								<Border x:Name="Background"
+										MinHeight="{TemplateBinding MinHeight}"
+										Background="{TemplateBinding Background}"
+										BorderBrush="{TemplateBinding BorderBrush}"
+										BorderThickness="{TemplateBinding BorderThickness}"
+										CornerRadius="{TemplateBinding CornerRadius}" />
+
+								<!-- Placeholder — the header, shown while no time is picked -->
+								<TextBlock x:Name="PlaceholderText"
+										   Margin="{ThemeResource TimePickerContentMargin}"
+										   VerticalAlignment="Center"
+										   AutomationProperties.AccessibilityView="Raw"
+										   FontFamily="{TemplateBinding FontFamily}"
+										   FontSize="{TemplateBinding FontSize}"
+										   Foreground="{ThemeResource TimePickerPlaceholderTextForeground}"
+										   Text="{TemplateBinding Header}"
+										   TextWrapping="Wrap"
+										   Visibility="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyOrNullToCollapsedConverter}}" />
+
+								<!--
+									Content — the hour / minute / period parts stay under the control's ownership
+									(it fills them, reorders the hosts per culture and collapses the period column
+									for a 24-hour ClockIdentifier). Auto columns and a left-aligned grid render them
+									as a single value ("9:41 AM") instead of three full-width cells, so the field
+									reads like the DatePicker / TextBox field. First|SecondColumnDivider are typed
+									UIElement in the control contract, so they carry the time separator rather than
+									a vertical rule.
+								-->
+								<Grid x:Name="FlyoutButtonContentGrid"
+									  Margin="{ThemeResource TimePickerContentMargin}"
+									  HorizontalAlignment="Left"
+									  VerticalAlignment="Center"
+									  Visibility="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyOrNullToVisibleConverter}}">
+
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition x:Name="FirstTextBlockColumn"
+														  Width="Auto" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition x:Name="SecondTextBlockColumn"
+														  Width="Auto" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition x:Name="ThirdTextBlockColumn"
+														  Width="Auto" />
+									</Grid.ColumnDefinitions>
+
+									<!-- Hours -->
+									<Border x:Name="FirstPickerHost"
+											Grid.Column="0">
+										<TextBlock x:Name="HourTextBlock"
+												   VerticalAlignment="Center"
+												   AutomationProperties.AccessibilityView="Raw"
+												   FontFamily="{TemplateBinding FontFamily}"
+												   FontSize="{TemplateBinding FontSize}"
+												   Foreground="{ThemeResource TimePickerButtonTimeTextForeground}" />
+									</Border>
+
+									<!-- Time separator -->
+									<TextBlock x:Name="FirstColumnDivider"
+											   Grid.Column="1"
+											   Margin="{ThemeResource TimePickerColumnDividerMargin}"
+											   VerticalAlignment="Center"
+											   AutomationProperties.AccessibilityView="Raw"
+											   FontFamily="{TemplateBinding FontFamily}"
+											   FontSize="{TemplateBinding FontSize}"
+											   Foreground="{ThemeResource TimePickerSpacerFill}"
+											   Text=":" />
+
+									<!-- Minutes -->
+									<Border x:Name="SecondPickerHost"
+											Grid.Column="2">
+										<TextBlock x:Name="MinuteTextBlock"
+												   VerticalAlignment="Center"
+												   AutomationProperties.AccessibilityView="Raw"
+												   FontFamily="{TemplateBinding FontFamily}"
+												   FontSize="{TemplateBinding FontSize}"
+												   Foreground="{ThemeResource TimePickerButtonTimeTextForeground}" />
+									</Border>
+
+									<!-- Period spacing — collapsed by the control for a 24-hour clock -->
+									<TextBlock x:Name="SecondColumnDivider"
+											   Grid.Column="3"
+											   Margin="{ThemeResource TimePickerColumnDividerMargin}"
+											   VerticalAlignment="Center"
+											   AutomationProperties.AccessibilityView="Raw"
+											   FontFamily="{TemplateBinding FontFamily}"
+											   FontSize="{TemplateBinding FontSize}" />
+
+									<!-- AM/PM -->
+									<Border x:Name="ThirdPickerHost"
+											Grid.Column="4">
+										<TextBlock x:Name="PeriodTextBlock"
+												   VerticalAlignment="Center"
+												   AutomationProperties.AccessibilityView="Raw"
+												   FontFamily="{TemplateBinding FontFamily}"
+												   FontSize="{TemplateBinding FontSize}"
+												   Foreground="{ThemeResource TimePickerButtonTimeTextForeground}" />
+									</Border>
+								</Grid>
+							</Grid>
+						</Button>
+
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal" />
+
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="Background.Background" Value="{ThemeResource TimePickerButtonBackgroundDisabled}" />
+										<Setter Target="Background.BorderBrush" Value="{ThemeResource TimePickerButtonBorderBrushDisabled}" />
+										<Setter Target="PlaceholderText.Foreground" Value="{ThemeResource TimePickerHeaderForegroundDisabled}" />
+										<Setter Target="HourTextBlock.Foreground" Value="{ThemeResource TimePickerButtonTimeTextForegroundDisabled}" />
+										<Setter Target="MinuteTextBlock.Foreground" Value="{ThemeResource TimePickerButtonTimeTextForegroundDisabled}" />
+										<Setter Target="PeriodTextBlock.Foreground" Value="{ThemeResource TimePickerButtonTimeTextForegroundDisabled}" />
+										<Setter Target="FirstColumnDivider.Foreground" Value="{ThemeResource TimePickerSpacerFillDisabled}" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="HasTimeStates">
+								<!--
+									Once a time is picked the value replaces the placeholder. Without one, the
+									header is the placeholder; the control's own "hour : minute AM" run only
+									shows when there is no header to use, otherwise the two would overlap.
+								-->
+								<VisualState x:Name="HasTime">
+									<VisualState.Setters>
+										<Setter Target="FlyoutButtonContentGrid.Visibility" Value="Visible" />
+										<Setter Target="PlaceholderText.Visibility" Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+
+								<VisualState x:Name="HasNoTime">
+									<VisualState.Setters>
+										<Setter Target="HourTextBlock.Foreground" Value="{ThemeResource TimePickerPlaceholderTextForeground}" />
+										<Setter Target="MinuteTextBlock.Foreground" Value="{ThemeResource TimePickerPlaceholderTextForeground}" />
+										<Setter Target="PeriodTextBlock.Foreground" Value="{ThemeResource TimePickerPlaceholderTextForeground}" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<!-- ═══════════════════════════════════════════════════════════════════════ -->
+	<!-- Default aliases (for implicit styles) -->
+	<!-- ═══════════════════════════════════════════════════════════════════════ -->
+	<Style x:Key="SimpleDefaultTimePickerStyle"
+		   TargetType="TimePicker"
+		   BasedOn="{StaticResource SimpleTimePickerStyle}" />
+
+	<Style x:Key="SimpleDefaultTimePickerFlyoutPresenterStyle"
+		   TargetType="TimePickerFlyoutPresenter"
+		   BasedOn="{StaticResource SimpleTimePickerFlyoutPresenterStyle}" />
+
+</ResourceDictionary>

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/TimePicker.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/TimePicker.xaml
@@ -12,10 +12,12 @@
 		TimePicker* = canonical semantic keys (source of truth)
 
 		Template part names follow the WinUI TimePicker contract
-		(LayoutRoot / FlyoutButton / FlyoutButtonContentGrid /
-		First|Second|ThirdPickerHost / First|Second|ThirdTextBlockColumn /
+		(LayoutRoot / FlyoutButton / First|Second|ThirdPickerHost /
+		First|Second|ThirdTextBlockColumn / Hour|Minute|PeriodTextBlock /
 		First|SecondColumnDivider) so the control can reorder hour / minute / period
 		per culture and collapse the period column for a 24-hour ClockIdentifier.
+		FlyoutButtonContentGrid and PlaceholderText are this template's own names,
+		not part of that contract.
 
 		SDS TimePicker CSS mapping:
 		Field:       background-default-default bg, border-default-default border, radius-200 (8px), text-default-default
@@ -47,11 +49,7 @@
 			<!-- Selection band: must contrast with TimePickerFlyoutPresenterBackground (SurfaceBrush) in both themes -->
 			<StaticResource x:Key="TimePickerFlyoutPresenterHighlightFill" ResourceKey="SurfaceVariantBrush" />
 			<StaticResource x:Key="TimePickerFlyoutPresenterCornerRadius" ResourceKey="SimpleRadius400CornerRadius" />
-			<x:Double x:Key="TimePickerFlyoutPresenterWidth">242</x:Double>
-			<x:Double x:Key="TimePickerFlyoutPresenterMinWidth">242</x:Double>
-			<x:Double x:Key="TimePickerFlyoutPresenterMaxHeight">398</x:Double>
 			<StaticResource x:Key="TimePickerFlyoutPresenterHighlightHeight" ResourceKey="SimpleIconLarge" />
-			<x:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">52</x:Double>
 			<StaticResource x:Key="TimePickerSpacerThemeWidth" ResourceKey="SimpleStrokeBorder" />
 			<StaticResource x:Key="TimePickerFlyoutBorderThickness" ResourceKey="SimpleStrokeBorder" />
 			<StaticResource x:Key="TimePickerFlyoutPresenterFontFamily" ResourceKey="SimpleFontFamily" />
@@ -74,24 +72,16 @@
 			<StaticResource x:Key="TimePickerSpacerFill" ResourceKey="OnSurfaceVariantBrush" />
 			<StaticResource x:Key="TimePickerSpacerFillDisabled" ResourceKey="OutlineDisabledBrush" />
 
-			<!-- ── Header ── -->
-			<StaticResource x:Key="TimePickerHeaderForeground" ResourceKey="OnSurfaceBrush" />
+			<!-- ── Header (rendered as the in-field placeholder) ── -->
+			<StaticResource x:Key="TimePickerHeaderForeground" ResourceKey="OnSurfaceLowBrush" />
 			<StaticResource x:Key="TimePickerHeaderForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
 
 			<!-- ── Dimensions ── -->
 			<StaticResource x:Key="TimePickerCornerRadius" ResourceKey="SimpleRadius200CornerRadius" />
 			<StaticResource x:Key="TimePickerBorderThemeThickness" ResourceKey="SimpleStrokeBorderThickness" />
-			<Thickness x:Key="TimePickerContentMargin">16,10,16,10</Thickness>
 			<StaticResource x:Key="TimePickerFlyoutButtonPadding" ResourceKey="SimpleSpace0Thickness" />
 			<StaticResource x:Key="TimePickerMinHeight" ResourceKey="ControlHeightMediumLarge" />
-			<x:Double x:Key="TimePickerFlyoutButtonOpacityPressed">0.8</x:Double>
-			<x:Double x:Key="TimePickerFlyoutButtonOpacityDisabled">0.5</x:Double>
-			<!-- Kept for back-compat: the header now renders as the in-field placeholder -->
-			<StaticResource x:Key="TimePickerHeaderMargin" ResourceKey="Space100BottomThickness" />
-			<!-- Kept for back-compat: the column separator is text, not a rule -->
 			<StaticResource x:Key="TimePickerColumnDividerWidth" ResourceKey="SimpleStrokeBorder" />
-			<Thickness x:Key="TimePickerColumnDividerMargin">2,0,2,0</Thickness>
-			<Thickness x:Key="TimePickerFlyoutPresenterTitleMargin">16,12,16,4</Thickness>
 		</ResourceDictionary>
 
 		<!-- ─── Dark Theme (Default) ─── -->
@@ -108,11 +98,7 @@
 			<!-- Selection band: must contrast with TimePickerFlyoutPresenterBackground (SurfaceBrush) in both themes -->
 			<StaticResource x:Key="TimePickerFlyoutPresenterHighlightFill" ResourceKey="SurfaceVariantBrush" />
 			<StaticResource x:Key="TimePickerFlyoutPresenterCornerRadius" ResourceKey="SimpleRadius400CornerRadius" />
-			<x:Double x:Key="TimePickerFlyoutPresenterWidth">242</x:Double>
-			<x:Double x:Key="TimePickerFlyoutPresenterMinWidth">242</x:Double>
-			<x:Double x:Key="TimePickerFlyoutPresenterMaxHeight">398</x:Double>
 			<StaticResource x:Key="TimePickerFlyoutPresenterHighlightHeight" ResourceKey="SimpleIconLarge" />
-			<x:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">52</x:Double>
 			<StaticResource x:Key="TimePickerSpacerThemeWidth" ResourceKey="SimpleStrokeBorder" />
 			<StaticResource x:Key="TimePickerFlyoutBorderThickness" ResourceKey="SimpleStrokeBorder" />
 			<StaticResource x:Key="TimePickerFlyoutPresenterFontFamily" ResourceKey="SimpleFontFamily" />
@@ -135,27 +121,40 @@
 			<StaticResource x:Key="TimePickerSpacerFill" ResourceKey="OnSurfaceVariantBrush" />
 			<StaticResource x:Key="TimePickerSpacerFillDisabled" ResourceKey="OutlineDisabledBrush" />
 
-			<!-- ── Header ── -->
-			<StaticResource x:Key="TimePickerHeaderForeground" ResourceKey="OnSurfaceBrush" />
+			<!-- ── Header (rendered as the in-field placeholder) ── -->
+			<StaticResource x:Key="TimePickerHeaderForeground" ResourceKey="OnSurfaceLowBrush" />
 			<StaticResource x:Key="TimePickerHeaderForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
 
 			<!-- ── Dimensions ── -->
 			<StaticResource x:Key="TimePickerCornerRadius" ResourceKey="SimpleRadius200CornerRadius" />
 			<StaticResource x:Key="TimePickerBorderThemeThickness" ResourceKey="SimpleStrokeBorderThickness" />
-			<Thickness x:Key="TimePickerContentMargin">16,10,16,10</Thickness>
 			<StaticResource x:Key="TimePickerFlyoutButtonPadding" ResourceKey="SimpleSpace0Thickness" />
 			<StaticResource x:Key="TimePickerMinHeight" ResourceKey="ControlHeightMediumLarge" />
-			<x:Double x:Key="TimePickerFlyoutButtonOpacityPressed">0.8</x:Double>
-			<x:Double x:Key="TimePickerFlyoutButtonOpacityDisabled">0.5</x:Double>
-			<!-- Kept for back-compat: the header now renders as the in-field placeholder -->
-			<StaticResource x:Key="TimePickerHeaderMargin" ResourceKey="Space100BottomThickness" />
-			<!-- Kept for back-compat: the column separator is text, not a rule -->
 			<StaticResource x:Key="TimePickerColumnDividerWidth" ResourceKey="SimpleStrokeBorder" />
-			<Thickness x:Key="TimePickerColumnDividerMargin">2,0,2,0</Thickness>
-			<Thickness x:Key="TimePickerFlyoutPresenterTitleMargin">16,12,16,4</Thickness>
 		</ResourceDictionary>
 
 	</ResourceDictionary.ThemeDictionaries>
+
+	<!-- ═══════════════════════════════════════════════════════════════════════ -->
+	<!-- Theme-invariant dimensions -->
+	<!--
+		Declared at dictionary scope rather than duplicated into every theme branch:
+		the values are identical in Light and Dark, and a single declaration keeps
+		them resolvable from Storyboard/Setter values, which read through
+		StaticResource and do not re-resolve per ThemeDictionary.
+		Consumers still override them from their own App resources.
+	-->
+	<!-- ═══════════════════════════════════════════════════════════════════════ -->
+	<x:Double x:Key="TimePickerFlyoutPresenterWidth">242</x:Double>
+	<x:Double x:Key="TimePickerFlyoutPresenterMinWidth">242</x:Double>
+	<x:Double x:Key="TimePickerFlyoutPresenterMaxWidth">456</x:Double>
+	<x:Double x:Key="TimePickerFlyoutPresenterMaxHeight">398</x:Double>
+	<x:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">52</x:Double>
+	<x:Double x:Key="TimePickerFlyoutButtonOpacityPressed">0.8</x:Double>
+	<x:Double x:Key="TimePickerFlyoutButtonOpacityDisabled">0.5</x:Double>
+	<Thickness x:Key="TimePickerContentMargin">16,10,16,10</Thickness>
+	<Thickness x:Key="TimePickerColumnDividerMargin">2,0,2,0</Thickness>
+	<Thickness x:Key="TimePickerFlyoutPresenterTitleMargin">16,12,16,4</Thickness>
 
 	<!-- ═══════════════════════════════════════════════════════════════════════ -->
 	<!-- SimpleTimePickerFlyoutButtonStyle -->
@@ -358,6 +357,8 @@
 		<Setter Property="FontFamily" Value="{ThemeResource BodyLargeFontFamily}" />
 		<Setter Property="FontSize" Value="{ThemeResource BodyLargeFontSize}" />
 		<Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+		<not_win:Setter Property="FlyoutPresenterStyle"
+						Value="{StaticResource SimpleTimePickerFlyoutPresenterStyle}" />
 
 		<Setter Property="Template">
 			<Setter.Value>
@@ -372,6 +373,7 @@
 						<!-- Flyout Button -->
 						<Button x:Name="FlyoutButton"
 								MinWidth="{ThemeResource TimePickerFlyoutPresenterMinWidth}"
+								MaxWidth="{ThemeResource TimePickerFlyoutPresenterMaxWidth}"
 								HorizontalAlignment="Stretch"
 								HorizontalContentAlignment="Stretch"
 								IsEnabled="{TemplateBinding IsEnabled}"
@@ -388,48 +390,60 @@
 										BorderThickness="{TemplateBinding BorderThickness}"
 										CornerRadius="{TemplateBinding CornerRadius}" />
 
-								<!-- Placeholder — the header, shown while no time is picked -->
-								<TextBlock x:Name="PlaceholderText"
-										   Margin="{ThemeResource TimePickerContentMargin}"
-										   VerticalAlignment="Center"
-										   AutomationProperties.AccessibilityView="Raw"
-										   FontFamily="{TemplateBinding FontFamily}"
-										   FontSize="{TemplateBinding FontSize}"
-										   Foreground="{ThemeResource TimePickerPlaceholderTextForeground}"
-										   Text="{TemplateBinding Header}"
-										   TextWrapping="Wrap"
-										   Visibility="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyOrNullToCollapsedConverter}}" />
+								<!--
+									Placeholder — the header, shown while no time is picked. A ContentPresenter
+									rather than a TextBlock so a non-string Header and HeaderTemplate both render
+									(Header is typed object; Text="{TemplateBinding Header}" would ToString it and
+									drop HeaderTemplate entirely).
+								-->
+								<ContentPresenter x:Name="PlaceholderText"
+												  Margin="{ThemeResource TimePickerContentMargin}"
+												  VerticalAlignment="Center"
+												  AutomationProperties.AccessibilityView="Raw"
+												  Content="{TemplateBinding Header}"
+												  ContentTemplate="{TemplateBinding HeaderTemplate}"
+												  FontFamily="{TemplateBinding FontFamily}"
+												  FontSize="{TemplateBinding FontSize}"
+												  Foreground="{ThemeResource TimePickerHeaderForeground}"
+												  TextWrapping="Wrap"
+												  Visibility="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyOrNullToCollapsedConverter}}" />
 
 								<!--
-									Content — the hour / minute / period parts stay under the control's ownership
-									(it fills them, reorders the hosts per culture and collapses the period column
-									for a 24-hour ClockIdentifier). Auto columns and a left-aligned grid render them
-									as a single value ("9:41 AM") instead of three full-width cells, so the field
-									reads like the DatePicker / TextBox field. First|SecondColumnDivider are typed
-									UIElement in the control contract, so they carry the time separator rather than
-									a vertical rule.
+									Content — the hour / minute / period parts stay under the control's ownership:
+									it fills the TextBlocks, reparents them between First|Second|ThirdPickerHost to
+									reorder per culture, and collapses the period host for a 24-hour ClockIdentifier.
+
+									The dividers are neutral rules, not glyphs. UpdateOrderAndLayout only toggles
+									divider *visibility* — it never moves them — so a literal ":" in FirstColumnDivider
+									is only correct while the hour happens to come first. Under a period-first culture
+									(ko-KR / zh-CN / ja-JP put the period in FirstPickerHost) it would render
+									"오전 : 9  41", with the colon between period and hour and none between hour and
+									minute. A rule carries no ordering assumption, so it is correct in every culture.
+
+									The star column widths match the control: UpdateOrderAndLayout assigns 1* to every
+									populated column and 0 to the rest, overwriting whatever the template declares.
 								-->
 								<Grid x:Name="FlyoutButtonContentGrid"
 									  Margin="{ThemeResource TimePickerContentMargin}"
-									  HorizontalAlignment="Left"
 									  VerticalAlignment="Center"
 									  Visibility="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyOrNullToVisibleConverter}}">
 
 									<Grid.ColumnDefinitions>
 										<ColumnDefinition x:Name="FirstTextBlockColumn"
-														  Width="Auto" />
+														  Width="*" />
 										<ColumnDefinition Width="Auto" />
 										<ColumnDefinition x:Name="SecondTextBlockColumn"
-														  Width="Auto" />
+														  Width="*" />
 										<ColumnDefinition Width="Auto" />
 										<ColumnDefinition x:Name="ThirdTextBlockColumn"
-														  Width="Auto" />
+														  Width="*" />
 									</Grid.ColumnDefinitions>
 
 									<!-- Hours -->
 									<Border x:Name="FirstPickerHost"
 											Grid.Column="0">
 										<TextBlock x:Name="HourTextBlock"
+												   HorizontalAlignment="Center"
 												   VerticalAlignment="Center"
 												   AutomationProperties.AccessibilityView="Raw"
 												   FontFamily="{TemplateBinding FontFamily}"
@@ -437,21 +451,18 @@
 												   Foreground="{ThemeResource TimePickerButtonTimeTextForeground}" />
 									</Border>
 
-									<!-- Time separator -->
-									<TextBlock x:Name="FirstColumnDivider"
+									<Rectangle x:Name="FirstColumnDivider"
 											   Grid.Column="1"
+											   Width="{ThemeResource TimePickerColumnDividerWidth}"
 											   Margin="{ThemeResource TimePickerColumnDividerMargin}"
-											   VerticalAlignment="Center"
-											   AutomationProperties.AccessibilityView="Raw"
-											   FontFamily="{TemplateBinding FontFamily}"
-											   FontSize="{TemplateBinding FontSize}"
-											   Foreground="{ThemeResource TimePickerSpacerFill}"
-											   Text=":" />
+											   HorizontalAlignment="Center"
+											   Fill="{ThemeResource TimePickerSpacerFill}" />
 
 									<!-- Minutes -->
 									<Border x:Name="SecondPickerHost"
 											Grid.Column="2">
 										<TextBlock x:Name="MinuteTextBlock"
+												   HorizontalAlignment="Center"
 												   VerticalAlignment="Center"
 												   AutomationProperties.AccessibilityView="Raw"
 												   FontFamily="{TemplateBinding FontFamily}"
@@ -459,19 +470,19 @@
 												   Foreground="{ThemeResource TimePickerButtonTimeTextForeground}" />
 									</Border>
 
-									<!-- Period spacing — collapsed by the control for a 24-hour clock -->
-									<TextBlock x:Name="SecondColumnDivider"
+									<!-- Collapsed by the control for a 24-hour clock -->
+									<Rectangle x:Name="SecondColumnDivider"
 											   Grid.Column="3"
+											   Width="{ThemeResource TimePickerColumnDividerWidth}"
 											   Margin="{ThemeResource TimePickerColumnDividerMargin}"
-											   VerticalAlignment="Center"
-											   AutomationProperties.AccessibilityView="Raw"
-											   FontFamily="{TemplateBinding FontFamily}"
-											   FontSize="{TemplateBinding FontSize}" />
+											   HorizontalAlignment="Center"
+											   Fill="{ThemeResource TimePickerSpacerFill}" />
 
 									<!-- AM/PM -->
 									<Border x:Name="ThirdPickerHost"
 											Grid.Column="4">
 										<TextBlock x:Name="PeriodTextBlock"
+												   HorizontalAlignment="Center"
 												   VerticalAlignment="Center"
 												   AutomationProperties.AccessibilityView="Raw"
 												   FontFamily="{TemplateBinding FontFamily}"
@@ -494,7 +505,8 @@
 										<Setter Target="HourTextBlock.Foreground" Value="{ThemeResource TimePickerButtonTimeTextForegroundDisabled}" />
 										<Setter Target="MinuteTextBlock.Foreground" Value="{ThemeResource TimePickerButtonTimeTextForegroundDisabled}" />
 										<Setter Target="PeriodTextBlock.Foreground" Value="{ThemeResource TimePickerButtonTimeTextForegroundDisabled}" />
-										<Setter Target="FirstColumnDivider.Foreground" Value="{ThemeResource TimePickerSpacerFillDisabled}" />
+										<Setter Target="FirstColumnDivider.Fill" Value="{ThemeResource TimePickerSpacerFillDisabled}" />
+										<Setter Target="SecondColumnDivider.Fill" Value="{ThemeResource TimePickerSpacerFillDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/_Resources.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/_Resources.xaml
@@ -56,6 +56,10 @@
 	<Style BasedOn="{StaticResource SimpleDefaultDatePickerStyle}" TargetType="DatePicker" />
 	<Style BasedOn="{StaticResource SimpleDefaultDatePickerFlyoutPresenterStyle}" TargetType="DatePickerFlyoutPresenter" />
 
+	<!-- TimePicker -->
+	<Style BasedOn="{StaticResource SimpleDefaultTimePickerStyle}" TargetType="TimePicker" />
+	<Style BasedOn="{StaticResource SimpleDefaultTimePickerFlyoutPresenterStyle}" TargetType="TimePickerFlyoutPresenter" />
+
 	<!-- AutoSuggestBox -->
 	<Style BasedOn="{StaticResource SimpleDefaultAutoSuggestBoxStyle}" TargetType="AutoSuggestBox" />
 
@@ -147,10 +151,12 @@
 	<StaticResource x:Key="NavigationViewStyle" ResourceKey="SimpleNavigationViewStyle" />
 	<StaticResource x:Key="NavigationViewItemStyle" ResourceKey="SimpleNavigationViewItemStyle" />
 
-	<!-- CalendarView / CalendarDatePicker / DatePicker -->
+	<!-- CalendarView / CalendarDatePicker / DatePicker / TimePicker -->
 	<StaticResource x:Key="CalendarViewStyle" ResourceKey="SimpleCalendarViewStyle" />
 	<StaticResource x:Key="CalendarDatePickerStyle" ResourceKey="SimpleCalendarDatePickerStyle" />
 	<StaticResource x:Key="DatePickerStyle" ResourceKey="SimpleDatePickerStyle" />
+	<StaticResource x:Key="TimePickerStyle" ResourceKey="SimpleTimePickerStyle" />
+	<StaticResource x:Key="TimePickerFlyoutPresenterStyle" ResourceKey="SimpleTimePickerFlyoutPresenterStyle" />
 
 	<!-- ProgressBar / ProgressRing -->
 	<StaticResource x:Key="ProgressBarStyle" ResourceKey="SimpleProgressBarStyle" />

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/_Resources.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/_Resources.xaml
@@ -155,6 +155,7 @@
 	<StaticResource x:Key="CalendarViewStyle" ResourceKey="SimpleCalendarViewStyle" />
 	<StaticResource x:Key="CalendarDatePickerStyle" ResourceKey="SimpleCalendarDatePickerStyle" />
 	<StaticResource x:Key="DatePickerStyle" ResourceKey="SimpleDatePickerStyle" />
+	<StaticResource x:Key="DatePickerFlyoutPresenterStyle" ResourceKey="SimpleDatePickerFlyoutPresenterStyle" />
 	<StaticResource x:Key="TimePickerStyle" ResourceKey="SimpleTimePickerStyle" />
 	<StaticResource x:Key="TimePickerFlyoutPresenterStyle" ResourceKey="SimpleTimePickerFlyoutPresenterStyle" />
 

--- a/src/library/Uno.Themes.WinUI.Markup/Theme/TimePicker.cs
+++ b/src/library/Uno.Themes.WinUI.Markup/Theme/TimePicker.cs
@@ -1,0 +1,208 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using Uno.Extensions.Markup;
+using Uno.Extensions.Markup.Internals;
+
+namespace Uno.Themes.Markup;
+
+public static partial class Theme
+{
+	/// <summary>
+	/// C# Markup accessors for the <c>TimePicker*</c> lightweight-styling keys, mirroring
+	/// <see cref="DatePicker"/>.
+	///
+	/// <c>TimePicker</c> only reports the <c>Normal</c> / <c>Disabled</c> and <c>HasTime</c> /
+	/// <c>HasNoTime</c> visual states — it has no <c>PointerOver</c> or <c>Pressed</c> state of its
+	/// own — so the <c>PointerOver</c> / <c>Pressed</c> members present on <see cref="DatePicker"/>
+	/// are deliberately absent here rather than exposed as keys nothing resolves.
+	/// </summary>
+	public static partial class TimePicker
+	{
+		public static partial class Resources
+		{
+			public static class Default
+			{
+				public static partial class Button
+				{
+					public static partial class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "TimePickerButtonBackground")]
+						public static ThemeResourceKey<Brush> Default => new("TimePickerButtonBackground");
+
+						[ResourceKeyDefinition(typeof(Brush), "TimePickerButtonBackgroundDisabled")]
+						public static ThemeResourceKey<Brush> Disabled => new("TimePickerButtonBackgroundDisabled");
+					}
+
+					public static partial class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "TimePickerButtonBorderBrush")]
+						public static ThemeResourceKey<Brush> Default => new("TimePickerButtonBorderBrush");
+
+						[ResourceKeyDefinition(typeof(Brush), "TimePickerButtonBorderBrushDisabled")]
+						public static ThemeResourceKey<Brush> Disabled => new("TimePickerButtonBorderBrushDisabled");
+					}
+
+					public static partial class TimeTextForeground
+					{
+						[ResourceKeyDefinition(typeof(Brush), "TimePickerButtonTimeTextForeground")]
+						public static ThemeResourceKey<Brush> Default => new("TimePickerButtonTimeTextForeground");
+
+						[ResourceKeyDefinition(typeof(Brush), "TimePickerButtonTimeTextForegroundDisabled")]
+						public static ThemeResourceKey<Brush> Disabled => new("TimePickerButtonTimeTextForegroundDisabled");
+					}
+
+					[ResourceKeyDefinition(typeof(double), "TimePickerButtonContentHeight")]
+					public static ThemeResourceKey<double> ContentHeight => new("TimePickerButtonContentHeight");
+
+					[ResourceKeyDefinition(typeof(Thickness), "TimePickerButtonContentMargin")]
+					public static ThemeResourceKey<Thickness> ContentMargin => new("TimePickerButtonContentMargin");
+
+					[ResourceKeyDefinition(typeof(double), "TimePickerButtonBottomBorderHeight")]
+					public static ThemeResourceKey<double> BottomBorderHeight => new("TimePickerButtonBottomBorderHeight");
+
+					[ResourceKeyDefinition(typeof(Thickness), "TimePickerButtonPlaceholderMargin")]
+					public static ThemeResourceKey<Thickness> PlaceholderMargin => new("TimePickerButtonPlaceholderMargin");
+				}
+
+				public static partial class Header
+				{
+					[ResourceKeyDefinition(typeof(Brush), "TimePickerHeaderForeground")]
+					public static ThemeResourceKey<Brush> Foreground => new("TimePickerHeaderForeground");
+
+					[ResourceKeyDefinition(typeof(Brush), "TimePickerHeaderForegroundDisabled")]
+					public static ThemeResourceKey<Brush> ForegroundDisabled => new("TimePickerHeaderForegroundDisabled");
+
+					/// <summary>
+					/// How far the header shrinks once it floats above the value. The vertical movement
+					/// is layout-driven, so there is no companion offset key.
+					/// </summary>
+					[ResourceKeyDefinition(typeof(double), "TimePickerHeaderFloatScale")]
+					public static ThemeResourceKey<double> FloatScale => new("TimePickerHeaderFloatScale");
+				}
+
+				public static partial class ColumnDivider
+				{
+					[ResourceKeyDefinition(typeof(double), "TimePickerColumnDividerWidth")]
+					public static ThemeResourceKey<double> Width => new("TimePickerColumnDividerWidth");
+
+					[ResourceKeyDefinition(typeof(Thickness), "TimePickerColumnDividerMargin")]
+					public static ThemeResourceKey<Thickness> Margin => new("TimePickerColumnDividerMargin");
+				}
+
+				public static partial class SpacerFill
+				{
+					[ResourceKeyDefinition(typeof(Brush), "TimePickerSpacerFill")]
+					public static ThemeResourceKey<Brush> Default => new("TimePickerSpacerFill");
+
+					[ResourceKeyDefinition(typeof(Brush), "TimePickerSpacerFillDisabled")]
+					public static ThemeResourceKey<Brush> Disabled => new("TimePickerSpacerFillDisabled");
+				}
+
+				public static class Flyout
+				{
+					public static partial class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "TimePickerFlyoutPresenterBackground")]
+						public static ThemeResourceKey<Brush> Default => new("TimePickerFlyoutPresenterBackground");
+					}
+
+					public static partial class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "TimePickerFlyoutPresenterBorderBrush")]
+						public static ThemeResourceKey<Brush> Default => new("TimePickerFlyoutPresenterBorderBrush");
+					}
+
+					public static partial class SpacerFill
+					{
+						[ResourceKeyDefinition(typeof(Brush), "TimePickerFlyoutPresenterSpacerFill")]
+						public static ThemeResourceKey<Brush> Default => new("TimePickerFlyoutPresenterSpacerFill");
+					}
+
+					public static partial class HighlightFill
+					{
+						[ResourceKeyDefinition(typeof(Brush), "TimePickerFlyoutPresenterHighlightFill")]
+						public static ThemeResourceKey<Brush> Default => new("TimePickerFlyoutPresenterHighlightFill");
+					}
+
+					public static partial class Typography
+					{
+						[ResourceKeyDefinition(typeof(FontFamily), "TimePickerFlyoutPresenterFontFamily")]
+						public static ThemeResourceKey<FontFamily> FontFamily => new("TimePickerFlyoutPresenterFontFamily");
+
+						[ResourceKeyDefinition(typeof(double), "TimePickerFlyoutPresenterFontSize")]
+						public static ThemeResourceKey<double> FontSize => new("TimePickerFlyoutPresenterFontSize");
+					}
+
+					public static partial class Button
+					{
+						public static partial class Background
+						{
+							[ResourceKeyDefinition(typeof(Brush), "TimePickerFlyoutButtonBackground")]
+							public static ThemeResourceKey<Brush> Default => new("TimePickerFlyoutButtonBackground");
+						}
+
+						public static class Opacity
+						{
+							[ResourceKeyDefinition(typeof(double), "TimePickerFlyoutButtonOpacityPressed")]
+							public static ThemeResourceKey<double> Pressed => new("TimePickerFlyoutButtonOpacityPressed");
+
+							[ResourceKeyDefinition(typeof(double), "TimePickerFlyoutButtonOpacityDisabled")]
+							public static ThemeResourceKey<double> Disabled => new("TimePickerFlyoutButtonOpacityDisabled");
+						}
+
+						[ResourceKeyDefinition(typeof(Thickness), "TimePickerFlyoutButtonPadding")]
+						public static ThemeResourceKey<Thickness> Padding => new("TimePickerFlyoutButtonPadding");
+					}
+
+					[ResourceKeyDefinition(typeof(CornerRadius), "TimePickerFlyoutPresenterCornerRadius")]
+					public static ThemeResourceKey<CornerRadius> CornerRadius => new("TimePickerFlyoutPresenterCornerRadius");
+
+					[ResourceKeyDefinition(typeof(double), "TimePickerFlyoutBorderThickness")]
+					public static ThemeResourceKey<double> BorderThickness => new("TimePickerFlyoutBorderThickness");
+
+					[ResourceKeyDefinition(typeof(double), "TimePickerFlyoutElevation")]
+					public static ThemeResourceKey<double> Elevation => new("TimePickerFlyoutElevation");
+
+					[ResourceKeyDefinition(typeof(double), "TimePickerFlyoutPresenterWidth")]
+					public static ThemeResourceKey<double> Width => new("TimePickerFlyoutPresenterWidth");
+
+					[ResourceKeyDefinition(typeof(double), "TimePickerFlyoutPresenterMinWidth")]
+					public static ThemeResourceKey<double> MinWidth => new("TimePickerFlyoutPresenterMinWidth");
+
+					[ResourceKeyDefinition(typeof(double), "TimePickerFlyoutPresenterMaxWidth")]
+					public static ThemeResourceKey<double> MaxWidth => new("TimePickerFlyoutPresenterMaxWidth");
+
+					[ResourceKeyDefinition(typeof(double), "TimePickerFlyoutPresenterMaxHeight")]
+					public static ThemeResourceKey<double> MaxHeight => new("TimePickerFlyoutPresenterMaxHeight");
+
+					[ResourceKeyDefinition(typeof(double), "TimePickerFlyoutPresenterAcceptDismissHostGridHeight")]
+					public static ThemeResourceKey<double> AcceptDismissHostGridHeight => new("TimePickerFlyoutPresenterAcceptDismissHostGridHeight");
+
+					[ResourceKeyDefinition(typeof(double), "TimePickerFlyoutPresenterHighlightHeight")]
+					public static ThemeResourceKey<double> HighlightHeight => new("TimePickerFlyoutPresenterHighlightHeight");
+				}
+
+				[ResourceKeyDefinition(typeof(CornerRadius), "TimePickerCornerRadius")]
+				public static ThemeResourceKey<CornerRadius> CornerRadius => new("TimePickerCornerRadius");
+
+				[ResourceKeyDefinition(typeof(double), "TimePickerHeight")]
+				public static ThemeResourceKey<double> Height => new("TimePickerHeight");
+
+				public static partial class PlaceholderTextForeground
+				{
+					[ResourceKeyDefinition(typeof(Brush), "TimePickerPlaceholderTextForeground")]
+					public static ThemeResourceKey<Brush> Default => new("TimePickerPlaceholderTextForeground");
+				}
+			}
+		}
+
+		public static partial class Styles
+		{
+			[ResourceKeyDefinition(typeof(Style), "TimePickerStyle", TargetType = typeof(global::Microsoft.UI.Xaml.Controls.TimePicker))]
+			public static StaticResourceKey<Style> Default => new("TimePickerStyle");
+
+			[ResourceKeyDefinition(typeof(Style), "TimePickerFlyoutPresenterStyle", TargetType = typeof(global::Microsoft.UI.Xaml.Controls.TimePickerFlyoutPresenter))]
+			public static StaticResourceKey<Style> FlyoutPresenter => new("TimePickerFlyoutPresenterStyle");
+		}
+	}
+}

--- a/src/samples/MaterialSampleApp/RuntimeTests/Given_MaterialPickerStyles.cs
+++ b/src/samples/MaterialSampleApp/RuntimeTests/Given_MaterialPickerStyles.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
@@ -149,21 +150,74 @@ public class Given_MaterialPickerStyles
 		Assert.IsInstanceOfType(resource, typeof(Style), $"{styleKey} should be a Style");
 	}
 
+	/// <summary>
+	/// A <c>&lt;StaticResource&gt;</c> alias hands back an independent *copy* of the style it points at —
+	/// measured, and true of the long-shipped <c>DatePickerStyle</c> alias as well. So neither the
+	/// <see cref="Style"/> nor its <see cref="ControlTemplate"/> is reference-equal to the theme-specific
+	/// key's, and <c>Assert.AreSame</c> on either only tests Uno's resource-lookup internals.
+	///
+	/// The contract the docs actually publish ("Direct match" in <c>doc/semantic-styles.md</c>) is that
+	/// the semantic key styles the control the same way, so this compares what the two styles actually
+	/// set — every setter's property and value. An alias resolving to the wrong style, or missing
+	/// entirely (leaving the Fluent default in place), still fails.
+	///
+	/// Compared at the style level rather than by applying both to controls, as
+	/// <c>Given_SemanticStyles</c> does for the button aliases, because
+	/// <see cref="TimePickerFlyoutPresenter"/> has no public parameterless constructor and so cannot be
+	/// instantiated by a test.
+	/// </summary>
 	[TestMethod]
 	[RunsOnUIThread]
-	public void When_SemanticMaterialTimePickerKeys_Requested_ThenTheyAliasTheMaterialStyles()
+	[DataRow("TimePickerStyle", "MaterialTimePickerStyle")]
+	[DataRow("TimePickerFlyoutPresenterStyle", "MaterialTimePickerFlyoutPresenterStyle")]
+	public void When_SemanticMaterialTimePickerKeys_Requested_ThenTheyMatchTheMaterialStyles(
+		string semanticKey,
+		string materialKey)
 	{
 		var container = CreateThemedContainer();
 
-		Assert.AreSame(
-			container.Resources["MaterialTimePickerStyle"],
-			container.Resources["TimePickerStyle"],
-			"TimePickerStyle should alias MaterialTimePickerStyle");
-		Assert.AreSame(
-			container.Resources["MaterialTimePickerFlyoutPresenterStyle"],
-			container.Resources["TimePickerFlyoutPresenterStyle"],
-			"TimePickerFlyoutPresenterStyle should alias MaterialTimePickerFlyoutPresenterStyle");
+		AssertStylesMatch(
+			container.Resources[materialKey] as Style,
+			container.Resources[semanticKey] as Style,
+			$"{semanticKey} vs {materialKey}");
 	}
+
+	/// <summary>
+	/// Compares two styles by target type and by the values their setters carry, rather than by
+	/// reference. <c>Template</c> and <see cref="Style"/>-valued setters are skipped — those are the
+	/// copied object references, not observable styling.
+	/// </summary>
+	private static void AssertStylesMatch(Style? expected, Style? actual, string context)
+	{
+		Assert.IsNotNull(expected, $"{context}: the theme-specific key should resolve to a Style");
+		Assert.IsNotNull(actual, $"{context}: the semantic key should resolve to a Style");
+		Assert.AreEqual(expected!.TargetType, actual!.TargetType, $"{context}: TargetType should match");
+
+		var expectedSetters = DescribeSetters(expected);
+		var actualSetters = DescribeSetters(actual);
+
+		Assert.IsTrue(
+			expectedSetters.Count >= 5,
+			$"{context}: only {expectedSetters.Count} setters were comparable — the sweep is no longer meaningful");
+		CollectionAssert.AreEquivalent(
+			expectedSetters,
+			actualSetters,
+			$"{context}: the two styles should set the same properties to the same values");
+	}
+
+	/// <summary>
+	/// Renders a style's setters as <c>property=value</c> strings. Values are stringified rather than
+	/// compared by reference: brushes, <c>FontFamily</c> and friends have no cross-instance equality
+	/// guarantee, and the alias hands back copies of all of them.
+	/// </summary>
+	private static List<string> DescribeSetters(Style style) => style.Setters
+		.OfType<Setter>()
+		.Where(setter => setter.Property is not null && setter.Property != Control.TemplateProperty)
+		.Where(setter => setter.Value is not (Style or ControlTemplate))
+		.Select(setter => setter.Value is SolidColorBrush brush
+			? $"{setter.Property}={brush.Color}"
+			: $"{setter.Property}={setter.Value}")
+		.ToList();
 
 	[TestMethod]
 	[RunsOnUIThread]

--- a/src/samples/MaterialSampleApp/RuntimeTests/Given_MaterialPickerStyles.cs
+++ b/src/samples/MaterialSampleApp/RuntimeTests/Given_MaterialPickerStyles.cs
@@ -1,0 +1,478 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Material;
+using Uno.UI.RuntimeTests;
+
+namespace Uno.Themes.Samples.RuntimeTests;
+
+/// <summary>
+/// Guards the Material v2 <see cref="DatePicker"/> and <see cref="TimePicker"/> styles.
+///
+/// These templates previously had no runtime coverage at all: every picker test lived in
+/// SimpleSampleApp and merged <c>SimpleTheme</c>, so the Material half of the same change —
+/// the floating header, the culture-safe dividers and the whole <c>TimePicker*</c> key family —
+/// was verified only by "it builds". The defects those tests protect against reproduce
+/// identically in Material, hence this parallel suite.
+/// </summary>
+[TestClass]
+public class Given_MaterialPickerStyles
+{
+	/// <summary>
+	/// Parts the WinUI/Uno TimePicker itself looks up, taken from <c>TimePicker.partial.mux.cs</c>.
+	/// A template missing one of these still renders — it just silently loses culture ordering or
+	/// 24-hour support — so they are asserted explicitly rather than inferred from "it looked fine".
+	/// </summary>
+	private static readonly string[] TimePickerContractParts =
+	{
+		"LayoutRoot",
+		"FlyoutButton",
+		"FirstPickerHost",
+		"SecondPickerHost",
+		"ThirdPickerHost",
+		"HourTextBlock",
+		"MinuteTextBlock",
+		"PeriodTextBlock",
+		"FirstColumnDivider",
+		"SecondColumnDivider",
+	};
+
+	private static Grid CreateThemedContainer(ElementTheme theme = ElementTheme.Default)
+	{
+		var container = new Grid { RequestedTheme = theme };
+		container.Resources.MergedDictionaries.Add(new MaterialTheme());
+		return container;
+	}
+
+	private static FrameworkElement? FindDescendantByName(DependencyObject root, string name)
+	{
+		var count = VisualTreeHelper.GetChildrenCount(root);
+		for (var i = 0; i < count; i++)
+		{
+			var child = VisualTreeHelper.GetChild(root, i);
+			if (child is FrameworkElement fe && fe.Name == name)
+			{
+				return fe;
+			}
+
+			if (FindDescendantByName(child, name) is { } match)
+			{
+				return match;
+			}
+		}
+
+		return null;
+	}
+
+	/// <summary>
+	/// Loads one <see cref="Border"/> per key, each bound to that key through <c>ThemeResource</c>,
+	/// then reads the brushes back once per theme.
+	///
+	/// Two traps make the obvious version of this useless. The <see cref="ResourceDictionary"/>
+	/// indexer resolves ThemeDictionaries against the *application* theme, so
+	/// <c>container.Resources[key]</c> returns the same brush whatever theme is asked for; and theme
+	/// brushes only re-materialize when the <b>XamlRoot content's</b> theme changes — setting
+	/// <see cref="FrameworkElement.RequestedTheme"/> on the container subtree is not enough (the same
+	/// approach <c>Given_DefaultPalette</c> uses).
+	/// </summary>
+	private static async Task<(SolidColorBrush? First, SolidColorBrush? Second)> ResolveThemeBrushPairAsync(
+		ElementTheme theme,
+		string firstKey,
+		string secondKey)
+	{
+		var container = CreateThemedContainer();
+		var probes = (Panel)XamlReader.Load(
+			$$"""
+			<StackPanel xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+				<Border Width="8" Height="8" Background="{ThemeResource {{firstKey}}}" />
+				<Border Width="8" Height="8" Background="{ThemeResource {{secondKey}}}" />
+			</StackPanel>
+			""");
+
+		container.Children.Add(probes);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(container);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var root = container.XamlRoot?.Content as FrameworkElement;
+		Assert.IsNotNull(root, "The loaded container should expose the XamlRoot content");
+
+		var initialTheme = root!.RequestedTheme;
+		try
+		{
+			root.RequestedTheme = theme;
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			var first = ((Border)probes.Children[0]).Background as SolidColorBrush;
+			var second = ((Border)probes.Children[1]).Background as SolidColorBrush;
+
+			Assert.IsNotNull(first, $"{firstKey} should resolve to a SolidColorBrush under {theme}");
+			Assert.IsNotNull(second, $"{secondKey} should resolve to a SolidColorBrush under {theme}");
+
+			return (first, second);
+		}
+		finally
+		{
+			root.RequestedTheme = initialTheme;
+			await UnitTestsUIContentHelper.WaitForIdle();
+		}
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Style keys resolve.
+	// ─────────────────────────────────────────────────────────────────────
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow("MaterialTimePickerStyle")]
+	[DataRow("MaterialDefaultTimePickerStyle")]
+	[DataRow("MaterialTimePickerFlyoutButtonStyle")]
+	[DataRow("MaterialTimePickerFlyoutPresenterStyle")]
+	[DataRow("MaterialDefaultTimePickerFlyoutPresenterStyle")]
+	[DataRow("MaterialDatePickerStyle")]
+	[DataRow("MaterialDatePickerFlyoutPresenterStyle")]
+	public void When_MaterialPickerStyleKey_Requested_ThenItResolves(string styleKey)
+	{
+		var container = CreateThemedContainer();
+
+		Assert.IsTrue(
+			container.Resources.TryGetValue(styleKey, out var resource),
+			$"{styleKey} should be available from MaterialTheme");
+		Assert.IsInstanceOfType(resource, typeof(Style), $"{styleKey} should be a Style");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_SemanticMaterialTimePickerKeys_Requested_ThenTheyAliasTheMaterialStyles()
+	{
+		var container = CreateThemedContainer();
+
+		Assert.AreSame(
+			container.Resources["MaterialTimePickerStyle"],
+			container.Resources["TimePickerStyle"],
+			"TimePickerStyle should alias MaterialTimePickerStyle");
+		Assert.AreSame(
+			container.Resources["MaterialTimePickerFlyoutPresenterStyle"],
+			container.Resources["TimePickerFlyoutPresenterStyle"],
+			"TimePickerFlyoutPresenterStyle should alias MaterialTimePickerFlyoutPresenterStyle");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_MaterialTimePickerLightweightKeys_Requested_ThenTheyResolve()
+	{
+		var container = CreateThemedContainer();
+
+		var keys = new[]
+		{
+			"TimePickerButtonBackground",
+			"TimePickerButtonBackgroundDisabled",
+			"TimePickerButtonBorderBrush",
+			"TimePickerButtonBorderBrushDisabled",
+			"TimePickerButtonTimeTextForeground",
+			"TimePickerButtonTimeTextForegroundDisabled",
+			"TimePickerHeaderForeground",
+			"TimePickerHeaderForegroundDisabled",
+			"TimePickerPlaceholderTextForeground",
+			"TimePickerSpacerFill",
+			"TimePickerSpacerFillDisabled",
+			"TimePickerFlyoutPresenterBackground",
+			"TimePickerFlyoutPresenterBorderBrush",
+			"TimePickerFlyoutPresenterSpacerFill",
+			"TimePickerFlyoutPresenterHighlightFill",
+			"TimePickerFlyoutPresenterCornerRadius",
+			"TimePickerCornerRadius",
+			"TimePickerHeight",
+			"TimePickerColumnDividerWidth",
+			"TimePickerColumnDividerMargin",
+			"TimePickerButtonPlaceholderMargin",
+			"TimePickerButtonContentMargin",
+			"TimePickerHeaderFloatScale",
+		};
+
+		var missing = keys
+			.Where(key => !container.Resources.TryGetValue(key, out var value) || value is null)
+			.ToList();
+
+		CollectionAssert.AreEqual(
+			Array.Empty<string>(),
+			missing,
+			$"These Material TimePicker lightweight keys did not resolve: {string.Join(", ", missing)}");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow("TimePicker")]
+	[DataRow("DatePicker")]
+	public void When_HeaderFloatScale_Requested_ThenItResolvesOutsideThemeDictionaries(string control)
+	{
+		// The float scale is read by a Storyboard's To=, which resolves through StaticResource.
+		// StaticResource does not re-resolve per ThemeDictionary, so a key defined only inside
+		// ThemeDictionaries is documented as tunable but is not reliably overridable. Keeping it at
+		// dictionary scope is what makes the documented lightweight-styling key actually work.
+		var container = CreateThemedContainer();
+
+		Assert.IsTrue(
+			container.Resources.TryGetValue($"{control}HeaderFloatScale", out var value),
+			$"{control}HeaderFloatScale should resolve");
+		Assert.IsInstanceOfType(value, typeof(double), $"{control}HeaderFloatScale should be a Double");
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Template-part contract and culture safety.
+	// ─────────────────────────────────────────────────────────────────────
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(ElementTheme.Light)]
+	[DataRow(ElementTheme.Dark)]
+	public async Task When_MaterialTimePickerStyle_Applied_ThenRequiredTemplatePartsArePresent(ElementTheme theme)
+	{
+		var container = CreateThemedContainer(theme);
+		var picker = new TimePicker
+		{
+			Header = "Pick a time",
+			Style = container.Resources["MaterialTimePickerStyle"] as Style,
+		};
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var missing = TimePickerContractParts
+			.Where(part => FindDescendantByName(picker, part) is null)
+			.ToList();
+
+		CollectionAssert.AreEqual(
+			Array.Empty<string>(),
+			missing,
+			$"MaterialTimePickerStyle is missing these named template parts under {theme}: {string.Join(", ", missing)}");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_TimeIsSelected_ThenTheDividersCarryNoOrderDependentText()
+	{
+		// UpdateOrderAndLayout reparents the hour/minute/period TextBlocks between the picker hosts
+		// to reorder per culture, but it only toggles the *visibility* of the dividers — it never
+		// moves them. A literal ":" in FirstColumnDivider is therefore correct only while the hour
+		// comes first; in a period-first culture (ko-KR / zh-CN / ja-JP) it lands between the period
+		// and the hour. Neutral rules carry no ordering assumption, so "not a TextBlock" is the
+		// invariant worth pinning — and it is deterministic, unlike swapping the ambient culture.
+		var container = CreateThemedContainer();
+		var picker = new TimePicker
+		{
+			SelectedTime = new TimeSpan(9, 41, 0),
+			Style = container.Resources["MaterialTimePickerStyle"] as Style,
+		};
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		foreach (var dividerName in new[] { "FirstColumnDivider", "SecondColumnDivider" })
+		{
+			var divider = FindDescendantByName(picker, dividerName);
+			Assert.IsNotNull(divider, $"{dividerName} should be part of the template");
+			Assert.IsNotInstanceOfType(
+				divider,
+				typeof(TextBlock),
+				$"{dividerName} must not be a TextBlock: the control never repositions the dividers, "
+					+ "so any glyph in one is wrong as soon as the culture reorders the columns");
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_ClockIdentifierIs24Hour_ThenPeriodDividerCollapses()
+	{
+		var container = CreateThemedContainer();
+		var picker = new TimePicker
+		{
+			ClockIdentifier = "24HourClock",
+			Style = container.Resources["MaterialTimePickerStyle"] as Style,
+		};
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var secondDivider = FindDescendantByName(picker, "SecondColumnDivider");
+		Assert.IsNotNull(secondDivider, "SecondColumnDivider should be part of the template");
+		Assert.AreEqual(
+			Visibility.Collapsed,
+			secondDivider!.Visibility,
+			"With a 24-hour clock there is no AM/PM column, so the second divider must collapse");
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Header placement — the floating label.
+	// ─────────────────────────────────────────────────────────────────────
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(typeof(TimePicker), "MaterialTimePickerStyle")]
+	[DataRow(typeof(DatePicker), "MaterialDatePickerStyle")]
+	public async Task When_HeaderIsSet_ThenItRendersOnce(Type pickerType, string styleKey)
+	{
+		// The header used to render twice — once as a label above the field and again as the
+		// header-bound placeholder inside it.
+		const string header = "Departure";
+
+		var container = CreateThemedContainer();
+		var picker = CreatePicker(pickerType, styleKey, container, header);
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		Assert.AreEqual(
+			1,
+			CountVisibleTextBlocksWithText(picker, header),
+			$"{styleKey} should render '{header}' exactly once");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(typeof(TimePicker), "MaterialTimePickerStyle")]
+	[DataRow(typeof(DatePicker), "MaterialDatePickerStyle")]
+	public async Task When_NoHeaderIsSet_ThenTheValueIsVerticallyCentred(Type pickerType, string styleKey)
+	{
+		// A bare <TimePicker /> is the default usage. The header and value sit in two Auto rows so
+		// that, with no header, row 0 collapses and the value centres. When the value instead
+		// carried a fixed top inset sized for a header, a header-less field rendered its value
+		// against the bottom edge.
+		var container = CreateThemedContainer();
+		var picker = CreatePicker(pickerType, styleKey, container);
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var header = FindDescendantByName(picker, "HeaderTextBlock");
+		Assert.IsNotNull(header, "HeaderTextBlock should be part of the template");
+		Assert.AreEqual(
+			Visibility.Collapsed,
+			header!.Visibility,
+			"With no Header there is nothing to render, so the header row must collapse");
+
+		var content = FindDescendantByName(picker, "FlyoutButtonContentGrid");
+		Assert.IsNotNull(content, "FlyoutButtonContentGrid should be part of the template");
+
+		var offset = content!.TransformToVisual(picker).TransformPoint(default).Y;
+		var slack = picker.ActualHeight - content.ActualHeight;
+		Assert.IsTrue(
+			Math.Abs(offset - (slack / 2)) <= 2,
+			$"With no Header the value should sit centred (expected ~{slack / 2:0.#}px from the top, "
+				+ $"measured {offset:0.#}px of a {picker.ActualHeight:0.#}px field)");
+	}
+
+	private static FrameworkElement CreatePicker(Type pickerType, string styleKey, Grid container, string? header = null)
+	{
+		var picker = (FrameworkElement)Activator.CreateInstance(pickerType)!;
+		switch (picker)
+		{
+			case TimePicker timePicker:
+				timePicker.Header = header;
+				break;
+			case DatePicker datePicker:
+				datePicker.Header = header;
+				break;
+			default:
+				throw new ArgumentOutOfRangeException(nameof(pickerType), pickerType, "Unsupported picker type");
+		}
+
+		picker.Style = container.Resources[styleKey] as Style;
+		return picker;
+	}
+
+	private static int CountVisibleTextBlocksWithText(DependencyObject root, string text)
+	{
+		var count = 0;
+		var children = VisualTreeHelper.GetChildrenCount(root);
+		for (var i = 0; i < children; i++)
+		{
+			var child = VisualTreeHelper.GetChild(root, i);
+			if (child is TextBlock { Visibility: Visibility.Visible } textBlock && textBlock.Text == text)
+			{
+				count++;
+			}
+
+			if (child is not FrameworkElement { Visibility: Visibility.Collapsed })
+			{
+				count += CountVisibleTextBlocksWithText(child, text);
+			}
+		}
+
+		return count;
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Selection-band contrast, resolved per theme.
+	// ─────────────────────────────────────────────────────────────────────
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(ElementTheme.Light)]
+	[DataRow(ElementTheme.Dark)]
+	public async Task When_FlyoutPresenterHighlight_Resolved_ThenItContrastsWithTheFlyoutBackground(ElementTheme theme)
+	{
+		// The selection band paints directly on the flyout background; when the two resolve to the
+		// same color the selected row is invisible. Resolving through a themed element is what makes
+		// the Dark row meaningful — the ResourceDictionary indexer would return the ambient theme's
+		// brush for both rows.
+		var (highlight, background) = await ResolveThemeBrushPairAsync(
+			theme,
+			"TimePickerFlyoutPresenterHighlightFill",
+			"TimePickerFlyoutPresenterBackground");
+
+		Assert.AreNotEqual(
+			background!.Color,
+			highlight!.Color,
+			$"The TimePicker selection band must be distinguishable from the flyout background under {theme}");
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Lightweight-styling override precedence.
+	// ─────────────────────────────────────────────────────────────────────
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_TimePickerButtonBackgroundOverridden_ThenFieldReflectsChange()
+	{
+		var expected = Microsoft.UI.Colors.DarkOrchid;
+
+		var container = CreateThemedContainer();
+		container.Resources["TimePickerButtonBackground"] = new SolidColorBrush(expected);
+
+		var picker = new TimePicker
+		{
+			Style = container.Resources["MaterialTimePickerStyle"] as Style,
+		};
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var background = picker.Background as SolidColorBrush;
+		Assert.IsNotNull(background, "TimePicker should have a Background brush from the style");
+		Assert.AreEqual(
+			expected,
+			background!.Color,
+			"Overriding TimePickerButtonBackground should change the Material TimePicker field background");
+	}
+}

--- a/src/samples/SamplesApp.Shared/Content/Controls/TimePickerSamplePage.xaml
+++ b/src/samples/SamplesApp.Shared/Content/Controls/TimePickerSamplePage.xaml
@@ -8,7 +8,8 @@
 	  xmlns:ios="http://uno.ui/ios"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:smtx="using:ShowMeTheXAML"
-	  mc:Ignorable="d android ios">
+	  xmlns:xamarin="http://uno.ui/xamarin"
+	  mc:Ignorable="d android ios xamarin">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<sample:SamplePageLayout>
@@ -46,12 +47,97 @@
 					</StackPanel>
 				</DataTemplate>
 			</sample:SamplePageLayout.MaterialTemplate>
-			<sample:SamplePageLayout.CupertinoTemplate>
+			<sample:SamplePageLayout.M3MaterialTemplate>
 				<DataTemplate>
 					<StackPanel>
+
+						<!-- Default -->
+						<TextBlock Text="Default"
+								   Style="{StaticResource TitleSmall}"
+								   Margin="12,16,12,4" />
+
+						<smtx:XamlDisplay UniqueKey="M3_TimePickerSamplePage_Default"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+
+							<TimePicker Header="Select a Time"
+										xamarin:UseNativeStyle="False"
+										Style="{StaticResource MaterialTimePickerStyle}" />
+						</smtx:XamlDisplay>
+
+						<!-- 24-hour clock -->
+						<TextBlock Text="24-hour clock"
+								   Style="{StaticResource TitleSmall}"
+								   Margin="12,8,12,4" />
+
+						<smtx:XamlDisplay UniqueKey="M3_TimePickerSamplePage_24Hour"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+
+							<TimePicker Header="Select a Time"
+										xamarin:UseNativeStyle="False"
+										ClockIdentifier="24HourClock"
+										Style="{StaticResource MaterialTimePickerStyle}" />
+						</smtx:XamlDisplay>
+
+						<!-- Disabled -->
+						<TextBlock Text="Disabled"
+								   Style="{StaticResource TitleSmall}"
+								   Margin="12,8,12,4" />
+
+						<smtx:XamlDisplay UniqueKey="M3_TimePickerSamplePage_Disabled"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+
+							<TimePicker Header="Select a Time"
+										xamarin:UseNativeStyle="False"
+										IsEnabled="False"
+										Style="{StaticResource MaterialTimePickerStyle}" />
+						</smtx:XamlDisplay>
 					</StackPanel>
 				</DataTemplate>
+			</sample:SamplePageLayout.M3MaterialTemplate>
+			<sample:SamplePageLayout.CupertinoTemplate>
+				<DataTemplate>
+					<StackPanel />
+				</DataTemplate>
 			</sample:SamplePageLayout.CupertinoTemplate>
+			<sample:SamplePageLayout.SimpleTemplate>
+				<DataTemplate>
+					<StackPanel>
+
+						<!-- Basic TimePicker -->
+						<smtx:XamlDisplay UniqueKey="Simple_TimePicker_Basic"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TimePicker />
+						</smtx:XamlDisplay>
+
+						<!-- With Header -->
+						<smtx:XamlDisplay UniqueKey="Simple_TimePicker_WithHeader"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TimePicker Header="Start Time" />
+						</smtx:XamlDisplay>
+
+						<!-- 24-hour clock -->
+						<smtx:XamlDisplay UniqueKey="Simple_TimePicker_24Hour"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TimePicker Header="Start Time"
+										ClockIdentifier="24HourClock" />
+						</smtx:XamlDisplay>
+
+						<!-- Minute increment -->
+						<smtx:XamlDisplay UniqueKey="Simple_TimePicker_MinuteIncrement"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TimePicker Header="Every 15 minutes"
+										MinuteIncrement="15" />
+						</smtx:XamlDisplay>
+
+						<!-- Disabled -->
+						<smtx:XamlDisplay UniqueKey="Simple_TimePicker_Disabled"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<TimePicker Header="Disabled"
+										IsEnabled="False" />
+						</smtx:XamlDisplay>
+					</StackPanel>
+				</DataTemplate>
+			</sample:SamplePageLayout.SimpleTemplate>
 		</sample:SamplePageLayout>
 	</Grid>
 </Page>

--- a/src/samples/SamplesApp.Shared/Content/Controls/TimePickerSamplePage.xaml.cs
+++ b/src/samples/SamplesApp.Shared/Content/Controls/TimePickerSamplePage.xaml.cs
@@ -1,7 +1,7 @@
 ﻿namespace Uno.Themes.Samples.Content.Controls;
 
 #if !__WASM__ && !__MACOS__
-[SamplePage(SampleCategory.Controls, "TimePicker", Description = "This control allows users to pick a time value.", DocumentationLink = "https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.timepicker", SupportedDesigns = new[] { Design.Material, Design.Cupertino })]
+[SamplePage(SampleCategory.Controls, "TimePicker", Description = "This control allows users to pick a time value.", DocumentationLink = "https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.timepicker", SupportedDesigns = new[] { Design.Material, Design.Cupertino, Design.Simple })]
 #endif
 public sealed partial class TimePickerSamplePage : Page
 {

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_PickerFieldLayout.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_PickerFieldLayout.cs
@@ -30,25 +30,40 @@ public class Given_PickerFieldLayout
 		return container;
 	}
 
-	private static FrameworkElement CreatePicker(string styleKey, Grid container, string? header = null)
+	/// <summary>
+	/// Builds the picker named by <paramref name="pickerType"/>. The type is passed explicitly
+	/// rather than sniffed out of the style key — a key that merely happens to contain "Time"
+	/// would silently produce the wrong control and still pass.
+	/// </summary>
+	private static FrameworkElement CreatePicker(Type pickerType, string styleKey, Grid container, string? header = null)
 	{
-		FrameworkElement picker = styleKey.Contains("Time")
-			? new TimePicker { Header = header }
-			: new DatePicker { Header = header };
+		var picker = (FrameworkElement)Activator.CreateInstance(pickerType)!;
+		switch (picker)
+		{
+			case TimePicker timePicker:
+				timePicker.Header = header;
+				break;
+			case DatePicker datePicker:
+				datePicker.Header = header;
+				break;
+			default:
+				throw new ArgumentOutOfRangeException(nameof(pickerType), pickerType, "Unsupported picker type");
+		}
+
 		picker.Style = container.Resources[styleKey] as Style;
 		return picker;
 	}
 
 	[TestMethod]
 	[RunsOnUIThread]
-	[DataRow("SimpleTimePickerStyle", "TimePickerFlyoutPresenterMinWidth")]
-	[DataRow("SimpleDatePickerStyle", "DatePickerFlyoutPresenterMinWidth")]
-	public async Task When_PlacedInAWideContainer_ThenTheFieldSizesToContent(string styleKey, string minWidthKey)
+	[DataRow(typeof(TimePicker), "SimpleTimePickerStyle", "TimePickerFlyoutPresenterMinWidth")]
+	[DataRow(typeof(DatePicker), "SimpleDatePickerStyle", "DatePickerFlyoutPresenterMinWidth")]
+	public async Task When_PlacedInAWideContainer_ThenTheFieldSizesToContent(Type pickerType, string styleKey, string minWidthKey)
 	{
 		var container = CreateThemedContainer();
 		container.Width = 900;
 
-		var picker = CreatePicker(styleKey, container);
+		var picker = CreatePicker(pickerType, styleKey, container);
 		container.Children.Add(picker);
 
 		UnitTestsUIContentHelper.Content = container;
@@ -67,16 +82,16 @@ public class Given_PickerFieldLayout
 
 	[TestMethod]
 	[RunsOnUIThread]
-	[DataRow("SimpleTimePickerStyle")]
-	[DataRow("SimpleDatePickerStyle")]
-	public async Task When_HeaderIsSet_ThenItRendersOnce(string styleKey)
+	[DataRow(typeof(TimePicker), "SimpleTimePickerStyle")]
+	[DataRow(typeof(DatePicker), "SimpleDatePickerStyle")]
+	public async Task When_HeaderIsSet_ThenItRendersOnce(Type pickerType, string styleKey)
 	{
 		// The header used to render twice — as a label above the field and again as the
 		// header-bound placeholder inside it.
 		const string header = "Date of Birth";
 
 		var container = CreateThemedContainer();
-		var picker = CreatePicker(styleKey, container, header);
+		var picker = CreatePicker(pickerType, styleKey, container, header);
 		container.Children.Add(picker);
 
 		UnitTestsUIContentHelper.Content = container;

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_PickerFieldLayout.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_PickerFieldLayout.cs
@@ -1,0 +1,112 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Simple;
+using Uno.UI.RuntimeTests;
+
+namespace Uno.Themes.Samples.RuntimeTests;
+
+/// <summary>
+/// Field-layout rules the Simple <see cref="DatePicker"/> and <see cref="TimePicker"/> share:
+/// the field sizes to its content, and the <c>Header</c> renders once, as the in-field placeholder.
+///
+/// Sizing is not only cosmetic: <c>TimePickerFlyout</c> / <c>DatePickerFlyout</c> assign
+/// <c>presenter.Width = target.ActualWidth</c> when opening, so a field that stretches to its
+/// container produces a flyout stretched to the same width — the picker columns then spread across
+/// the whole window instead of reading as a compact picker.
+/// </summary>
+[TestClass]
+public class Given_PickerFieldLayout
+{
+	private static Grid CreateThemedContainer()
+	{
+		var container = new Grid();
+		container.Resources.MergedDictionaries.Add(new SimpleTheme());
+		return container;
+	}
+
+	private static FrameworkElement CreatePicker(string styleKey, Grid container, string? header = null)
+	{
+		FrameworkElement picker = styleKey.Contains("Time")
+			? new TimePicker { Header = header }
+			: new DatePicker { Header = header };
+		picker.Style = container.Resources[styleKey] as Style;
+		return picker;
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow("SimpleTimePickerStyle", "TimePickerFlyoutPresenterMinWidth")]
+	[DataRow("SimpleDatePickerStyle", "DatePickerFlyoutPresenterMinWidth")]
+	public async Task When_PlacedInAWideContainer_ThenTheFieldSizesToContent(string styleKey, string minWidthKey)
+	{
+		var container = CreateThemedContainer();
+		container.Width = 900;
+
+		var picker = CreatePicker(styleKey, container);
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		Assert.IsTrue(
+			picker.ActualWidth < container.ActualWidth,
+			$"{styleKey} should size to content, but it filled {picker.ActualWidth} of {container.ActualWidth}px");
+
+		var minWidth = (double)container.Resources[minWidthKey];
+		Assert.IsTrue(
+			picker.ActualWidth >= minWidth,
+			$"{styleKey} should keep its {minWidth}px floor from {minWidthKey}, but measured {picker.ActualWidth}px");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow("SimpleTimePickerStyle")]
+	[DataRow("SimpleDatePickerStyle")]
+	public async Task When_HeaderIsSet_ThenItRendersOnce(string styleKey)
+	{
+		// The header used to render twice — as a label above the field and again as the
+		// header-bound placeholder inside it.
+		const string header = "Date of Birth";
+
+		var container = CreateThemedContainer();
+		var picker = CreatePicker(styleKey, container, header);
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		Assert.AreEqual(
+			1,
+			CountVisibleTextBlocksWithText(picker, header),
+			$"{styleKey} should render '{header}' exactly once, as the placeholder");
+	}
+
+	private static int CountVisibleTextBlocksWithText(DependencyObject root, string text)
+	{
+		var count = 0;
+		var children = VisualTreeHelper.GetChildrenCount(root);
+		for (var i = 0; i < children; i++)
+		{
+			var child = VisualTreeHelper.GetChild(root, i);
+			if (child is TextBlock { Visibility: Visibility.Visible } textBlock && textBlock.Text == text)
+			{
+				count++;
+			}
+
+			if (child is not FrameworkElement { Visibility: Visibility.Collapsed })
+			{
+				count += CountVisibleTextBlocksWithText(child, text);
+			}
+		}
+
+		return count;
+	}
+}

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_TimePickerStyles.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_TimePickerStyles.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
@@ -171,23 +172,77 @@ public class Given_TimePickerStyles
 		Assert.IsInstanceOfType(resource, typeof(Style), $"{styleKey} should be a Style");
 	}
 
+	/// <summary>
+	/// A <c>&lt;StaticResource&gt;</c> alias hands back an independent *copy* of the style it points at —
+	/// measured, and true of the long-shipped <c>DatePickerStyle</c> alias as well. So neither the
+	/// <see cref="Style"/> nor its <see cref="ControlTemplate"/> is reference-equal to the theme-specific
+	/// key's, and <c>Assert.AreSame</c> on either only tests Uno's resource-lookup internals.
+	///
+	/// The contract the docs actually publish ("Direct match" in <c>doc/semantic-styles.md</c>) is that
+	/// the semantic key styles the control the same way, so this compares what the two styles actually
+	/// set — every setter's property and value. An alias resolving to the wrong style, or missing
+	/// entirely (leaving the Fluent default in place), still fails.
+	///
+	/// Compared at the style level rather than by applying both to controls, as
+	/// <c>Given_SemanticStyles</c> does for the button aliases, because
+	/// <see cref="TimePickerFlyoutPresenter"/> has no public parameterless constructor and so cannot be
+	/// instantiated by a test.
+	/// </summary>
 	[TestMethod]
 	[RunsOnUIThread]
-	[DataRow(ElementTheme.Light)]
-	[DataRow(ElementTheme.Dark)]
-	public void When_SemanticTimePickerKeys_Requested_ThenTheyAliasTheSimpleStyles(ElementTheme theme)
+	[DataRow(ElementTheme.Light, "TimePickerStyle", "SimpleTimePickerStyle")]
+	[DataRow(ElementTheme.Dark, "TimePickerStyle", "SimpleTimePickerStyle")]
+	[DataRow(ElementTheme.Light, "TimePickerFlyoutPresenterStyle", "SimpleTimePickerFlyoutPresenterStyle")]
+	[DataRow(ElementTheme.Dark, "TimePickerFlyoutPresenterStyle", "SimpleTimePickerFlyoutPresenterStyle")]
+	public void When_SemanticTimePickerKeys_Requested_ThenTheyMatchTheSimpleStyles(
+		ElementTheme theme,
+		string semanticKey,
+		string simpleKey)
 	{
 		var container = CreateThemedContainer(theme);
 
-		Assert.AreSame(
-			container.Resources["SimpleTimePickerStyle"],
-			container.Resources["TimePickerStyle"],
-			$"TimePickerStyle should alias SimpleTimePickerStyle under {theme}");
-		Assert.AreSame(
-			container.Resources["SimpleTimePickerFlyoutPresenterStyle"],
-			container.Resources["TimePickerFlyoutPresenterStyle"],
-			$"TimePickerFlyoutPresenterStyle should alias SimpleTimePickerFlyoutPresenterStyle under {theme}");
+		AssertStylesMatch(
+			container.Resources[simpleKey] as Style,
+			container.Resources[semanticKey] as Style,
+			$"{semanticKey} vs {simpleKey} under {theme}");
 	}
+
+	/// <summary>
+	/// Compares two styles by target type and by the values their setters carry, rather than by
+	/// reference. <c>Template</c> and <see cref="Style"/>-valued setters are skipped — those are the
+	/// copied object references, not observable styling.
+	/// </summary>
+	private static void AssertStylesMatch(Style? expected, Style? actual, string context)
+	{
+		Assert.IsNotNull(expected, $"{context}: the theme-specific key should resolve to a Style");
+		Assert.IsNotNull(actual, $"{context}: the semantic key should resolve to a Style");
+		Assert.AreEqual(expected!.TargetType, actual!.TargetType, $"{context}: TargetType should match");
+
+		var expectedSetters = DescribeSetters(expected);
+		var actualSetters = DescribeSetters(actual);
+
+		Assert.IsTrue(
+			expectedSetters.Count >= 5,
+			$"{context}: only {expectedSetters.Count} setters were comparable — the sweep is no longer meaningful");
+		CollectionAssert.AreEquivalent(
+			expectedSetters,
+			actualSetters,
+			$"{context}: the two styles should set the same properties to the same values");
+	}
+
+	/// <summary>
+	/// Renders a style's setters as <c>property=value</c> strings. Values are stringified rather than
+	/// compared by reference: brushes, <c>FontFamily</c> and friends have no cross-instance equality
+	/// guarantee, and the alias hands back copies of all of them.
+	/// </summary>
+	private static List<string> DescribeSetters(Style style) => style.Setters
+		.OfType<Setter>()
+		.Where(setter => setter.Property is not null && setter.Property != Control.TemplateProperty)
+		.Where(setter => setter.Value is not (Style or ControlTemplate))
+		.Select(setter => setter.Value is SolidColorBrush brush
+			? $"{setter.Property}={brush.Color}"
+			: $"{setter.Property}={setter.Value}")
+		.ToList();
 
 	// ─────────────────────────────────────────────────────────────────────
 	// Lightweight styling keys resolve, in Light and Dark.

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_TimePickerStyles.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_TimePickerStyles.cs
@@ -1,9 +1,10 @@
 #nullable enable
 
-using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Simple;
@@ -27,13 +28,21 @@ namespace Uno.Themes.Samples.RuntimeTests;
 [TestClass]
 public class Given_TimePickerStyles
 {
-	/// <summary>Named parts the WinUI/Uno TimePicker looks up in its template.</summary>
-	private static readonly string[] RequiredTimePickerParts =
+	/// <summary>
+	/// Parts the WinUI/Uno TimePicker itself looks up, taken from <c>TimePicker.partial.mux.cs</c>.
+	/// Dropping one of these does not fail the build or throw — the control just silently loses
+	/// culture ordering or 24-hour support — so they are asserted explicitly.
+	///
+	/// <c>First|Second|ThirdTextBlockColumn</c> belong to the same contract but are not listed here:
+	/// a <c>ColumnDefinition</c> is not a visual-tree child, so it cannot be found by walking
+	/// <see cref="VisualTreeHelper"/>. <see cref="When_TemplateApplied_ThenTheControlDrivesTheColumnWidths"/>
+	/// covers them, and does it better — the control could only have assigned those widths if it
+	/// resolved the names.
+	/// </summary>
+	private static readonly string[] ControlContractParts =
 	{
 		"LayoutRoot",
-		"PlaceholderText",
 		"FlyoutButton",
-		"FlyoutButtonContentGrid",
 		"FirstPickerHost",
 		"SecondPickerHost",
 		"ThirdPickerHost",
@@ -44,11 +53,76 @@ public class Given_TimePickerStyles
 		"SecondColumnDivider",
 	};
 
+	/// <summary>
+	/// Names this template owns. They are not part of the control contract, so a future retemplate
+	/// may rename them — they are asserted only because the tests below address them.
+	/// </summary>
+	private static readonly string[] TemplateOwnedParts =
+	{
+		"PlaceholderText",
+		"FlyoutButtonContentGrid",
+	};
+
 	private static Grid CreateThemedContainer(ElementTheme theme = ElementTheme.Default)
 	{
 		var container = new Grid { RequestedTheme = theme };
 		container.Resources.MergedDictionaries.Add(new SimpleTheme());
 		return container;
+	}
+
+	/// <summary>
+	/// Loads one <see cref="Border"/> per key, each bound to that key through <c>ThemeResource</c>,
+	/// then reads the brushes back once per theme.
+	///
+	/// Two traps make the obvious version of this useless. The <see cref="ResourceDictionary"/>
+	/// indexer resolves ThemeDictionaries against the *application* theme, so
+	/// <c>container.Resources[key]</c> returns the same brush whatever theme is asked for; and theme
+	/// brushes only re-materialize when the <b>XamlRoot content's</b> theme changes — setting
+	/// <see cref="FrameworkElement.RequestedTheme"/> on the container subtree is not enough (the same
+	/// approach <c>Given_DefaultPalette</c> uses in MaterialSampleApp).
+	/// </summary>
+	private static async Task<(SolidColorBrush? First, SolidColorBrush? Second)> ResolveThemeBrushPairAsync(
+		ElementTheme theme,
+		string firstKey,
+		string secondKey)
+	{
+		var container = CreateThemedContainer();
+		var probes = (Panel)XamlReader.Load(
+			$$"""
+			<StackPanel xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+				<Border Width="8" Height="8" Background="{ThemeResource {{firstKey}}}" />
+				<Border Width="8" Height="8" Background="{ThemeResource {{secondKey}}}" />
+			</StackPanel>
+			""");
+
+		container.Children.Add(probes);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(container);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var root = container.XamlRoot?.Content as FrameworkElement;
+		Assert.IsNotNull(root, "The loaded container should expose the XamlRoot content");
+
+		var initialTheme = root!.RequestedTheme;
+		try
+		{
+			root.RequestedTheme = theme;
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			var first = ((Border)probes.Children[0]).Background as SolidColorBrush;
+			var second = ((Border)probes.Children[1]).Background as SolidColorBrush;
+
+			Assert.IsNotNull(first, $"{firstKey} should resolve to a SolidColorBrush under {theme}");
+			Assert.IsNotNull(second, $"{secondKey} should resolve to a SolidColorBrush under {theme}");
+
+			return (first, second);
+		}
+		finally
+		{
+			root.RequestedTheme = initialTheme;
+			await UnitTestsUIContentHelper.WaitForIdle();
+		}
 	}
 
 	private static FrameworkElement? FindDescendantByName(DependencyObject root, string name)
@@ -150,14 +224,9 @@ public class Given_TimePickerStyles
 			"TimePickerContentMargin",
 		};
 
-		var missing = new List<string>();
-		foreach (var key in keys)
-		{
-			if (!container.Resources.TryGetValue(key, out var value) || value is null)
-			{
-				missing.Add(key);
-			}
-		}
+		var missing = keys
+			.Where(key => !container.Resources.TryGetValue(key, out var value) || value is null)
+			.ToList();
 
 		CollectionAssert.AreEqual(
 			System.Array.Empty<string>(),
@@ -167,23 +236,25 @@ public class Given_TimePickerStyles
 
 	[TestMethod]
 	[RunsOnUIThread]
-	public void When_FlyoutPresenterHighlight_Resolved_ThenItContrastsWithTheFlyoutBackground()
+	[DataRow(ElementTheme.Light)]
+	[DataRow(ElementTheme.Dark)]
+	public async Task When_FlyoutPresenterHighlight_Resolved_ThenItContrastsWithTheFlyoutBackground(ElementTheme theme)
 	{
 		// The selection band sits directly on the flyout background; when the two resolve to the
-		// same color the selected row is invisible — PrimaryVariantLightBrush was #1E1E1E under
-		// Dark, exactly SurfaceBrush. Note the ResourceDictionary indexer resolves theme
-		// dictionaries against the *application* theme, so this covers the ambient theme only.
-		var container = CreateThemedContainer();
+		// same color the selected row is invisible. That is the bug this guards: the band used to
+		// be PrimaryVariantLightBrush, which is #1E1E1E under Dark — exactly SurfaceColor. Under
+		// Light the two already differed (#F5F5F5 vs #FFFFFF), so the Dark row is the one that
+		// reproduces it, and it only does so because the brushes are resolved through a themed
+		// element rather than the theme-blind ResourceDictionary indexer.
+		var (highlight, background) = await ResolveThemeBrushPairAsync(
+			theme,
+			"TimePickerFlyoutPresenterHighlightFill",
+			"TimePickerFlyoutPresenterBackground");
 
-		var highlight = container.Resources["TimePickerFlyoutPresenterHighlightFill"] as SolidColorBrush;
-		var background = container.Resources["TimePickerFlyoutPresenterBackground"] as SolidColorBrush;
-
-		Assert.IsNotNull(highlight, "TimePickerFlyoutPresenterHighlightFill should be a SolidColorBrush");
-		Assert.IsNotNull(background, "TimePickerFlyoutPresenterBackground should be a SolidColorBrush");
 		Assert.AreNotEqual(
 			background!.Color,
 			highlight!.Color,
-			"The TimePicker selection band must be distinguishable from the flyout background");
+			$"The TimePicker selection band must be distinguishable from the flyout background under {theme}");
 	}
 
 	// ─────────────────────────────────────────────────────────────────────
@@ -208,14 +279,10 @@ public class Given_TimePickerStyles
 		await UnitTestsUIContentHelper.WaitForLoaded(picker);
 		await UnitTestsUIContentHelper.WaitForIdle();
 
-		var missing = new List<string>();
-		foreach (var part in RequiredTimePickerParts)
-		{
-			if (FindDescendantByName(picker, part) is null)
-			{
-				missing.Add(part);
-			}
-		}
+		var missing = ControlContractParts
+			.Concat(TemplateOwnedParts)
+			.Where(part => FindDescendantByName(picker, part) is null)
+			.ToList();
 
 		CollectionAssert.AreEqual(
 			System.Array.Empty<string>(),
@@ -223,7 +290,7 @@ public class Given_TimePickerStyles
 			$"SimpleTimePickerStyle is missing these named template parts under {theme}: {string.Join(", ", missing)}");
 	}
 
-	// Field sizing (shared with DatePicker) lives in Given_PickerFieldSizing.
+	// Field sizing (shared with DatePicker) lives in Given_PickerFieldLayout.
 
 	[TestMethod]
 	[RunsOnUIThread]
@@ -248,7 +315,7 @@ public class Given_TimePickerStyles
 		var renderedHeaders = CountVisibleTextBlocksWithText(picker, header);
 		Assert.AreEqual(1, renderedHeaders, $"'{header}' should be rendered exactly once, as the placeholder");
 
-		var placeholder = FindDescendantByName(picker, "PlaceholderText") as TextBlock;
+		var placeholder = FindDescendantByName(picker, "PlaceholderText");
 		Assert.IsNotNull(placeholder, "PlaceholderText should be part of the template");
 		Assert.AreEqual(Visibility.Visible, placeholder!.Visibility, "The header should be visible while no time is set");
 
@@ -305,14 +372,24 @@ public class Given_TimePickerStyles
 
 	[TestMethod]
 	[RunsOnUIThread]
-	public async Task When_TimeIsSelected_ThenTheFieldReadsAsOneCompactValue()
+	public async Task When_TimeIsSelected_ThenTheDividersCarryNoOrderDependentText()
 	{
-		// The field should look like a single text field ("9:41 AM"), not three cells stretched
-		// across the control's width, so the content run stays far narrower than the field itself.
+		// Regression guard for a culture bug, so it asserts the property that makes the template
+		// culture-safe rather than a rendering that only holds for en-US.
+		//
+		// UpdateOrderAndLayout reparents the hour/minute/period TextBlocks between
+		// First|Second|ThirdPickerHost to reorder per culture, but it only toggles the *visibility*
+		// of the dividers — it never moves them. A literal ":" in FirstColumnDivider is therefore
+		// correct only while the hour happens to come first. Under a period-first culture
+		// (ko-KR / zh-CN / ja-JP put the period in FirstPickerHost) it renders "오전 : 9  41":
+		// colon between period and hour, none between hour and minute.
+		//
+		// A neutral rule carries no ordering assumption, so the invariant to hold is "the dividers
+		// are not text". Asserting it structurally keeps the test deterministic — swapping the
+		// ambient culture mid-test is flaky and would not re-run the control's ordering pass.
 		var container = CreateThemedContainer();
 		var picker = new TimePicker
 		{
-			Width = 400,
 			SelectedTime = new System.TimeSpan(9, 41, 0),
 			Style = container.Resources["SimpleTimePickerStyle"] as Style,
 		};
@@ -322,17 +399,59 @@ public class Given_TimePickerStyles
 		await UnitTestsUIContentHelper.WaitForLoaded(picker);
 		await UnitTestsUIContentHelper.WaitForIdle();
 
-		var content = FindDescendantByName(picker, "FlyoutButtonContentGrid");
-		Assert.IsNotNull(content, "FlyoutButtonContentGrid should be part of the template");
-		Assert.IsTrue(
-			content!.ActualWidth < picker.ActualWidth / 2,
-			$"The time value should stay a compact run, but it took {content.ActualWidth} of {picker.ActualWidth}px");
+		foreach (var dividerName in new[] { "FirstColumnDivider", "SecondColumnDivider" })
+		{
+			var divider = FindDescendantByName(picker, dividerName);
+			Assert.IsNotNull(divider, $"{dividerName} should be part of the template");
+			Assert.IsNotInstanceOfType(
+				divider,
+				typeof(TextBlock),
+				$"{dividerName} must not be a TextBlock: the control never repositions the dividers, "
+					+ "so any glyph in one is wrong as soon as the culture reorders the columns");
+		}
 
-		// The separator is a TextBlock (First|SecondColumnDivider are UIElement in the control
-		// contract), so a revert to a Rectangle rule fails this cast.
-		var separator = FindDescendantByName(picker, "FirstColumnDivider") as TextBlock;
-		Assert.IsNotNull(separator, "FirstColumnDivider should be the textual time separator");
-		Assert.AreEqual(":", separator!.Text, "The hour and minute should be separated by a colon");
+		// The hour / minute / period text stays owned by the control, so culture ordering,
+		// MinuteIncrement and ClockIdentifier all keep working.
+		var hour = FindDescendantByName(picker, "HourTextBlock") as TextBlock;
+		var minute = FindDescendantByName(picker, "MinuteTextBlock") as TextBlock;
+		Assert.IsFalse(string.IsNullOrEmpty(hour?.Text), "The control should have filled HourTextBlock");
+		Assert.IsFalse(string.IsNullOrEmpty(minute?.Text), "The control should have filled MinuteTextBlock");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_TemplateApplied_ThenTheControlDrivesTheColumnWidths()
+	{
+		// The named columns are the control's, not the template's: UpdateOrderAndLayout assigns 1*
+		// to every populated column and 0 to the rest on each pass, overwriting whatever width the
+		// template declared. Declaring "Auto" there reads as a compact-layout mechanism that does
+		// not exist — this pins the real behaviour so the template comment stays honest.
+		var container = CreateThemedContainer();
+		var picker = new TimePicker
+		{
+			SelectedTime = new System.TimeSpan(9, 41, 0),
+			Style = container.Resources["SimpleTimePickerStyle"] as Style,
+		};
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var grid = FindDescendantByName(picker, "FlyoutButtonContentGrid") as Grid;
+		Assert.IsNotNull(grid, "FlyoutButtonContentGrid should be part of the template");
+
+		var populated = grid!.ColumnDefinitions
+			.Where(c => c.Width.GridUnitType == GridUnitType.Star)
+			.ToList();
+
+		Assert.AreEqual(
+			3,
+			populated.Count,
+			"The control should have starred the three populated hour/minute/period columns");
+		Assert.IsTrue(
+			populated.All(c => c.Width.Value == 1.0),
+			"Every populated column should carry the control's 1* width");
 	}
 
 	[TestMethod]

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_TimePickerStyles.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_TimePickerStyles.cs
@@ -449,9 +449,16 @@ public class Given_TimePickerStyles
 			3,
 			populated.Count,
 			"The control should have starred the three populated hour/minute/period columns");
-		Assert.IsTrue(
-			populated.All(c => c.Width.Value == 1.0),
-			"Every populated column should carry the control's 1* width");
+		foreach (var column in populated)
+		{
+			// Delta rather than == : GridLength.Value is a double, and the control computes it
+			// rather than echoing the literal the template declared.
+			Assert.AreEqual(
+				1.0,
+				column.Width.Value,
+				0.0001,
+				"Every populated column should carry the control's 1* width");
+		}
 	}
 
 	[TestMethod]

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_TimePickerStyles.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_TimePickerStyles.cs
@@ -1,0 +1,392 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Simple;
+using Uno.UI.RuntimeTests;
+using Windows.UI;
+
+namespace Uno.Themes.Samples.RuntimeTests;
+
+/// <summary>
+/// Guards the Simple TimePicker styles (<c>SimpleTimePickerStyle</c>,
+/// <c>SimpleTimePickerFlyoutPresenterStyle</c> and their <c>SimpleDefault*</c> aliases).
+///
+/// The high-value assertion here is the template-part contract: Uno's
+/// <c>TimePicker.OnApplyTemplate</c> reparents the hour / minute / period TextBlocks into
+/// <c>First|Second|ThirdPickerHost</c> and drives <c>First|Second|ThirdTextBlockColumn</c> and
+/// <c>First|SecondColumnDivider</c> to reorder per culture and collapse the period column for a
+/// 24-hour <see cref="TimePicker.ClockIdentifier"/>. A template missing those named parts still
+/// renders — it just silently loses ordering and 24-hour support — so the names are asserted
+/// explicitly rather than inferred from "it looked fine".
+/// </summary>
+[TestClass]
+public class Given_TimePickerStyles
+{
+	/// <summary>Named parts the WinUI/Uno TimePicker looks up in its template.</summary>
+	private static readonly string[] RequiredTimePickerParts =
+	{
+		"LayoutRoot",
+		"PlaceholderText",
+		"FlyoutButton",
+		"FlyoutButtonContentGrid",
+		"FirstPickerHost",
+		"SecondPickerHost",
+		"ThirdPickerHost",
+		"HourTextBlock",
+		"MinuteTextBlock",
+		"PeriodTextBlock",
+		"FirstColumnDivider",
+		"SecondColumnDivider",
+	};
+
+	private static Grid CreateThemedContainer(ElementTheme theme = ElementTheme.Default)
+	{
+		var container = new Grid { RequestedTheme = theme };
+		container.Resources.MergedDictionaries.Add(new SimpleTheme());
+		return container;
+	}
+
+	private static FrameworkElement? FindDescendantByName(DependencyObject root, string name)
+	{
+		var count = VisualTreeHelper.GetChildrenCount(root);
+		for (var i = 0; i < count; i++)
+		{
+			var child = VisualTreeHelper.GetChild(root, i);
+			if (child is FrameworkElement fe && fe.Name == name)
+			{
+				return fe;
+			}
+
+			if (FindDescendantByName(child, name) is { } match)
+			{
+				return match;
+			}
+		}
+
+		return null;
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Style keys resolve, in Light and Dark.
+	// ─────────────────────────────────────────────────────────────────────
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(ElementTheme.Light, "SimpleTimePickerStyle")]
+	[DataRow(ElementTheme.Light, "SimpleDefaultTimePickerStyle")]
+	[DataRow(ElementTheme.Light, "SimpleTimePickerFlyoutButtonStyle")]
+	[DataRow(ElementTheme.Light, "SimpleTimePickerFlyoutPresenterStyle")]
+	[DataRow(ElementTheme.Light, "SimpleDefaultTimePickerFlyoutPresenterStyle")]
+	[DataRow(ElementTheme.Dark, "SimpleTimePickerStyle")]
+	[DataRow(ElementTheme.Dark, "SimpleDefaultTimePickerStyle")]
+	[DataRow(ElementTheme.Dark, "SimpleTimePickerFlyoutButtonStyle")]
+	[DataRow(ElementTheme.Dark, "SimpleTimePickerFlyoutPresenterStyle")]
+	[DataRow(ElementTheme.Dark, "SimpleDefaultTimePickerFlyoutPresenterStyle")]
+	public void When_TimePickerStyleKey_Requested_ThenItResolves(ElementTheme theme, string styleKey)
+	{
+		var container = CreateThemedContainer(theme);
+
+		Assert.IsTrue(
+			container.Resources.TryGetValue(styleKey, out var resource),
+			$"{styleKey} should be available under {theme}");
+		Assert.IsInstanceOfType(resource, typeof(Style), $"{styleKey} should be a Style");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(ElementTheme.Light)]
+	[DataRow(ElementTheme.Dark)]
+	public void When_SemanticTimePickerKeys_Requested_ThenTheyAliasTheSimpleStyles(ElementTheme theme)
+	{
+		var container = CreateThemedContainer(theme);
+
+		Assert.AreSame(
+			container.Resources["SimpleTimePickerStyle"],
+			container.Resources["TimePickerStyle"],
+			$"TimePickerStyle should alias SimpleTimePickerStyle under {theme}");
+		Assert.AreSame(
+			container.Resources["SimpleTimePickerFlyoutPresenterStyle"],
+			container.Resources["TimePickerFlyoutPresenterStyle"],
+			$"TimePickerFlyoutPresenterStyle should alias SimpleTimePickerFlyoutPresenterStyle under {theme}");
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Lightweight styling keys resolve, in Light and Dark.
+	// ─────────────────────────────────────────────────────────────────────
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(ElementTheme.Light)]
+	[DataRow(ElementTheme.Dark)]
+	public void When_TimePickerLightweightKeys_Requested_ThenTheyResolve(ElementTheme theme)
+	{
+		var container = CreateThemedContainer(theme);
+
+		var keys = new[]
+		{
+			"TimePickerButtonBackground",
+			"TimePickerButtonBackgroundDisabled",
+			"TimePickerButtonBorderBrush",
+			"TimePickerButtonBorderBrushDisabled",
+			"TimePickerButtonTimeTextForeground",
+			"TimePickerButtonTimeTextForegroundDisabled",
+			"TimePickerPlaceholderTextForeground",
+			"TimePickerHeaderForeground",
+			"TimePickerHeaderForegroundDisabled",
+			"TimePickerSpacerFill",
+			"TimePickerSpacerFillDisabled",
+			"TimePickerFlyoutPresenterBackground",
+			"TimePickerFlyoutPresenterBorderBrush",
+			"TimePickerFlyoutPresenterSpacerFill",
+			"TimePickerFlyoutPresenterHighlightFill",
+			"TimePickerFlyoutPresenterCornerRadius",
+			"TimePickerCornerRadius",
+			"TimePickerMinHeight",
+			"TimePickerContentMargin",
+		};
+
+		var missing = new List<string>();
+		foreach (var key in keys)
+		{
+			if (!container.Resources.TryGetValue(key, out var value) || value is null)
+			{
+				missing.Add(key);
+			}
+		}
+
+		CollectionAssert.AreEqual(
+			System.Array.Empty<string>(),
+			missing,
+			$"These TimePicker lightweight keys did not resolve under {theme}: {string.Join(", ", missing)}");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_FlyoutPresenterHighlight_Resolved_ThenItContrastsWithTheFlyoutBackground()
+	{
+		// The selection band sits directly on the flyout background; when the two resolve to the
+		// same color the selected row is invisible — PrimaryVariantLightBrush was #1E1E1E under
+		// Dark, exactly SurfaceBrush. Note the ResourceDictionary indexer resolves theme
+		// dictionaries against the *application* theme, so this covers the ambient theme only.
+		var container = CreateThemedContainer();
+
+		var highlight = container.Resources["TimePickerFlyoutPresenterHighlightFill"] as SolidColorBrush;
+		var background = container.Resources["TimePickerFlyoutPresenterBackground"] as SolidColorBrush;
+
+		Assert.IsNotNull(highlight, "TimePickerFlyoutPresenterHighlightFill should be a SolidColorBrush");
+		Assert.IsNotNull(background, "TimePickerFlyoutPresenterBackground should be a SolidColorBrush");
+		Assert.AreNotEqual(
+			background!.Color,
+			highlight!.Color,
+			"The TimePicker selection band must be distinguishable from the flyout background");
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Template-part contract.
+	// ─────────────────────────────────────────────────────────────────────
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(ElementTheme.Light)]
+	[DataRow(ElementTheme.Dark)]
+	public async Task When_TimePickerStyle_Applied_ThenRequiredTemplatePartsArePresent(ElementTheme theme)
+	{
+		var container = CreateThemedContainer(theme);
+		var picker = new TimePicker
+		{
+			Header = "Pick a time",
+			Style = container.Resources["SimpleTimePickerStyle"] as Style,
+		};
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var missing = new List<string>();
+		foreach (var part in RequiredTimePickerParts)
+		{
+			if (FindDescendantByName(picker, part) is null)
+			{
+				missing.Add(part);
+			}
+		}
+
+		CollectionAssert.AreEqual(
+			System.Array.Empty<string>(),
+			missing,
+			$"SimpleTimePickerStyle is missing these named template parts under {theme}: {string.Join(", ", missing)}");
+	}
+
+	// Field sizing (shared with DatePicker) lives in Given_PickerFieldSizing.
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_HeaderIsSet_ThenItRendersOnceAsThePlaceholder()
+	{
+		// The header used to render twice — as a label above the field and again as the
+		// header-bound placeholder inside it. It is the placeholder only.
+		const string header = "Start Time";
+
+		var container = CreateThemedContainer();
+		var picker = new TimePicker
+		{
+			Header = header,
+			Style = container.Resources["SimpleTimePickerStyle"] as Style,
+		};
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var renderedHeaders = CountVisibleTextBlocksWithText(picker, header);
+		Assert.AreEqual(1, renderedHeaders, $"'{header}' should be rendered exactly once, as the placeholder");
+
+		var placeholder = FindDescendantByName(picker, "PlaceholderText") as TextBlock;
+		Assert.IsNotNull(placeholder, "PlaceholderText should be part of the template");
+		Assert.AreEqual(Visibility.Visible, placeholder!.Visibility, "The header should be visible while no time is set");
+
+		// The control's own "hour : minute AM" run would sit on top of the placeholder.
+		var value = FindDescendantByName(picker, "FlyoutButtonContentGrid");
+		Assert.AreEqual(
+			Visibility.Collapsed,
+			value!.Visibility,
+			"With a header acting as the placeholder, the hour/minute run must stay hidden until a time is set");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_NoHeaderIsSet_ThenTheControlPlaceholderIsShown()
+	{
+		// Without a header there is nothing to use as the placeholder, so the control's own
+		// "hour : minute AM" run stays visible rather than leaving an empty field.
+		var container = CreateThemedContainer();
+		var picker = new TimePicker
+		{
+			Style = container.Resources["SimpleTimePickerStyle"] as Style,
+		};
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var value = FindDescendantByName(picker, "FlyoutButtonContentGrid");
+		Assert.IsNotNull(value, "FlyoutButtonContentGrid should be part of the template");
+		Assert.AreEqual(Visibility.Visible, value!.Visibility, "The hour/minute run is the fallback placeholder");
+	}
+
+	private static int CountVisibleTextBlocksWithText(DependencyObject root, string text)
+	{
+		var count = 0;
+		var children = VisualTreeHelper.GetChildrenCount(root);
+		for (var i = 0; i < children; i++)
+		{
+			var child = VisualTreeHelper.GetChild(root, i);
+			if (child is TextBlock { Visibility: Visibility.Visible } textBlock && textBlock.Text == text)
+			{
+				count++;
+			}
+
+			if (child is not FrameworkElement { Visibility: Visibility.Collapsed })
+			{
+				count += CountVisibleTextBlocksWithText(child, text);
+			}
+		}
+
+		return count;
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_TimeIsSelected_ThenTheFieldReadsAsOneCompactValue()
+	{
+		// The field should look like a single text field ("9:41 AM"), not three cells stretched
+		// across the control's width, so the content run stays far narrower than the field itself.
+		var container = CreateThemedContainer();
+		var picker = new TimePicker
+		{
+			Width = 400,
+			SelectedTime = new System.TimeSpan(9, 41, 0),
+			Style = container.Resources["SimpleTimePickerStyle"] as Style,
+		};
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var content = FindDescendantByName(picker, "FlyoutButtonContentGrid");
+		Assert.IsNotNull(content, "FlyoutButtonContentGrid should be part of the template");
+		Assert.IsTrue(
+			content!.ActualWidth < picker.ActualWidth / 2,
+			$"The time value should stay a compact run, but it took {content.ActualWidth} of {picker.ActualWidth}px");
+
+		// The separator is a TextBlock (First|SecondColumnDivider are UIElement in the control
+		// contract), so a revert to a Rectangle rule fails this cast.
+		var separator = FindDescendantByName(picker, "FirstColumnDivider") as TextBlock;
+		Assert.IsNotNull(separator, "FirstColumnDivider should be the textual time separator");
+		Assert.AreEqual(":", separator!.Text, "The hour and minute should be separated by a colon");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_ClockIdentifierIs24Hour_ThenPeriodColumnCollapses()
+	{
+		var container = CreateThemedContainer();
+		var picker = new TimePicker
+		{
+			ClockIdentifier = "24HourClock",
+			Style = container.Resources["SimpleTimePickerStyle"] as Style,
+		};
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var secondDivider = FindDescendantByName(picker, "SecondColumnDivider");
+		Assert.IsNotNull(secondDivider, "SecondColumnDivider should be part of the template");
+		Assert.AreEqual(
+			Visibility.Collapsed,
+			secondDivider!.Visibility,
+			"With a 24-hour clock there is no AM/PM column, so the second divider must collapse");
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Lightweight-styling override precedence.
+	// ─────────────────────────────────────────────────────────────────────
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_TimePickerButtonBackgroundOverridden_ThenFieldReflectsChange()
+	{
+		var expected = Colors.DarkOrchid;
+
+		var container = CreateThemedContainer();
+		container.Resources["TimePickerButtonBackground"] = new SolidColorBrush(expected);
+
+		var picker = new TimePicker
+		{
+			Style = container.Resources["SimpleTimePickerStyle"] as Style,
+		};
+		container.Children.Add(picker);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(picker);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		var background = picker.Background as SolidColorBrush;
+		Assert.IsNotNull(background, "TimePicker should have a Background brush from the style");
+		Assert.AreEqual(
+			expected,
+			background!.Color,
+			"Overriding TimePickerButtonBackground should change the TimePicker field background");
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1329

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature
- Documentation content changes

## Description

Adds `TimePicker` styles to Material v2 and Simple — neither had one (the only coverage was `Uno.Material/Styles/Controls/v1/TimePicker.xaml`, which binds v1-only brushes, has no `ThemeDictionaries`, exposes the flyout presenter style as `<ios:Style>`, and omits the template parts the control drives). Cupertino and Material v1 are untouched. Along the way it fixes three `DatePicker` issues that turned out to be the same defects in the shipped control.

### TimePicker (new)

- `MaterialTimePickerStyle` / `SimpleTimePickerStyle` plus flyout presenter and flyout button styles, with full `ThemeDictionaries` so every brush and dimension is lightweight-stylable.
- Template part names taken from Uno's `TimePicker.partial.mux.cs`, not guessed (`First|Second|ThirdPickerHost`, `*TextBlockColumn`, `First|SecondColumnDivider`), so culture-driven hour/minute/period reordering and 24-hour `ClockIdentifier` column collapse keep working.
- Dividers are neutral `Rectangle` rules, matching Fluent — **not** a literal `:`. `UpdateOrderAndLayout` only toggles divider *visibility* and never repositions them, so under a period-first culture (ko-KR / zh-CN / ja-JP) a glyph would land between the period and the hour. The columns are declared `*` for the same reason: the control assigns `1*` to every populated `*TextBlockColumn` on each pass, so `Auto` never applied at runtime.
- Implicit styles and semantic `TimePickerStyle` / `TimePickerFlyoutPresenterStyle` aliases registered in both `_Resources.xaml` files, plus `Theme.TimePicker` C# Markup accessors.

### DatePicker (fixes, both themes)

- **Selection band invisible in Dark.** Simple's `*FlyoutPresenterHighlightFill` was `PrimaryVariantLightBrush`, which resolves to `#1E1E1E` in Dark — exactly `SurfaceColor`, so the band painted itself onto the flyout background. Now `SurfaceVariantBrush`; the Light appearance is unchanged (`#F5F5F5` either way).
- **Field stretched to its container.** `HorizontalAlignment` `Stretch` → `Left`, with `*FlyoutPresenterMinWidth` as the floor, matching the Fluent picker. This also fixes the full-width flyout: `DatePickerFlyout`/`TimePickerFlyout` assign `presenter.Width = target.ActualWidth` on opening, so a stretched field produced a stretched flyout. Apps that want the old behaviour set `HorizontalAlignment="Stretch"` on the control.
- **`Header` rendered twice** — once as a label above/inside the field and again as the header-bound placeholder. Material now floats the header as a label (same behaviour as the Material `TextBox`: resting at body size centered in the field, animating up and scaling to `0.7` once a value is set). Simple renders it only as the in-field placeholder, the way `SimpleTextBox` shows `PlaceholderText`; with no `Header`, the control's own `hour : minute AM` run remains as the fallback. Both themes render the header through a `ContentPresenter`, so a non-string `Header` and a `HeaderTemplate` are honoured rather than `ToString()`-ed and dropped.
- The float is **layout-driven**: header and value occupy two `Auto` rows centred in the field, so the header-less, header-only and header+value cases all fall out of layout. There is no hand-computed offset — an earlier revision translated the label by `-11` derived from the 53px field height, which rendered a bare `<TimePicker />`'s value against the bottom edge.

### Notes for reviewers

- New lightweight-styling keys are additive: `{Date,Time}PickerHeaderFloatScale` and `TimePickerButtonPlaceholderMargin`. `*HeaderFloatScale` lives at dictionary scope rather than per-`ThemeDictionary`, because the Storyboard reads it through `StaticResource`, which does not re-resolve per theme — at theme scope it was documented as tunable but was not overridable.
- `DatePickerButtonPlaceholderMargin` keeps its name but changes meaning: it now insets the header row rather than padding the removed placeholder element (`4,0,0,0` → `10,0,10,0`). `DatePickerButtonContentMargin` changes `10,24,10,0` → `10,0,10,0` because the row layout, not a fixed inset, positions the value.
- Keys that still resolve but no longer affect rendering are documented as deprecated: `DatePickerButtonHeaderMargin` (also published by `Uno.Themes.WinUI.Markup` as `DatePicker.Button.HeaderMargin`), and Simple's `DatePickerHeaderMargin`, `DatePickerHeaderForeground`, `DatePickerHeaderForegroundDisabled`. No resource keys were removed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
	- [x] Skia Desktop (`MaterialSampleApp` / `SimpleSampleApp`, net10.0-desktop)
- [x] Updated the documentation as needed:
	- [x] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc) — new `doc/styles/TimePicker.md`, `doc/styles/simple/TimePicker.md`; updated `doc/styles/DatePicker.md`, `doc/styles/simple/DatePicker.md`, `semantic-styles.md`, `simple-controls-styles.md`
	- [x] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md) — Cupertino untouched
	- [x] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [ ] Contains **No** breaking changes
  > `DatePicker` behaviour changes for existing consumers: the field no longer stretches to its container (set `HorizontalAlignment="Stretch"` to restore), and `Header` no longer renders as a separate line — Material floats it as a label, Simple shows it as the placeholder. No resource keys were removed; the ones superseded are documented as deprecated.

## Other information

Runtime tests:

- `Given_TimePickerStyles` (SimpleSampleApp) — style-key resolution under Light/Dark, semantic aliases, template-part contract, 24-hour column collapse, control-assigned `1*` column widths, selection-band contrast, header-renders-once + placeholder fallback, lightweight-override precedence.
- `Given_PickerFieldLayout` (SimpleSampleApp) — sizes-to-content and header-renders-once, parameterized over both `DatePicker` and `TimePicker`.
- `Given_MaterialPickerStyles` (MaterialSampleApp) — **new**; the Material v2 picker templates previously had no runtime coverage at all. Covers template parts under Light/Dark, order-independent dividers, 24-hour collapse, header-renders-once, header-less vertical centring, flyout-highlight contrast and override precedence.

Contrast assertions resolve brushes through a themed, loaded element rather than the `ResourceDictionary` indexer — the indexer resolves `ThemeDictionaries` against the *application* theme, so the earlier `[DataRow(Light)]`/`[DataRow(Dark)]` pair asserted the same value and never reproduced the Dark bug it guarded.

Rebased on `master` (post `DefaultSpacing`/`Density` #1701 and seed-color fidelity #1697); the picker styles use no density or spacing tokens, so there is no interaction.

Full suites on net10.0-desktop (Release): **`SimpleSampleApp` 203 passed / 0 failed / 1 skipped** (the pre-existing `[Ignore]` on `Given_HotReload`), **`MaterialSampleApp` 58 passed / 0 failed**. `Uno.Themes-packages.slnf` builds clean with no new warnings.
