### PR TITLE
feat: add instance-based Application.GetTheme() extension

### DIFF
--- a/doc/seed-colors.md
+++ b/doc/seed-colors.md
@@ -167,6 +167,22 @@ if (theme?.Colors is { } colors)
 }
 ```
 
+### Instance-Based Access via `ApplicationExtensions`
+
+`SemanticThemeHelper.GetTheme()` always reads from `Application.Current`. When you hold a specific `Application` instance — for example in multi-app or hosted scenarios where `Application.Current` is not the application whose theme you want — use the `application.GetTheme()` extension method instead:
+
+```csharp
+using Uno.Themes;
+
+var theme = someApplication.GetTheme();
+if (theme?.Colors is { } colors)
+{
+    colors.PrimarySeed = myColor;
+}
+```
+
+`SemanticThemeHelper.GetTheme()` is equivalent to `Application.Current.GetTheme()`.
+
 > [!TIP]
 > The Material and Simple sample apps in this repository include a **Seed Color** page (under *Styles*) with a live color picker — drag it and watch the entire app re-theme in real time, and switch between the two generation modes to compare them.
 
@@ -205,6 +221,14 @@ Static convenience class for runtime theme configuration.
 | `SecondarySeed` | Property | Gets or sets the secondary seed color. `null` to auto-derive from primary.                         |
 | `TertiarySeed`  | Property | Gets or sets the tertiary seed color. `null` to auto-derive from primary.                          |
 | `SeedColorMode` | Property | Gets or sets the generation mode on the active theme: `Fidelity` (default) or `TonalSpot`.         |
+
+### `ApplicationExtensions`
+
+Extension methods on `Application` for theme access.
+
+| Member                       | Type             | Description                                                                                          |
+|------------------------------|------------------|------------------------------------------------------------------------------------------------------|
+| `GetTheme(this Application)` | Extension method | Returns the `BaseTheme` instance from the given application's resources, or `null` if none is found. |
 
 ## Color Precedence
 

--- a/specs/03-seed-color-palette/seed-color-palette.md
+++ b/specs/03-seed-color-palette/seed-color-palette.md
@@ -101,6 +101,12 @@ Seed colors are configured exclusively via `ThemeColors` (the `BaseTheme.Colors`
 
 Creates a `ThemeColors` instance automatically if the theme doesn't have one yet. Throws `InvalidOperationException` if no `BaseTheme` is found in application resources.
 
+### `ApplicationExtensions` (instance-based theme lookup)
+
+`Extensions/ApplicationExtensions.cs` exposes `GetTheme(this Application)`: the same first-level `MergedDictionaries` scan as `SemanticThemeHelper.GetTheme()`, but against the resources of the `Application` instance the caller holds. `SemanticThemeHelper.GetTheme()` is a pure delegation to it on `Application.Current`. The extension is null-tolerant (a `null` application yields `null`).
+
+Motivation: hosts that run several applications (e.g. Hot Design's ALC-hosted guest apps, the ALC wrapper sample in `specs/05-alc-wrapper-app/`) cannot reach a guest's theme through `Application.Current`, which is the host application. A caller that resolves the guest's `Application` instance can now fetch its theme directly. Because `Uno.Themes.WinUI` resolves from the default load context in those hosting setups, `BaseTheme` type identity is shared and the plain `OfType<BaseTheme>` match works across the ALC boundary — no reflection needed. Runtime coverage: `Given_ApplicationExtensions` in `src/samples/SimpleSampleApp/RuntimeTests/`.
+
 ## How It Works
 
 ### Color Space: HCT
@@ -205,6 +211,7 @@ This means:
 src/library/Uno.Themes/
     ThemeColors.cs                  # Grouped color configuration DependencyObject
     Helpers/SemanticThemeHelper.cs  # Static convenience API for runtime seed color changes
+    Extensions/ApplicationExtensions.cs # Instance-based GetTheme(this Application)
     ColorGeneration/
         ColorMath.cs                # sRGB/Linear/XYZ/L* conversions
         TonalPalette.cs             # Hue+chroma → tone-indexed ARGB lookup

--- a/src/library/Uno.Themes/Extensions/ApplicationExtensions.cs
+++ b/src/library/Uno.Themes/Extensions/ApplicationExtensions.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+
+#if WinUI
+using Microsoft.UI.Xaml;
+#else
+using Windows.UI.Xaml;
+#endif
+
+namespace Uno.Themes;
+
+/// <summary>
+/// Provides extension methods on <see cref="Application"/> for theme access.
+/// </summary>
+public static class ApplicationExtensions
+{
+	/// <summary>
+	/// Gets the <see cref="BaseTheme"/> instance from the given application's resources.
+	/// Returns <c>null</c> if no <see cref="BaseTheme"/> is found, or if <paramref name="application"/> is <c>null</c>.
+	/// </summary>
+	public static BaseTheme GetTheme(this Application application) =>
+		application?.Resources?.MergedDictionaries.OfType<BaseTheme>().FirstOrDefault();
+}

--- a/src/library/Uno.Themes/Helpers/SemanticThemeHelper.cs
+++ b/src/library/Uno.Themes/Helpers/SemanticThemeHelper.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 
 #if WinUI
 using Microsoft.UI.Xaml;
@@ -20,8 +19,7 @@ public static class SemanticThemeHelper
 	/// Gets the <see cref="BaseTheme"/> instance from <see cref="Application.Current.Resources"/>.
 	/// Returns <c>null</c> if no <see cref="BaseTheme"/> is found.
 	/// </summary>
-	public static BaseTheme GetTheme() =>
-		Application.Current?.Resources?.MergedDictionaries.OfType<BaseTheme>().FirstOrDefault();
+	public static BaseTheme GetTheme() => Application.Current.GetTheme();
 
 	/// <summary>
 	/// Gets or sets the primary seed color on the active theme.

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_ApplicationExtensions.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_ApplicationExtensions.cs
@@ -1,0 +1,45 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Simple;
+using Uno.UI.RuntimeTests;
+
+namespace Uno.Themes.Samples.RuntimeTests;
+
+/// <summary>
+/// Verifies the instance-based theme lookup: <c>application.GetTheme()</c>
+/// resolves the <c>BaseTheme</c> merged into the given application's resources,
+/// and <c>SemanticThemeHelper.GetTheme()</c> remains a pure delegation to it
+/// on <c>Application.Current</c>.
+/// </summary>
+[TestClass]
+public class Given_ApplicationExtensions
+{
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_GettingThemeFromApplicationInstance_Then_ReturnsMergedTheme()
+	{
+		var theme = Application.Current.GetTheme();
+
+		Assert.IsInstanceOfType(theme, typeof(SimpleTheme),
+			"The sample app merges a SimpleTheme at the application level");
+		Assert.IsTrue(
+			Application.Current.Resources.MergedDictionaries.Contains(theme),
+			"The returned theme should be the instance merged into the application's resources");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_ComparedToStaticHelper_Then_SameInstanceIsReturned()
+	{
+		var fromExtension = Application.Current.GetTheme();
+		var fromHelper = SemanticThemeHelper.GetTheme();
+
+		Assert.AreSame(fromHelper, fromExtension,
+			"SemanticThemeHelper.GetTheme() should delegate to the extension on Application.Current");
+	}
+
+	[TestMethod]
+	public void When_ApplicationIsNull_Then_ReturnsNull()
+	{
+		Assert.IsNull(ApplicationExtensions.GetTheme(null));
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1698

## PR Type

What kind of change does this PR introduce?

- Feature

## Description

`SemanticThemeHelper.GetTheme()` is hard-wired to `Application.Current`, so a host application running a guest app in a secondary (collectible) `AssemblyLoadContext` — e.g. the `ThemesSampleApp` guest hosting, or Uno Hot Design's designed-app hosting — cannot fetch the nested app's `BaseTheme`.

This PR exposes the lookup as a public instance-based extension method:

- **New** `Uno.Themes.ApplicationExtensions.GetTheme(this Application)` (`src/library/Uno.Themes/Extensions/ApplicationExtensions.cs`) — the same first-level `MergedDictionaries` scan as the static helper, against the resources of the `Application` the caller holds; null-tolerant (a `null` application yields `null`).
- `SemanticThemeHelper.GetTheme()` becomes a pure delegation to the extension on `Application.Current` — behavior unchanged. The seed-color properties remain `Application.Current`-scoped; instance-based callers reach colors via the returned theme's public `BaseTheme.Colors` property.

Because `Uno.Themes.WinUI` resolves from the default load context in these hosting setups, `BaseTheme` type identity is shared between host and guest and the plain `OfType<BaseTheme>` match works across the ALC boundary — no reflection needed.

**Tests:** new runtime tests `Given_ApplicationExtensions` (`src/samples/SimpleSampleApp/RuntimeTests/`):

- `When_GettingThemeFromApplicationInstance_Then_ReturnsMergedTheme`
- `When_ComparedToStaticHelper_Then_SameInstanceIsReturned`
- `When_ApplicationIsNull_Then_ReturnsNull`

Written red-first (compile failure on the missing extension), then green. Full desktop runtime suite: 96 passed, 1 skipped (pre-existing `[Ignore]`-gated leak guard, unrelated).

**Docs/specs:** `doc/seed-colors.md` gains an "Instance-Based Access via `ApplicationExtensions`" section and an API-reference entry (markdownlint/cspell clean — includes fixing a pre-existing MD060 table-alignment error in the touched file); `specs/03-seed-color-palette/seed-color-palette.md` records the new API and its motivation.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [x] Updated the documentation as needed:
	- [x] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [x] Contains **No** breaking changes

## Other information

Additive API only. Tested on desktop (Skia, net10.0-desktop) via the headless runtime-test run; other platforms are exercised by CI. The follow-up consumer (Uno Hot Design calling `applicationTypeInfoProvider.ApplicationInstance.GetTheme()`) lives in the uno.hotdesign repo and is out of scope here.

## Internal Issue (If applicable):

🤖 Generated with [Claude Code](https://claude.com/claude-code)