### PR TITLE
docs(samples): link filed upstream issues from ALC teardown sweeps

### DIFF
--- a/specs/05-alc-wrapper-app/progress.md
+++ b/specs/05-alc-wrapper-app/progress.md
@@ -108,7 +108,7 @@ Implemented as planned (`GuestAppCatalog` / `GuestAssemblyLoadContext` / `GuestA
   3. Re-running `Application.CleanupNonDefaultAlcCaches` after finalizers drain (guest `DependencyObject` finalizers can re-populate swept caches during unload).
 - **Loader diagnostics are Release-visible by design** (wrapper logging is not `#if DEBUG` like the heads): teardown branch logging + a `WeakReference` check that logs "Previous guest ALC was fully collected" / "still alive" on each load. The Release/Debug JIT-timing difference masked the leak in Debug builds — only the weak-ref telemetry makes regressions visible.
 - **Verified**: 16-cycle Release soak — previous ALC collected **15/15**, managed heap flat at ~32 MB (`eeheap`).
-- **Known limitation (upstream)**: each guest window create/close leaks its **native** X11 GL context (~12-15 MB native + 7 llvmpipe threads per cycle; llvmpipe group count grows 1:1 with cycles). Reproduces with and without an explicit `Window.Close()` before `Exit()` — the leak is in Uno's ALC guest-window native teardown, not reachable from the wrapper. Managed side is fully reclaimed. **Upstream issue to file.**
+- **Known limitation (upstream)**: each guest window create/close leaks its **native** X11 GL context (~12-15 MB native + 7 llvmpipe threads per cycle; llvmpipe group count grows 1:1 with cycles). Reproduces with and without an explicit `Window.Close()` before `Exit()` — the leak is in Uno's ALC guest-window native teardown, not reachable from the wrapper. Managed side is fully reclaimed. **Upstream: [uno#24076](https://github.com/unoplatform/uno/issues/24076).**
 - The stale-guest-build failure mode (`ReflectionTypeLoadException` from mixed-version theme dlls in a head's bin) is wrapped with an actionable "rebuild the head" message.
 
 ### Phase 5 — Build ordering ✅ 2026-07-18 (desktop only — wasm fell back, see below)
@@ -273,11 +273,11 @@ parsed) and was then immediately torn down.
 
 **Deviations from plan** (each documented in-phase): wrapper also sets `UnoEnableAlcAppSupport` (trimmed-publish linker substitution would hard-code `HasSecondaryApps=false`); `WasmScripts/AppManifest.js` required by Resizetizer; wasm P2P replaced by build-time warning + explicit CI guest builds (StaticWebAssets collision); three reflection-based teardown sweeps compensating Uno 6.7-dev per-ALC cleanup gaps; sln-level ProjectDependencies added.
 
-**Upstream issues to file against unoplatform/uno (6.7-dev ALC support)**
-1. `NameToPropertyDictionary.RemoveNonDefaultAlcEntries` misses cross-ALC entries (default-ALC key type, guest-ALC DP value) — pins guest ALCs via `_getPropertyCache`.
-2. ALC teardown does not prune `SystemNavigationManager` event subscriptions — a guest Shell's `BackRequested` handler roots its whole visual tree.
-3. Guest finalizers during unload re-populate property-system caches after `ExitAlcApplication`'s sweep.
-4. Native X11 window/GL context (+ render threads) leak per ALC-guest window create/close cycle (~12-15 MB native/cycle; managed side fully reclaimed). Reproduces with and without an explicit pre-Exit `Window.Close()`.
+**Upstream issues filed against unoplatform/uno (6.7-dev ALC support)** — full write-ups in `upstream-issues.md`
+1. [uno#24073](https://github.com/unoplatform/uno/issues/24073) — `NameToPropertyDictionary.RemoveNonDefaultAlcEntries` misses cross-ALC entries (default-ALC key type, guest-ALC DP value) — pins guest ALCs via `_getPropertyCache`.
+2. [uno#24074](https://github.com/unoplatform/uno/issues/24074) — ALC teardown does not prune `SystemNavigationManager` event subscriptions — a guest Shell's `BackRequested` handler roots its whole visual tree.
+3. [uno#24075](https://github.com/unoplatform/uno/issues/24075) — Guest finalizers during unload re-populate property-system caches after `ExitAlcApplication`'s sweep.
+4. [uno#24076](https://github.com/unoplatform/uno/issues/24076) — Native X11 window/GL context (+ render threads) leak per ALC-guest window create/close cycle (~12-15 MB native/cycle; managed side fully reclaimed). Reproduces with and without an explicit pre-Exit `Window.Close()`.
 
 **Accepted v1 limitations**: the native leak above (bounded by switch count in a dev tool); guest `Assets/**`/satellites not carried (some guest images may 404 — fonts covered by wrapper font packages); desktop wrapper output not self-contained (probes sibling bins; `GuestApps/` probe is the packaged-layout seam); single guest at a time by design.
 

--- a/specs/05-alc-wrapper-app/upstream-issues.md
+++ b/specs/05-alc-wrapper-app/upstream-issues.md
@@ -1,11 +1,19 @@
-# Upstream issue drafts — unoplatform/uno (6.7-dev secondary-ALC app support)
+# Upstream issues — unoplatform/uno (6.7-dev secondary-ALC app support)
 
-Ready-to-file drafts for the four gaps found while building `ThemesSampleApp` (see
-`progress.md` → Phase 4 findings and Review). All were reproduced against
-`Uno.Sdk.Private 6.7.0-dev.815` (`artifacts/uno` @ `21bf1ad6`) hosting the three theme sample
-heads through `AlcContentHost` / `WindowHelper.ContentHostOverride`. Once filed, replace the
-spec-pointer comment in `src/samples/ThemesSampleApp/GuestHosting/GuestAppLoader.Sweeps.cs`
-with the issue URLs, and delete each wrapper-side sweep when its fix ships.
+The four gaps found while building `ThemesSampleApp` (see `progress.md` → Phase 4 findings and
+Review). All were reproduced against `Uno.Sdk.Private 6.7.0-dev.815` (`artifacts/uno` @
+`21bf1ad6`) hosting the three theme sample heads through `AlcContentHost` /
+`WindowHelper.ContentHostOverride`.
+
+All four are now filed. Delete each wrapper-side sweep in
+`src/samples/ThemesSampleApp/GuestHosting/GuestAppLoader.Sweeps.cs` when its fix ships.
+
+| # | Issue | Wrapper-side sweep |
+| --- | --- | --- |
+| 1 | [unoplatform/uno#24073](https://github.com/unoplatform/uno/issues/24073) | clears `DependencyProperty._getPropertyCache` |
+| 2 | [unoplatform/uno#24074](https://github.com/unoplatform/uno/issues/24074) | prunes `SystemNavigationManager` handlers |
+| 3 | [unoplatform/uno#24075](https://github.com/unoplatform/uno/issues/24075) | re-invokes `Application.CleanupNonDefaultAlcCaches` |
+| 4 | [unoplatform/uno#24076](https://github.com/unoplatform/uno/issues/24076) | none, not reachable host-side |
 
 ---
 

--- a/src/samples/ThemesSampleApp/GuestHosting/GuestAppLoader.Sweeps.cs
+++ b/src/samples/ThemesSampleApp/GuestHosting/GuestAppLoader.Sweeps.cs
@@ -8,15 +8,22 @@ namespace Uno.Themes.WrapperApp.GuestHosting;
 /// The reflection-based sweeps compensating verified Uno 6.7-dev per-ALC cleanup gaps.
 /// </summary>
 /// <remarks>
-/// Each gap is documented in specs/05-alc-wrapper-app/progress.md → Review → "Upstream issues
-/// to file", with ready-to-file drafts in specs/05-alc-wrapper-app/upstream-issues.md; replace
-/// this pointer with the issue URLs once filed, and delete each sweep when its fix ships.
+/// Each gap is filed upstream with a repro and a suggested fix; delete each sweep when its
+/// fix ships:
+/// <list type="bullet">
+/// <item>unoplatform/uno#24075 — guest finalizers re-populate swept per-ALC caches during unload.</item>
+/// <item>unoplatform/uno#24073 — RemoveNonDefaultAlcEntries misses cross-ALC _getPropertyCache entries.</item>
+/// <item>unoplatform/uno#24074 — ALC teardown does not prune SystemNavigationManager subscriptions.</item>
+/// </list>
+/// unoplatform/uno#24076 (native X11 window/GL context leak) has no host-side sweep.
+/// Full write-ups in specs/05-alc-wrapper-app/upstream-issues.md.
 /// Internal API by necessity; every step degrades to a logged warning (memory stays resident
 /// until the next guest exits), never an exception.
 /// </remarks>
 internal sealed partial class GuestAppLoader
 {
 	// Same sweep ExitAlcApplication runs, needed a second time after guest finalizers finish.
+	// Upstream: unoplatform/uno#24075.
 	private static readonly MethodInfo? _cleanupNonDefaultAlcCaches =
 		SafeGetMethod(typeof(Application), "CleanupNonDefaultAlcCaches", BindingFlags.Static | BindingFlags.NonPublic);
 
@@ -25,7 +32,7 @@ internal sealed partial class GuestAppLoader
 	// framework element caches a DEFAULT-ALC key (e.g. Button) with a GUEST-ALC value, which
 	// Uno's per-key ALC sweep can never remove — pinning the whole guest ALC (verified via
 	// heap dump). It is a pure cache over DependencyPropertyRegistry, so clearing it wholesale
-	// is safe; it repopulates on demand.
+	// is safe; it repopulates on demand. Upstream: unoplatform/uno#24073.
 	private static readonly FieldInfo? _getPropertyCacheField =
 		SafeGetField(typeof(DependencyProperty), "_getPropertyCache", BindingFlags.Static | BindingFlags.NonPublic);
 	private static readonly MethodInfo? _getPropertyCacheClear =
@@ -101,6 +108,7 @@ internal sealed partial class GuestAppLoader
 	// and nothing unsubscribes it when a hosted guest is torn down (Uno's per-ALC sweep does
 	// not cover this singleton's event fields), so the whole guest visual tree stays rooted —
 	// verified via heap dump. Remove any handler whose origin lives in a collectible ALC.
+	// Upstream: unoplatform/uno#24074.
 	private static readonly string[] _navigationManagerEventFields = ["_backRequested", "InternalBackRequested"];
 
 	private void PruneGuestNavigationHandlers()


### PR DESCRIPTION
## PR Type

- Documentation content changes

## Description

Follow-up to #1693. The four secondary-ALC cleanup gaps found while building `ThemesSampleApp` have now been filed against `unoplatform/uno`, so this swaps the "issues to file" / "ready-to-file drafts" pointers for the actual issue URLs.

| Issue | Wrapper-side sweep it retires |
| --- | --- |
| [uno#24073](https://github.com/unoplatform/uno/issues/24073) — `RemoveNonDefaultAlcEntries` misses cross-ALC `_getPropertyCache` entries | clears `DependencyProperty._getPropertyCache` |
| [uno#24074](https://github.com/unoplatform/uno/issues/24074) — ALC teardown does not prune `SystemNavigationManager` subscriptions | prunes guest-ALC `BackRequested` handlers |
| [uno#24075](https://github.com/unoplatform/uno/issues/24075) — guest finalizers re-populate swept per-ALC caches during unload | re-invokes `Application.CleanupNonDefaultAlcCaches` |
| [uno#24076](https://github.com/unoplatform/uno/issues/24076) — native X11 window/GL context leak per guest window cycle | none, not reachable host-side |

Each sweep in `GuestAppLoader.Sweeps.cs` now names the issue that retires it, so the deletion trigger is visible right at the code instead of one indirection away in the spec.

Files touched:

- `src/samples/ThemesSampleApp/GuestHosting/GuestAppLoader.Sweeps.cs` — `<remarks>` lists the filed issues; each sweep's comment gets an `Upstream:` line.
- `specs/05-alc-wrapper-app/upstream-issues.md` — retitled from "drafts", issue/sweep mapping table at the top; the four write-ups are unchanged.
- `specs/05-alc-wrapper-app/progress.md` — "Upstream issues to file" → "filed", with links; the native-leak known-limitation note points at uno#24076.

**Comments and specs only, no behavior change.**

## PR Checklist

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Contains **No** breaking changes

Test matrix and doc checkboxes are not applicable: no build inputs, no product code, and no shipping documentation is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLBRk6Pso68HHtj14yhM8A
