### PR TITLE
feat!: add DefaultSpacing base unit and make Density a pure mode

### DIFF
--- a/doc/design-tokens.md
+++ b/doc/design-tokens.md
@@ -68,17 +68,19 @@ Per-scale keys follow the pattern `{Role}{Size}FontFamily`, `{Role}{Size}FontSiz
 
 ### Via Scalar Properties
 
-Set `DefaultCornerRadius` (shape) or `DefaultDensity` (spacing) on the theme to generate an entire scale from a single base value:
+Set `DefaultCornerRadius` (shape) or `DefaultSpacing` (spacing) on the theme to generate an entire scale from a single base value:
 
 ```xml
 <!-- App.xaml -->
-<MaterialTheme DefaultCornerRadius="4" DefaultDensity="Comfy" />
+<MaterialTheme DefaultCornerRadius="4" DefaultSpacing="6" />
 ```
 
 This generates all `Radius*` / `Space*` tokens as multiples of the base value. The same properties are available on `SimpleTheme`.
 
+For spacing, the [density mode](#density-modes) (`DefaultDensity`) composes with the base unit rather than replacing it: the effective spacing base is `DefaultSpacing × density factor` (`Compact` ×0.75, `Regular` ×1, `Comfy` ×1.25). With the default base of 4, the modes yield 3 / 4 / 5.
+
 > [!IMPORTANT]
-> `DefaultCornerRadius` and `DefaultDensity` are **construction-time settings**. Set them where the theme is declared — normally `App.xaml` — and treat them as fixed for the lifetime of the theme.
+> `DefaultCornerRadius`, `DefaultSpacing`, and `DefaultDensity` are **construction-time settings**. Set them where the theme is declared — normally `App.xaml` — and treat them as fixed for the lifetime of the theme.
 >
 > Assigning them later does regenerate the `Radius*` and `Space*` token resources, but it does **not** restyle controls: neither the ones already on screen nor ones created afterwards. Unlike colors — which *can* change live, see [Runtime Seed Color Changes](seed-colors.md#runtime-seed-color-changes) — these tokens are `CornerRadius` / `Thickness` / `double` **values**, and the per-control keys that consume them (`ButtonCornerRadius`, `ButtonPadding`, …) are resolved once when the theme's control-style dictionaries are first parsed. There is no live instance to update, so the new value never reaches the control templates.
 >
@@ -98,32 +100,31 @@ To override individual tokens without changing the whole scale, use standard XAM
 
 ### Properties Reference
 
-| Property              | Type      | Description                                                                                   |
-|-----------------------|-----------|-----------------------------------------------------------------------------------------------|
-| `DefaultCornerRadius` | `double`  | Base corner radius unit; generates the full `Radius*` scale. Construction-time.               |
-| `DefaultDensity`      | `Density` | Preset that sets the base spacing unit; generates the full `Space*` scale. Construction-time. |
+| Property              | Type      | Description                                                                                                                             |
+|-----------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `DefaultCornerRadius` | `double`  | Base corner radius unit; generates the full `Radius*` scale. Construction-time.                                                         |
+| `DefaultSpacing`      | `double`  | Base spacing unit (default 4); generates the full `Space*` scale, scaled by the `DefaultDensity` mode. Construction-time.               |
+| `DefaultDensity`      | `Density` | Density mode that scales the spacing base unit (`Compact` ×0.75, `Regular` ×1, `Comfy` ×1.25). Construction-time.                       |
 
-These properties are defined on `BaseTheme` and inherited by `MaterialTheme`, `SimpleTheme`, and their toolkit wrappers (`MaterialToolkitTheme`, `SimpleToolkitTheme`). Both are construction-time settings — see the note above. Color configuration lives on the separate `Colors` property (`ThemeColors`), which *does* support runtime changes — see [Seed Color Palette](seed-colors.md).
+These properties are defined on `BaseTheme` and inherited by `MaterialTheme`, `SimpleTheme`, and their toolkit wrappers (`MaterialToolkitTheme`, `SimpleToolkitTheme`). All are construction-time settings — see the note above. Color configuration lives on the separate `Colors` property (`ThemeColors`), which *does* support runtime changes — see [Seed Color Palette](seed-colors.md).
 
-There is no separate `DefaultSpacing` property; the base spacing unit is selected through `DefaultDensity`.
-
-### Density
+### Density Modes
 
 The `DefaultDensity` property controls the spacing density of all controls.
-It adjusts padding and margins (Space* tokens) while keeping control heights and icon sizes constant:
+It is a *mode*, not a value: it scales the `DefaultSpacing` base unit (effective base = `DefaultSpacing × factor`), adjusting padding and margins (Space* tokens) while keeping control heights and icon sizes constant. The two axes are orthogonal — a branded base unit and a density mode compose freely. The fixed tokens (`ControlHeight*`, `IconSize*`, `TouchTargetMinSize`) never change across density modes.
 
-| DefaultDensity      | Base Spacing | Feel                               |
-|---------------------|:------------:|------------------------------------|
-| `Compact`           |      3       | Tighter padding for data-dense UIs |
-| `Regular` (default) |      4       | Balanced spacing                   |
-| `Comfy`             |      5       | More generous padding              |
+| DefaultDensity      | Factor | Base at default spacing (4) | Feel                               |
+|---------------------|:------:|:---------------------------:|------------------------------------|
+| `Compact`           | ×0.75  |              3              | Tighter padding for data-dense UIs |
+| `Regular` (default) |   ×1   |              4              | Balanced spacing                   |
+| `Comfy`             | ×1.25  |              5              | More generous padding              |
 
 ```xml
 <!-- App.xaml — Material with compact density -->
 <MaterialTheme xmlns="using:Uno.Material" DefaultDensity="Compact" />
 
-<!-- App.xaml — Simple with comfortable density -->
-<SimpleTheme xmlns="using:Uno.Simple" DefaultDensity="Comfy" />
+<!-- App.xaml — Simple: branded 6px base unit in comfortable mode (effective base 7.5) -->
+<SimpleTheme xmlns="using:Uno.Simple" DefaultSpacing="6" DefaultDensity="Comfy" />
 ```
 
 Pick the density where the theme is declared. Switching it at runtime does not restyle existing or newly-created controls — see [Via Scalar Properties](#via-scalar-properties).

--- a/doc/material-getting-started.md
+++ b/doc/material-getting-started.md
@@ -37,7 +37,8 @@ Initialization of the Uno Material resources is handled by the specialized `Mate
 | `Colors`              | `ThemeColors` | (Optional) Groups all color configuration: seed colors (`PrimarySeed`, …), the generation mode (`SeedColorMode`), and color overrides. See [Seed Color Palette](xref:Uno.Themes.SeedColors). |
 | `FontOverrideSource`  | `string`      | (Optional) Gets or sets a Uniform Resource Identifier that provides the source location of a `ResourceDictionary` containing overrides for the default Uno Material font resources           |
 | `DefaultCornerRadius` | `double`      | (Optional) Base corner-radius unit driving the shape design tokens. See [Design Tokens](design-tokens.md).                                                                                   |
-| `DefaultDensity`      | `Density`     | (Optional) Spacing density preset (`Compact` / `Regular` / `Comfy`) driving the spacing design tokens. See [Design Tokens](design-tokens.md).                                                |
+| `DefaultSpacing`      | `double`      | (Optional) Base spacing unit (default 4) driving the spacing design tokens; scaled by the `DefaultDensity` mode. See [Design Tokens](design-tokens.md).                                      |
+| `DefaultDensity`      | `Density`     | (Optional) Density mode (`Compact` / `Regular` / `Comfy`) scaling the spacing base unit by ×0.75 / ×1 / ×1.25. See [Design Tokens](design-tokens.md).                                        |
 | `ColorOverrideSource` | `string`      | (Deprecated) Use `OverrideSource` on `Colors` instead — see the [migration notes](xref:Uno.Themes.Material.Migration).                                                                       |
 
 ### Creating a new project with Uno Material

--- a/doc/material-migration.md
+++ b/doc/material-migration.md
@@ -48,7 +48,7 @@ Uno Themes 7.0 introduces the Simple design system, the theme-agnostic Semantic 
 
 - **Simple theme**: new `Uno.Simple.WinUI` and `Uno.Simple.WinUI.Markup` packages providing a minimal, density-driven design system. See [Simple - Getting Started](simple-getting-started.md).
 - **Semantic Design Language**: design-system-agnostic style aliases (`FilledButtonStyle`, `OutlinedTextBoxStyle`, …) shared by Material and Simple, so apps can switch design systems without changing style keys. See [Semantic Design Language](semantic-styles.md).
-- **Design tokens**: spacing (`Space*`), shape (`Radius*`), and density (`ControlHeight*`, `IconSize*`) tokens, driven globally by the new `DefaultDensity` and `DefaultCornerRadius` theme properties. See [Design Tokens](design-tokens.md).
+- **Design tokens**: spacing (`Space*`), shape (`Radius*`), and density (`ControlHeight*`, `IconSize*`) tokens, driven globally by the new `DefaultSpacing`, `DefaultDensity`, and `DefaultCornerRadius` theme properties. See [Design Tokens](design-tokens.md).
 - **Seed color generation** (opt-in): generate a full palette from one or more seed colors via the new `Colors` property (`ThemeColors`) and `SemanticThemeHelper`. See [Seed Color Palette](seed-colors.md).
 - **Control extensions**: new `ControlExtensions.LeadingIcon` and `ControlExtensions.TrailingIcon` attached properties; `ControlExtensions.Icon` keeps working and now forwards its value to `LeadingIcon`. See [Control Extensions](themes-control-extensions.md).
 - **XAML Hot Reload**: theme resources now participate in Hot Reload.
@@ -130,7 +130,7 @@ Material v2 sizing, spacing, and corner-radius resources are no longer hard-code
 | `ButtonPadding`      | `16,0`    | `Space400HorizontalThickness` | `16,0`        |
 | `ButtonCornerRadius` | `20`      | `Radius500CornerRadius`       | `20`          |
 
-Roughly forty keys across all Material v2 controls follow this pattern. Because the values are now derived, the new `DefaultDensity` (`Compact` / `Regular` / `Comfy`) and `DefaultCornerRadius` theme properties reshape every Material control globally. See [Design Tokens](design-tokens.md).
+Roughly forty keys across all Material v2 controls follow this pattern. Because the values are now derived, the new `DefaultSpacing`, `DefaultDensity` (`Compact` / `Regular` / `Comfy`), and `DefaultCornerRadius` theme properties reshape every Material control globally. See [Design Tokens](design-tokens.md).
 
 ### `StringFormatConverter` is now culture-aware
 

--- a/specs/07-default-spacing/progress.md
+++ b/specs/07-default-spacing/progress.md
@@ -1,0 +1,65 @@
+# DefaultSpacing token + Density-as-mode composition (issue #1688)
+
+Implements https://github.com/unoplatform/Uno.Themes/issues/1688.
+
+## Design
+
+Revised after review: the first cut treated `DefaultSpacing` and `DefaultDensity` as two
+competing sources of the base unit (explicit spacing wins, density preset as fallback,
+`Compact = 3` / `Regular = 4` / `Comfy = 5` baked into the enum values). That collapsed two
+orthogonal axes into one knob — a branded base unit silently discarded the density axis.
+See `specs/lessons.md` ("A design-token 'mode' (density) must be a factor…").
+
+Current model — spacing and density **compose**:
+
+- `DefaultSpacing` (double DP on `BaseTheme`, default **4**) is the base spacing unit.
+  Non-finite or negative consumer values degrade to the default base of 4 (the value is
+  consumed from property-changed callbacks and must not poison the `Space*` scale).
+- `Density` is a pure **mode** (`Compact`, `Regular`, `Comfy` — no meaningful underlying
+  values). It scales the base unit: Compact ×0.75, Regular ×1, Comfy ×1.25. Undefined enum
+  values degrade to ×1.
+- Effective base = `DefaultSpacing × density factor`. Factors are chosen so the default
+  base of 4 reproduces the historical presets exactly (3 / 4 / 5) — density-only consumers
+  see no change.
+- `FixedDensityDefaults` (`ControlHeight*`, `IconSize*`, `TouchTargetMinSize`) stay
+  invariant across both axes (unchanged).
+- Breaking change (8.0): `Density` enum underlying values changed from 3/4/5 to 0/1/2.
+  Anyone persisting `(int)Density` or casting the enum to a number is affected; the names
+  and the rendered output at defaults are unchanged.
+
+## Checklist
+
+- [x] `DefaultSpacing` DP on `BaseTheme` (default 4) with XML docs (construction-time remark,
+      composition with density)
+- [x] `Density` enum reduced to a mode (no base-unit values); XML docs state the factors
+- [x] `UpdateSource()`: effective base = sanitized `DefaultSpacing` × density factor
+- [x] Runtime tests in `SimpleSampleApp/RuntimeTests/Given_DesignTokens.cs`:
+  - [x] `DefaultSpacing` set (Regular) → `Space*` tokens are multiples of it
+  - [x] Composition: spacing × Compact/Regular/Comfy → scaled base (4.5 / 6 / 7.5 for base 6)
+  - [x] Runtime switch: assign `DefaultSpacing`, then set NaN → default base returns, mode kept
+  - [x] Thickness companions derive from `DefaultSpacing`
+  - [x] Edge: NaN / negative / infinity → default base (4) × mode
+  - [x] Shape tokens unaffected by `DefaultSpacing`; fixed tokens invariant
+  - [x] Pre-existing density-only tests (Simple + Material heads) unchanged — outputs
+        identical by construction
+- [x] `doc/design-tokens.md`: composition documented ("Density Modes" section, factor table)
+- [x] `doc/material-getting-started.md` + `doc/material-migration.md` updated
+- [x] Build clean (desktop TFM) + `Given_DesignTokens` runtime tests green headlessly
+
+## Review
+
+Implemented as designed. `Enum.IsDefined` fallback replaced by the factor `switch` default
+(same graceful degradation, one less reflection call). No new resource keys, no Markup
+helpers needed.
+
+Verification (Simple host, net10.0-desktop Debug, headless `--runtime-tests` run, 2026-08-19):
+- All 18 DefaultSpacing/composition cases passed (value rows, composition matrix
+  Compact/Regular/Comfy, invalid-value fallbacks incl. NaN, runtime set/clear, thickness
+  companions, shape independence, fixed-token invariance).
+- Pre-existing density-only tests unchanged and passing — outputs identical by
+  construction (default base 4 × factors = 3/4/5). Material head run separately
+  (`Given_DesignTokens` filter): 32 cases, 0 failed.
+- Full suite: 171 cases — 0 failed, 1 skipped (pre-existing `[Ignore]`d hot-reload leak
+  guard, unrelated).
+- Build clean: no new warnings in `BaseTheme.cs` / `Given_DesignTokens.cs` (only the two
+  pre-existing CS0618 obsolete-member warnings in `BaseTheme.cs`).

--- a/specs/lessons.md
+++ b/specs/lessons.md
@@ -4,6 +4,19 @@ Domain lessons and postmortems for the Uno.Themes repo. Append new entries at th
 
 ---
 
+## A design-token "mode" (density) must be a factor over the scale's base unit, never a competing source of the base value
+
+**Context:** Spec 07 (`DefaultSpacing`, issue #1688). The first implementation gave `Density` enum members base-unit pixel values (`Compact = 3`, `Regular = 4`, `Comfy = 5`) and made `DefaultSpacing` an *override* that beat the preset ("override-beats-preset, like the color stack"). The user rejected this: density is a **mode** the consumer picks (Compact / Regular / Comfy), not an alternate spelling of a pixel value.
+
+**Root cause:** two orthogonal design axes were collapsed into one knob. Spacing (the scale's base unit — a brand/identity decision) and density (a contextual mode over that scale — a usability decision) both fed the same variable, making them mutually exclusive: setting a branded base unit silently discarded the density axis, and `DefaultSpacing="6"` + `Compact` was inexpressible. Encoding the magnitudes as the enum's underlying values (`Compact = 3`) hard-coupled the presets to the default base and leaked implementation into the public API surface.
+
+**How to apply:**
+- When a token system exposes both a scale and a mode, make them **compose**: `effective = base × modeFactor` (here Compact ×0.75, Regular ×1, Comfy ×1.25 — chosen so the default base of 4 reproduces the historical 3/4/5). "Override beats preset" is the right pattern for two sources of the *same* value (color overrides); it is the wrong pattern for two *different* axes.
+- Enum underlying values are API surface. If a preset's magnitude is meaningful, map it in code (a `switch` near its single consumer); never make the enum value *be* the magnitude — it can't survive a base-unit change and it invites `(double)enum` casts.
+- Fixed tokens (`ControlHeight*`, `IconSize*`, `TouchTargetMinSize`) stay invariant across **both** axes — density and spacing scale breathing room, never structure or touch targets.
+
+---
+
 ## Pick the oracle the reference *implementation* emits, not the value the spec *publishes* — and never assume a numeric fallback is doing the job its name claims
 
 **Context:** Seed color fidelity (spec 06). Two distinct traps hit while correcting `HctSolver`.

--- a/src/library/Uno.Themes/BaseTheme.cs
+++ b/src/library/Uno.Themes/BaseTheme.cs
@@ -22,18 +22,19 @@ namespace Uno.Themes;
 
 /// <summary>
 /// Controls the spacing density applied to all controls.
-/// Drives the base spacing unit used by all Space* tokens.
+/// A density is a <em>mode</em>: it scales the base spacing unit
+/// (<see cref="BaseTheme.DefaultSpacing"/>) without defining it.
 /// </summary>
 public enum Density
 {
-	/// <summary>Compact — base spacing unit = 3 px, tighter padding for data-dense UIs.</summary>
-	Compact = 3,
+	/// <summary>Compact — spacing scaled to 0.75× the base unit; tighter padding for data-dense UIs.</summary>
+	Compact,
 
-	/// <summary>Regular (default) — base spacing unit = 4 px, balanced spacing.</summary>
-	Regular = 4,
+	/// <summary>Regular (default) — spacing at 1× the base unit; balanced spacing.</summary>
+	Regular,
 
-	/// <summary>Comfortable — base spacing unit = 5 px, more generous padding.</summary>
-	Comfy = 5,
+	/// <summary>Comfortable — spacing scaled to 1.25× the base unit; more generous padding.</summary>
+	Comfy,
 }
 
 public abstract partial class BaseTheme : ResourceDictionary
@@ -310,11 +311,58 @@ public abstract partial class BaseTheme : ResourceDictionary
 	}
 	#endregion
 
+	#region DefaultSpacing (DP)
+	/// <summary>
+	/// The default base spacing unit (px) when <see cref="DefaultSpacing"/> is not set
+	/// or holds an invalid (non-finite or negative) value.
+	/// </summary>
+	private const double DefaultBaseSpacing = 4.0;
+
+	/// <summary>
+	/// Gets or sets the base spacing unit (in pixels). Default is 4.
+	/// All spacing scale tokens (Space0, Space050, Space100, …) and their
+	/// <see cref="Thickness"/> companions are computed as multiples of this value,
+	/// scaled by the <see cref="DefaultDensity"/> mode —
+	/// e.g. <c>DefaultSpacing="6"</c> at <see cref="Density.Regular"/> makes
+	/// Space100=6, Space200=12, Space400=24; at <see cref="Density.Compact"/> Space100=4.5.
+	/// Individual tokens can still be overridden via lightweight styling.
+	/// </summary>
+	/// <remarks>
+	/// This is a <b>construction-time</b> setting, for the same reason as
+	/// <see cref="DefaultCornerRadius"/>: assigning it later regenerates the <c>Space*</c> token
+	/// resources but does not restyle controls, because the per-control padding and margin keys
+	/// hold resolved <see cref="Thickness"/> values. To offer spacing as a user setting, change the
+	/// property and then recreate the root content.
+	/// Non-finite or negative values are treated as unset and fall back to the default of 4.
+	/// </remarks>
+	public double DefaultSpacing
+	{
+		get => (double)GetValue(DefaultSpacingProperty);
+		set => SetValue(DefaultSpacingProperty, value);
+	}
+
+	public static DependencyProperty DefaultSpacingProperty { get; } =
+		DependencyProperty.Register(
+			nameof(DefaultSpacing),
+			typeof(double),
+			typeof(BaseTheme),
+			new PropertyMetadata(DefaultBaseSpacing, OnDefaultSpacingChanged));
+
+	private static void OnDefaultSpacingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+	{
+		if (d is BaseTheme theme)
+		{
+			theme.UpdateSource();
+		}
+	}
+	#endregion
+
 	#region DefaultDensity (DP)
 	/// <summary>
-	/// Gets or sets the density preset for the theme. Default is <see cref="Density.Regular"/>.
-	/// This drives the base spacing unit used by all Space* tokens:
-	/// Compact = 3, Regular = 4, Comfy = 5.
+	/// Gets or sets the density mode for the theme. Default is <see cref="Density.Regular"/>.
+	/// The mode scales the <see cref="DefaultSpacing"/> base unit used by all Space* tokens
+	/// (Compact = ×0.75, Regular = ×1, Comfy = ×1.25), so density and spacing compose:
+	/// the effective base unit is <c>DefaultSpacing × density factor</c>.
 	/// Control heights and icon sizes remain constant across densities.
 	/// </summary>
 	/// <remarks>
@@ -426,8 +474,22 @@ public abstract partial class BaseTheme : ResourceDictionary
 		// every colour, spacing and shape key out of the consuming app permanently.
 		var colors = BuildColorLayer(out var resolvedOverride);
 
-		var baseSpacing = Enum.IsDefined(DefaultDensity) ? (double)DefaultDensity : 4.0;
-		var spacing = GenerateSpacingScale(baseSpacing);
+		// Spacing and density are orthogonal: DefaultSpacing supplies the base unit, the density
+		// mode scales it. Non-finite or negative consumer values degrade to the default base (4)
+		// instead of poisoning every Space* token — this runs from property-changed callbacks and
+		// must not misbehave on untrusted input.
+		var requestedSpacing = DefaultSpacing;
+		var baseSpacing = double.IsFinite(requestedSpacing) && requestedSpacing >= 0
+			? requestedSpacing
+			: DefaultBaseSpacing;
+		// Factors chosen so the default base of 4 yields the historical presets: 3 / 4 / 5.
+		var densityFactor = DefaultDensity switch
+		{
+			Density.Compact => 0.75,
+			Density.Comfy => 1.25,
+			_ => 1.0, // Regular, and graceful fallback for undefined enum values
+		};
+		var spacing = GenerateSpacingScale(baseSpacing * densityFactor);
 		var shape = GenerateShapeScale(DefaultCornerRadius);
 		var density = GenerateDensityDefaults();
 

--- a/src/samples/SamplesApp.Shared/Content/Styles/DesignTokensSamplePage.xaml
+++ b/src/samples/SamplesApp.Shared/Content/Styles/DesignTokensSamplePage.xaml
@@ -19,7 +19,7 @@
 						<TextBlock Text="Controls Preview"
 								   Style="{StaticResource TitleLarge}"
 								   Margin="0,16,0,4" />
-						<TextBlock Text="Override DefaultDensity or DefaultCornerRadius on the theme to see how these controls change globally."
+						<TextBlock Text="Override DefaultSpacing, DefaultDensity, or DefaultCornerRadius on the theme to see how these controls change globally."
 								   Style="{StaticResource BodySmall}"
 								   TextWrapping="Wrap"
 								   Opacity="0.6" />
@@ -199,7 +199,7 @@
 						<TextBlock Text="Controls Preview"
 								   Style="{StaticResource TitleLarge}"
 								   Margin="0,16,0,4" />
-						<TextBlock Text="Override DefaultDensity or DefaultCornerRadius on the theme to see how these controls change globally."
+						<TextBlock Text="Override DefaultSpacing, DefaultDensity, or DefaultCornerRadius on the theme to see how these controls change globally."
 								   Style="{StaticResource BodySmall}"
 								   TextWrapping="Wrap"
 								   Opacity="0.6" />

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_DesignTokens.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_DesignTokens.cs
@@ -20,12 +20,14 @@ public class Given_DesignTokens
 
 	private static (Grid container, SimpleTheme theme) CreateThemedContainer(
 		Density density = Density.Regular,
-		double cornerRadius = 4.0)
+		double cornerRadius = 4.0,
+		double spacing = double.NaN)
 	{
 		var theme = new SimpleTheme
 		{
 			DefaultDensity = density,
 			DefaultCornerRadius = cornerRadius,
+			DefaultSpacing = spacing,
 		};
 		var container = new Grid();
 		container.Resources.MergedDictionaries.Add(theme);
@@ -270,7 +272,107 @@ public class Given_DesignTokens
 	}
 
 	// ═══════════════════════════════════════════════════════════════════════
-	// 8. VISUAL INTEGRATION — render actual controls, verify layout values
+	// 8. DEFAULT SPACING — base unit; the density mode scales it (×0.75/×1/×1.25)
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(6.0, "Space0", 0.0)]     // zero is always zero
+	[DataRow(6.0, "Space050", 3.0)]   // base=6 × 0.5
+	[DataRow(6.0, "Space100", 6.0)]   // base=6 × 1
+	[DataRow(6.0, "Space400", 24.0)]  // base=6 × 4
+	[DataRow(2.5, "Space200", 5.0)]   // fractional base
+	[DataRow(0.0, "Space100", 0.0)]   // zero is a valid base
+	public void When_DefaultSpacingSet_Then_SpaceTokenHasCorrectValue(
+		double spacing, string tokenKey, double expected)
+	{
+		var (container, _) = CreateThemedContainer(Density.Regular, spacing: spacing);
+		var actual = GetResource<double>(container, tokenKey);
+		Assert.AreEqual(expected, actual, 0.001,
+			$"{tokenKey} at DefaultSpacing={spacing}: expected {expected}, got {actual}");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(Density.Compact, 6.0, 4.5)]  // 6 × 0.75
+	[DataRow(Density.Regular, 6.0, 6.0)]  // 6 × 1
+	[DataRow(Density.Comfy, 6.0, 7.5)]    // 6 × 1.25
+	[DataRow(Density.Compact, 8.0, 6.0)]  // 8 × 0.75
+	public void When_DefaultSpacingAndDensitySet_Then_TheyCompose(
+		Density density, double spacing, double expectedBase)
+	{
+		// Density is a mode over the spacing base unit, not a competing setting:
+		// effective base = DefaultSpacing × density factor.
+		var (container, _) = CreateThemedContainer(density, spacing: spacing);
+		Assert.AreEqual(expectedBase, GetResource<double>(container, "Space100"), 0.001);
+		Assert.AreEqual(expectedBase * 2, GetResource<double>(container, "Space200"), 0.001);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_DefaultSpacingSet_Then_ThicknessCompanionsDeriveFromIt()
+	{
+		var (container, _) = CreateThemedContainer(Density.Regular, spacing: 6.0);
+
+		Assert.AreEqual(new Thickness(12), GetResource<Thickness>(container, "Space200Thickness"));
+		Assert.AreEqual(new Thickness(6, 0, 6, 0), GetResource<Thickness>(container, "Space100HorizontalThickness"));
+		Assert.AreEqual(new Thickness(0, 6, 0, 0), GetResource<Thickness>(container, "Space100TopThickness"));
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_DefaultSpacingChangedAtRuntime_Then_DensityModeStillApplies()
+	{
+		var (container, theme) = CreateThemedContainer(Density.Comfy);
+		Assert.AreEqual(5.0, GetResource<double>(container, "Space100"), 0.001,
+			"Default base (4) × Comfy (1.25) should be 5");
+
+		theme.DefaultSpacing = 6.0;
+		Assert.AreEqual(7.5, GetResource<double>(container, "Space100"), 0.001,
+			"New base (6) × Comfy (1.25) should be 7.5");
+
+		theme.DefaultSpacing = double.NaN;
+		Assert.AreEqual(5.0, GetResource<double>(container, "Space100"), 0.001,
+			"An invalid base (NaN) should restore the default base (4) × Comfy (1.25)");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(double.NaN)]
+	[DataRow(-1.0)]
+	[DataRow(double.PositiveInfinity)]
+	[DataRow(double.NegativeInfinity)]
+	public void When_DefaultSpacingInvalid_Then_FallsBackToDefaultBase(double invalid)
+	{
+		var (container, _) = CreateThemedContainer(Density.Comfy, spacing: invalid);
+		Assert.AreEqual(5.0, GetResource<double>(container, "Space100"), 0.001,
+			$"DefaultSpacing={invalid} should fall back to the default base (4) × Comfy (1.25)");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_DefaultSpacingChanges_Then_ShapeTokensAreUnaffected()
+	{
+		var (container, theme) = CreateThemedContainer(spacing: 6.0, cornerRadius: 4.0);
+		Assert.AreEqual(8.0, GetResource<double>(container, "Radius200"), 0.001);
+
+		theme.DefaultSpacing = 10.0;
+		Assert.AreEqual(8.0, GetResource<double>(container, "Radius200"), 0.001);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_DefaultSpacingSet_Then_FixedTokensAreConstant()
+	{
+		var (container, _) = CreateThemedContainer(spacing: 10.0);
+
+		Assert.AreEqual(40.0, GetResource<double>(container, "ControlHeightMedium"), 0.001);
+		Assert.AreEqual(24.0, GetResource<double>(container, "IconSizeMedium"), 0.001);
+		Assert.AreEqual(48.0, GetResource<double>(container, "TouchTargetMinSize"), 0.001);
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 9. VISUAL INTEGRATION — render actual controls, verify layout values
 	// ═══════════════════════════════════════════════════════════════════════
 
 	[TestMethod]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1688

## PR Type

What kind of change does this PR introduce?

- Feature

## Description

Adds a `DefaultSpacing` property and reworks `Density` into a pure, composable mode.

- **`DefaultSpacing`** (double DP on `BaseTheme`, default **4**) is the base spacing unit driving the whole `Space*` scale (and `Thickness` companions). Non-finite or negative values degrade to the default base of 4 instead of poisoning the scale.
- **`Density` is now a mode, not a value**: `Compact` / `Regular` / `Comfy` scale the base unit by ×0.75 / ×1 / ×1.25. The two axes are orthogonal and compose — `DefaultSpacing="6" DefaultDensity="Compact"` yields an effective base of 4.5, which the previous design (density presets carrying base-unit values) could not express.
- Factors are chosen so the default base reproduces the historical presets exactly (4 × 0.75/1/1.25 = 3/4/5): **density-only usage renders pixel-identically**.
- Fixed tokens (`ControlHeight*`, `IconSize*`, `TouchTargetMinSize`) remain invariant across both axes.

Design notes in `specs/07-default-spacing/progress.md`; a postmortem on the initial (rejected) override-beats-preset design is in `specs/lessons.md`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [x] Updated the documentation as needed:
	- [x] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [ ] Contains **No** breaking changes
  > **Breaking:** the `Density` enum no longer carries base-unit values (`Compact`=3/`Regular`=4/`Comfy`=5 → 0/1/2). XAML usage (`DefaultDensity="Compact"`) and default-rendered output are unaffected; only code persisting or casting `(int)Density` must migrate — set `DefaultSpacing` explicitly to reproduce a custom base unit. Detailed migration note in the commit's `BREAKING CHANGE` footer.

## Other information

Tested on **desktop (Skia)**, the CI-validated runtime-test target (not in the platform list above):

- Simple host, headless `--runtime-tests`, full suite: **171 cases — 0 failed, 1 skipped** (pre-existing `[Ignore]`d hot-reload leak guard). Includes 18 new/reworked `DefaultSpacing` cases (composition matrix, invalid-value fallbacks incl. NaN, runtime set/clear, thickness companions, shape independence, fixed-token invariance).
- Material head, `Given_DesignTokens` filter: **32 cases — 0 failed** (pre-existing density tests unchanged, outputs identical by construction).
- Builds clean — no new warnings in touched files.

## Internal Issue (If applicable):

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2Te8aeQaRnmftRLg2mCKL
