### PR TITLE
feat(samples): live spacing & density tuning applied to the running theme

### DIFF
--- a/doc/design-tokens.md
+++ b/doc/design-tokens.md
@@ -84,7 +84,7 @@ For spacing, the [density mode](#density-modes) (`DefaultDensity`) composes with
 >
 > Assigning them later does regenerate the `Radius*` and `Space*` token resources, but it does **not** restyle controls: neither the ones already on screen nor ones created afterwards. Unlike colors — which *can* change live, see [Runtime Seed Color Changes](seed-colors.md#runtime-seed-color-changes) — these tokens are `CornerRadius` / `Thickness` / `double` **values**, and the per-control keys that consume them (`ButtonCornerRadius`, `ButtonPadding`, …) are resolved once when the theme's control-style dictionaries are first parsed. There is no live instance to update, so the new value never reaches the control templates.
 >
-> If you need to offer density or shape as a user setting, change the property and then recreate the root content (or re-navigate) so the styles are applied fresh.
+> If you need to offer density or shape as a user setting, change the property and then recreate the root content (or re-navigate) so the styles are applied fresh. The **Spacing & Density** sample page (`SpacingDensitySamplePage` in the sample apps) demonstrates a live variant of this recipe: as you drag the spacing slider or switch density modes it reloads the running theme's style layer, applies the new values, and forces a theme-change pass so the whole app restyles in place.
 
 ### Via Lightweight Styling
 

--- a/specs/08-spacing-density-live-sample/progress.md
+++ b/specs/08-spacing-density-live-sample/progress.md
@@ -1,0 +1,99 @@
+# Live spacing & density sample page (stacked on #1701)
+
+Stacked PR on `dev/sb/default-spacing` (PR #1701 — `DefaultSpacing` base unit + Density as a
+pure mode). Adds the interactive counterpart to the Seed Color sample: slide the base spacing
+unit and switch density modes, and watch the spacing tokens and the styled controls of the
+**whole running app** update live — global, like the seed color picker, per explicit user
+request (an earlier scoped-sandbox design was rejected: "i want the slider and selections to
+affect the entire app at runtime").
+
+## Design
+
+Why this needs more than setting the DPs: `DefaultSpacing` / `DefaultDensity` changes on the
+running theme regenerate the raw `Space*` token resources, but the per-control alias keys
+(`ButtonPadding` → `Space400HorizontalThickness` StaticResource aliases in the control-style
+layer) materialize lazily on first lookup and are then cached for the dictionary's lifetime —
+and rendered controls only re-evaluate `{ThemeResource}` bindings on a theme-change pass. The
+color picker gets live updates for free because semantic brushes are singleton instances
+mutated in place; spacing tokens are `double`/`Thickness` values with no instance to mutate.
+
+The page therefore applies knob changes to the running app theme in three steps
+(`ApplyToTheme` in the page code-behind — sample-level only, no library changes):
+
+1. **Reload the theme's static control-style layer** in place
+   (`theme.Source = new Uri(theme.Source.OriginalString)`) so the per-control alias keys
+   re-materialize lazily against the new scale. The theme instance keeps its `Colors` /
+   font configuration — nothing to copy.
+2. **Set `DefaultSpacing` / `DefaultDensity`** — the property-changed callbacks rebuild the
+   dynamic token layers via `UpdateSource()`. (Guarded: the reload only happens when at least
+   one DP will actually change, so `UpdateSource()` is guaranteed to run after the reload.)
+3. **Force a theme-change pass** (flip the root's `RequestedTheme` to the opposite of
+   `ActualTheme` and restore it, synchronously) so every live `{ThemeResource}` binding —
+   style setters like `ButtonPadding`, the page's token bars — re-resolves app-wide. Same
+   machinery as a dark/light switch; both writes happen in one dispatcher frame, so no flash.
+
+Fallback if the in-place `Source` reload turns out not to refresh the alias cache (empirically
+verified by the mechanism runtime tests below): swap a fresh theme instance of the same runtime
+type into `Application.Resources.MergedDictionaries` (fresh-instance re-resolution is already
+proven by the pre-existing §8 visual tests), copying `Colors` and override sources.
+
+Known limitation, documented on the page: values baked with `{StaticResource Space*}` *inside*
+control templates (a handful of margins in NavigationView/Flyout/etc.) refresh only when the
+template re-applies — the same coverage a dark/light switch achieves.
+
+The slider snaps to 0.5-px steps, so a full drag produces at most ~24 apply passes.
+The knobs initialize from the running theme's current values, so page state survives
+navigation with no static bookkeeping.
+
+## Checklist
+
+- [x] Mechanism runtime tests (Material head `Given_DesignTokens`):
+  - [x] fresh-theme swap + `RequestedTheme` flip restyles an already-rendered button
+  - [x] in-place `Source` reload + DP change + flip restyles an already-rendered button
+- [x] `SpacingDensitySamplePage.xaml(.cs)` under `src/samples/SamplesApp.Shared/Content/Styles/`
+      (Material + Simple designs, global apply via the running theme)
+- [x] Registered in `SamplesApp.Shared.projitems`
+- [x] Material-head runtime test: composition on a rendered control —
+      `DefaultSpacing=6` × `Compact` → `FilledButtonStyle` Padding `(18,0,18,0)`
+- [x] Material-head runtime test: end-to-end page test — drive the slider/density combo,
+      assert the app theme carries the values and the rendered preview button restyled live
+      (restores the global theme in `finally`)
+- [x] `doc/design-tokens.md`: pointer to the interactive sample
+- [x] Build clean (desktop TFM, Material + Simple heads); runtime tests green headlessly
+
+## Review
+
+Implemented as designed — sample-level only, driven entirely through existing public API
+(`SemanticThemeHelper.GetTheme()`, `ResourceDictionary.Source`, `DefaultSpacing`,
+`DefaultDensity`, `RequestedTheme`). Both candidate mechanisms were verified empirically
+before choosing; the page uses the in-place `Source` reload (keeps `Colors`/font
+configuration on the instance — nothing to copy), and the fresh-instance swap test remains
+as documentation of the fallback recipe.
+
+Verification (net10.0-desktop Debug, headless `--runtime-tests` runs on Windows, 2026-08-20):
+- Material head, `Given_DesignTokens` filter: **36 cases, 0 failed**, including the four new
+  tests — `When_FilledButton_WithCustomSpacingAndCompactDensity_Then_PaddingComposes`,
+  `When_ThemeSwappedAndThemeFlipped_Then_RenderedButtonRestyles`,
+  `When_SourceReloadedAfterSpacingChangeAndThemeFlipped_Then_RenderedButtonRestyles`, and the
+  end-to-end `When_SpacingDensitySamplePage_KnobsChanged_Then_AppThemeRestylesLive` (loads the
+  real page, drives `SpacingSlider`/`DensityCombo`, asserts the app theme carries 8/Compact and
+  the already-rendered preview button restyled to `(24,0,24,0)`, restores the theme in
+  `finally`).
+- Simple head, full suite: **171 cases, 0 failed** — the shared page compiles and registers
+  under the Simple head with no regressions.
+- Both heads build with 0 errors; the only warnings are the pre-existing shared-project
+  nullable warnings also present on the base branch (none from the added files — the one new
+  CS8600 that appeared in an intermediate build was fixed by pattern-matching the
+  `Activator.CreateInstance` result before it was ever committed, and that code path was later
+  replaced by the in-place reload anyway).
+
+Empirical findings worth keeping (they refine the base PR's construction-time story):
+- A `RequestedTheme` flip (opposite of `ActualTheme`, then restore, synchronously) re-resolves
+  `{ThemeResource}` style-setter bindings of already-rendered controls — including
+  `Thickness`-valued ones like `ButtonPadding` — against the *current* resource graph, so a
+  swapped or reloaded theme takes effect without recreating content.
+- Re-setting `ResourceDictionary.Source` to the same URI on a live `BaseTheme` re-creates the
+  static style layer with fresh lazy alias entries (it is not a same-value no-op), and the
+  theme's own `UpdateSource()` afterwards re-attaches the dynamic layers cleanly. The reload
+  must only be done when a subsequent DP change is guaranteed (the page guards this), since the
+  dynamic layers are gone until `UpdateSource()` runs.

--- a/specs/lessons.md
+++ b/specs/lessons.md
@@ -143,3 +143,16 @@ Domain lessons and postmortems for the Uno.Themes repo. Append new entries at th
 
 **Verification trap (the more important lesson):** these font tests **passed in the minimal dedicated `Uno.Themes.RuntimeTests` host but failed in `SimpleSampleApp`** (and therefore in CI). The dedicated host merges `<SimpleTheme/>` app-wide, which "warms" the ambient resolution scope so the fragile `<StaticResource>` aliases happen to resolve to the right weight — a **false positive**. The real consumer-like host (`SimpleSampleApp`, also what CI runs) exposed the bug.
 - **Always verify font/typography/resource-precedence changes in `SimpleSampleApp` (the CI host), not only in a minimal host.** A minimal single-theme host can mask cross-dictionary resolution and merge-order bugs. If two hosts disagree, trust the one that matches CI.
+
+---
+
+## "Like the seed color picker" means app-wide live application — confirm blast radius before building a sandboxed preview
+
+**Context:** PR #1702 (spacing & density live sample, stacked on #1701). The request was "density and spacing tokens updating at runtime live … just like the color picker for the color seed". The first implementation was a *scoped* sandbox (fresh theme merged into a preview panel only) because the library documents `DefaultSpacing`/`DefaultDensity` as construction-time. The user corrected: they wanted the sliders to restyle the **entire running app**, exactly as `SemanticThemeHelper.PrimarySeed` does.
+
+**How to apply:**
+- When a sample or feature is asked to behave "like" an existing one, the comparison defines the **scope of effect** (app-wide vs. local), not just the interaction pattern. If the reference feature is global, build global — or ask before narrowing scope on technical-limitation grounds.
+- A documented limitation ("construction-time", "requires content recreation") bounds the *default* library behavior, not what a determined caller can do. Verify empirically before treating it as a hard wall. For this repo specifically, two recipes make already-rendered controls pick up a new spacing/shape scale live, both proven by `Given_DesignTokens` runtime tests in the Material head:
+  1. re-set `theme.Source` to its own URI (re-creates the static style layer with fresh lazy `<StaticResource>` alias entries — not a same-value no-op), then change a token DP so `UpdateSource()` re-attaches the dynamic layers, **then**
+  2. flip the root's `RequestedTheme` to the opposite of `ActualTheme` and restore it synchronously — this re-resolves `{ThemeResource}` style-setter bindings (including `Thickness` values) against the current resource graph, same machinery as a dark/light switch.
+  Only reload `Source` when a DP change is guaranteed to follow, since the dynamic layers are missing until `UpdateSource()` runs. `{StaticResource Space*}` refs *inside* control templates stay stale until re-templating — same coverage as a dark/light switch.

--- a/src/samples/MaterialSampleApp/RuntimeTests/Given_DesignTokens.cs
+++ b/src/samples/MaterialSampleApp/RuntimeTests/Given_DesignTokens.cs
@@ -20,10 +20,12 @@ public class Given_DesignTokens
 
 	private static (Grid container, MaterialTheme theme) CreateThemedContainer(
 		Density density = Density.Regular,
-		double cornerRadius = 4.0)
+		double cornerRadius = 4.0,
+		double spacing = 4.0)
 	{
 		var theme = new MaterialTheme
 		{
+			DefaultSpacing = spacing,
 			DefaultDensity = density,
 			DefaultCornerRadius = cornerRadius,
 		};
@@ -328,6 +330,167 @@ public class Given_DesignTokens
 		// ButtonCornerRadius = Radius500CornerRadius = CornerRadius(6×5=30)
 		Assert.AreEqual(new CornerRadius(30), button.CornerRadius,
 			"FilledButton CornerRadius should be 30 at base=6 (Radius500 = 6×5)");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_FilledButton_WithCustomSpacingAndCompactDensity_Then_PaddingComposes()
+	{
+		var (container, _) = CreateThemedContainer(Density.Compact, spacing: 6.0);
+
+		var style = container.Resources["FilledButtonStyle"] as Style;
+		Assert.IsNotNull(style, "FilledButtonStyle should exist");
+
+		var button = new Button { Content = "Composed", Style = style };
+		container.Children.Add(button);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(button);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		// ButtonPadding = Space400HorizontalThickness = (6 × 0.75) × 4 = 18
+		Assert.AreEqual(new Thickness(18, 0, 18, 0), button.Padding,
+			"FilledButton Padding should compose DefaultSpacing × Compact factor (6 × 0.75 × 4 = 18)");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 8.bis LIVE RESTYLE — an already-rendered control picks up a new spacing
+	//        scale after the theme is refreshed and a theme-change pass forces
+	//        ThemeResource bindings to re-resolve
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_ThemeSwappedAndThemeFlipped_Then_RenderedButtonRestyles()
+	{
+		var (container, _) = CreateThemedContainer();
+
+		var style = container.Resources["FilledButtonStyle"] as Style;
+		Assert.IsNotNull(style, "FilledButtonStyle should exist");
+
+		var button = new Button { Content = "Live", Style = style };
+		container.Children.Add(button);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(button);
+		await UnitTestsUIContentHelper.WaitForIdle();
+		Assert.AreEqual(new Thickness(16, 0, 16, 0), button.Padding,
+			"Sanity: Regular density padding before the swap");
+
+		// Swap in a fresh theme carrying the new scale, then force a theme-change pass so the
+		// already-applied style's ThemeResource setters re-resolve against it.
+		var dense = new MaterialTheme
+		{
+			DefaultSpacing = 8.0,
+			DefaultDensity = Density.Compact,
+		};
+		container.Resources.MergedDictionaries.Clear();
+		container.Resources.MergedDictionaries.Add(dense);
+
+		FlipRequestedTheme(container);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		// ButtonPadding = Space400HorizontalThickness = (8 × 0.75) × 4 = 24
+		Assert.AreEqual(new Thickness(24, 0, 24, 0), button.Padding,
+			"The rendered button should restyle to the swapped theme's composed padding (8 × 0.75 × 4 = 24)");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_SourceReloadedAfterSpacingChangeAndThemeFlipped_Then_RenderedButtonRestyles()
+	{
+		var (container, theme) = CreateThemedContainer();
+
+		var style = container.Resources["FilledButtonStyle"] as Style;
+		Assert.IsNotNull(style, "FilledButtonStyle should exist");
+
+		var button = new Button { Content = "Live", Style = style };
+		container.Children.Add(button);
+
+		UnitTestsUIContentHelper.Content = container;
+		await UnitTestsUIContentHelper.WaitForLoaded(button);
+		await UnitTestsUIContentHelper.WaitForIdle();
+		Assert.AreEqual(new Thickness(16, 0, 16, 0), button.Padding,
+			"Sanity: Regular density padding before the change");
+
+		// Reload the static control-style layer in place so its per-control alias keys
+		// (ButtonPadding → Space400HorizontalThickness) re-materialize, set the new scale
+		// (the property-changed callbacks rebuild the dynamic token layers), then force a
+		// theme-change pass so live ThemeResource bindings re-resolve.
+		theme.Source = new Uri(theme.Source.OriginalString);
+		theme.DefaultSpacing = 8.0;
+		theme.DefaultDensity = Density.Compact;
+
+		FlipRequestedTheme(container);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		// ButtonPadding = Space400HorizontalThickness = (8 × 0.75) × 4 = 24
+		Assert.AreEqual(new Thickness(24, 0, 24, 0), button.Padding,
+			"The rendered button should restyle to the reloaded theme's composed padding (8 × 0.75 × 4 = 24)");
+	}
+
+	private static void FlipRequestedTheme(FrameworkElement root)
+	{
+		var original = root.RequestedTheme;
+		root.RequestedTheme = root.ActualTheme == ElementTheme.Dark ? ElementTheme.Light : ElementTheme.Dark;
+		root.RequestedTheme = original;
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 9. SAMPLE-PAGE INTEGRATION — the spacing & density page applies the knob
+	//    values to the RUNNING app theme and restyles the live tree
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_SpacingDensitySamplePage_KnobsChanged_Then_AppThemeRestylesLive()
+	{
+		var theme = SemanticThemeHelper.GetTheme();
+		Assert.IsNotNull(theme, "The sample app should carry a BaseTheme in Application.Resources");
+
+		var originalSpacing = theme.DefaultSpacing;
+		var originalDensity = theme.DefaultDensity;
+		var page = new Samples.Content.Styles.SpacingDensitySamplePage();
+		try
+		{
+			UnitTestsUIContentHelper.Content = page;
+			await UnitTestsUIContentHelper.WaitForLoaded(page);
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			var slider = page.FindName("SpacingSlider") as Slider;
+			var combo = page.FindName("DensityCombo") as ComboBox;
+			var button = page.FindName("PreviewFilledButton") as Button;
+			Assert.IsNotNull(slider, "SpacingSlider should exist");
+			Assert.IsNotNull(combo, "DensityCombo should exist");
+			Assert.IsNotNull(button, "PreviewFilledButton should exist");
+
+			slider.Value = 8;
+			combo.SelectedIndex = 0; // Compact
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			// The page writes through to the running app theme…
+			Assert.AreEqual(8.0, theme.DefaultSpacing, 0.001, "The page should apply DefaultSpacing to the app theme");
+			Assert.AreEqual(Density.Compact, theme.DefaultDensity, "The page should apply DefaultDensity to the app theme");
+
+			// …and the already-rendered preview button restyles live:
+			// ButtonPadding = Space400HorizontalThickness = (8 × 0.75) × 4 = 24
+			Assert.AreEqual(new Thickness(24, 0, 24, 0), button.Padding,
+				"The rendered preview Button should restyle live to the composed padding (8 × 0.75 × 4 = 24)");
+		}
+		finally
+		{
+			// Restore the global theme for subsequent tests, using the same recipe as the page.
+			if (theme.DefaultSpacing != originalSpacing || theme.DefaultDensity != originalDensity)
+			{
+				theme.Source = new Uri(theme.Source.OriginalString);
+				theme.DefaultSpacing = originalSpacing;
+				theme.DefaultDensity = originalDensity;
+				if (page.XamlRoot?.Content is FrameworkElement root)
+				{
+					FlipRequestedTheme(root);
+				}
+			}
+		}
 	}
 
 }

--- a/src/samples/SamplesApp.Shared/Content/Styles/SpacingDensitySamplePage.xaml
+++ b/src/samples/SamplesApp.Shared/Content/Styles/SpacingDensitySamplePage.xaml
@@ -1,0 +1,140 @@
+<Page x:Class="Uno.Themes.Samples.Content.Styles.SpacingDensitySamplePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<ScrollViewer>
+		<StackPanel Spacing="8" Margin="24,0" MaxWidth="1200">
+
+			<!-- Header -->
+			<TextBlock Text="Spacing &amp; Density"
+					   Style="{StaticResource HeadlineSmall}"
+					   Margin="0,16,0,4" />
+			<TextBlock Text="Adjust the base spacing unit (DefaultSpacing) and the density mode (DefaultDensity) on the running theme, and watch the whole app restyle live. The two axes compose: effective base = DefaultSpacing × density factor."
+					   Style="{StaticResource BodyMedium}"
+					   Opacity="0.7"
+					   TextWrapping="Wrap" />
+
+			<!-- Knobs -->
+			<Grid ColumnSpacing="24" Margin="0,8,0,0">
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="2*" />
+					<ColumnDefinition Width="*" />
+				</Grid.ColumnDefinitions>
+				<Slider x:Name="SpacingSlider"
+						Header="DefaultSpacing — base unit (px)"
+						Minimum="0"
+						Maximum="12"
+						StepFrequency="0.5"
+						SnapsTo="StepValues"
+						Value="4"
+						ValueChanged="OnSpacingChanged" />
+				<ComboBox x:Name="DensityCombo"
+						  Grid.Column="1"
+						  Header="DefaultDensity"
+						  HorizontalAlignment="Stretch"
+						  VerticalAlignment="Bottom"
+						  SelectionChanged="OnDensityChanged">
+					<ComboBoxItem Content="Compact (×0.75)" />
+					<ComboBoxItem Content="Regular (×1)" />
+					<ComboBoxItem Content="Comfy (×1.25)" />
+				</ComboBox>
+			</Grid>
+			<TextBlock x:Name="EffectiveBaseText"
+					   Style="{StaticResource LabelLarge}" />
+			<TextBlock x:Name="TokenValuesText"
+					   Style="{StaticResource BodySmall}"
+					   Opacity="0.6"
+					   TextWrapping="Wrap" />
+
+			<!-- Spacing token bars -->
+			<TextBlock Text="Spacing Tokens"
+					   Style="{StaticResource TitleMedium}"
+					   Margin="0,16,0,4" />
+			<TextBlock Text="Bars show the actual pixel width of each spacing token."
+					   Style="{StaticResource BodySmall}"
+					   Opacity="0.6" />
+			<StackPanel Spacing="4">
+				<StackPanel Orientation="Horizontal" Spacing="8">
+					<Border Background="{ThemeResource TertiaryBrush}" Width="{ThemeResource Space050}" Height="16" />
+					<TextBlock Text="Space050" VerticalAlignment="Center" Style="{StaticResource LabelSmall}" />
+				</StackPanel>
+				<StackPanel Orientation="Horizontal" Spacing="8">
+					<Border Background="{ThemeResource TertiaryBrush}" Width="{ThemeResource Space100}" Height="16" />
+					<TextBlock Text="Space100" VerticalAlignment="Center" Style="{StaticResource LabelSmall}" />
+				</StackPanel>
+				<StackPanel Orientation="Horizontal" Spacing="8">
+					<Border Background="{ThemeResource TertiaryBrush}" Width="{ThemeResource Space150}" Height="16" />
+					<TextBlock Text="Space150" VerticalAlignment="Center" Style="{StaticResource LabelSmall}" />
+				</StackPanel>
+				<StackPanel Orientation="Horizontal" Spacing="8">
+					<Border Background="{ThemeResource TertiaryBrush}" Width="{ThemeResource Space200}" Height="16" />
+					<TextBlock Text="Space200" VerticalAlignment="Center" Style="{StaticResource LabelSmall}" />
+				</StackPanel>
+				<StackPanel Orientation="Horizontal" Spacing="8">
+					<Border Background="{ThemeResource TertiaryBrush}" Width="{ThemeResource Space300}" Height="16" />
+					<TextBlock Text="Space300" VerticalAlignment="Center" Style="{StaticResource LabelSmall}" />
+				</StackPanel>
+				<StackPanel Orientation="Horizontal" Spacing="8">
+					<Border Background="{ThemeResource TertiaryBrush}" Width="{ThemeResource Space400}" Height="16" />
+					<TextBlock Text="Space400" VerticalAlignment="Center" Style="{StaticResource LabelSmall}" />
+				</StackPanel>
+				<StackPanel Orientation="Horizontal" Spacing="8">
+					<Border Background="{ThemeResource TertiaryBrush}" Width="{ThemeResource Space600}" Height="16" />
+					<TextBlock Text="Space600" VerticalAlignment="Center" Style="{StaticResource LabelSmall}" />
+				</StackPanel>
+				<StackPanel Orientation="Horizontal" Spacing="8">
+					<Border Background="{ThemeResource TertiaryBrush}" Width="{ThemeResource Space800}" Height="16" />
+					<TextBlock Text="Space800" VerticalAlignment="Center" Style="{StaticResource LabelSmall}" />
+				</StackPanel>
+			</StackPanel>
+
+			<!-- Controls Preview -->
+			<TextBlock Text="Controls Preview"
+					   Style="{StaticResource TitleMedium}"
+					   Margin="0,24,0,4" />
+			<TextBlock Text="Standard controls restyled by the running theme — the rest of the app updates the same way."
+					   Style="{StaticResource BodySmall}"
+					   Opacity="0.6"
+					   Margin="0,0,0,8" />
+
+			<StackPanel Orientation="Horizontal" Spacing="12">
+				<Button x:Name="PreviewFilledButton"
+						Content="Filled"
+						Style="{StaticResource FilledButtonStyle}" />
+				<Button Content="Outlined" Style="{StaticResource OutlinedButtonStyle}" />
+				<Button Content="Text" Style="{StaticResource TextButtonStyle}" />
+			</StackPanel>
+			<TextBox PlaceholderText="Filled text field"
+					 Style="{StaticResource FilledTextBoxStyle}"
+					 MaxWidth="400"
+					 HorizontalAlignment="Left"
+					 Margin="0,8,0,0" />
+			<CheckBox Content="Checkbox" IsChecked="True" />
+			<RadioButton Content="Radio option" IsChecked="True" />
+			<ToggleSwitch Header="Toggle switch" IsOn="True" />
+
+			<!-- Usage Snippet -->
+			<TextBlock Text="Usage"
+					   Style="{StaticResource TitleMedium}"
+					   Margin="0,24,0,4" />
+			<TextBlock Text="Spacing and density are construction-time settings — declare them where the theme is defined. This page refreshes the running theme's style layer and forces a theme-change pass to demonstrate the effect live."
+					   Style="{StaticResource BodySmall}"
+					   Opacity="0.6"
+					   TextWrapping="Wrap" />
+			<Border Background="{ThemeResource SurfaceVariantBrush}"
+					CornerRadius="8"
+					Padding="16">
+				<TextBlock x:Name="XamlSnippet"
+						   FontFamily="Consolas, Courier New, monospace"
+						   Style="{StaticResource BodyMedium}"
+						   IsTextSelectionEnabled="True" />
+			</Border>
+
+			<Border Height="32" />
+		</StackPanel>
+	</ScrollViewer>
+</Page>

--- a/src/samples/SamplesApp.Shared/Content/Styles/SpacingDensitySamplePage.xaml.cs
+++ b/src/samples/SamplesApp.Shared/Content/Styles/SpacingDensitySamplePage.xaml.cs
@@ -1,0 +1,148 @@
+using System.Globalization;
+using System.Text;
+using Microsoft.UI.Xaml.Controls.Primitives;
+
+namespace Uno.Themes.Samples.Content.Styles;
+
+[SamplePage(
+	SampleCategory.Styles,
+	"Spacing & Density",
+	Description = "Adjust the DefaultSpacing base unit and the DefaultDensity mode on the running theme and watch the whole app restyle live.",
+	SortOrder = 21,
+	SupportedDesigns = new[] { Design.Material, Design.Simple })]
+public sealed partial class SpacingDensitySamplePage : Page
+{
+	// Tokens surfaced in the numeric readout, smallest to largest; matches the bars in the XAML.
+	private static readonly string[] ReadoutTokens = { "Space050", "Space100", "Space150", "Space200", "Space300", "Space400", "Space600", "Space800" };
+
+	private bool _initialized;
+
+	public SpacingDensitySamplePage()
+	{
+		this.InitializeComponent();
+
+		// The running theme is the single source of truth — the knobs reflect whatever it
+		// currently carries, so the page state survives navigation without extra bookkeeping.
+		var theme = SemanticThemeHelper.GetTheme();
+		SpacingSlider.Value = theme?.DefaultSpacing ?? 4d;
+		DensityCombo.SelectedIndex = (theme?.DefaultDensity ?? Density.Regular) switch
+		{
+			Density.Compact => 0,
+			Density.Comfy => 2,
+			_ => 1,
+		};
+		_initialized = true;
+		UpdateReadouts();
+	}
+
+	private Density SelectedDensity => DensityCombo.SelectedIndex switch
+	{
+		0 => Density.Compact,
+		2 => Density.Comfy,
+		_ => Density.Regular,
+	};
+
+	private void OnSpacingChanged(object sender, RangeBaseValueChangedEventArgs e)
+	{
+		if (_initialized)
+		{
+			ApplyToTheme();
+		}
+	}
+
+	private void OnDensityChanged(object sender, SelectionChangedEventArgs e)
+	{
+		if (_initialized)
+		{
+			ApplyToTheme();
+		}
+	}
+
+	private void ApplyToTheme()
+	{
+		if (SemanticThemeHelper.GetTheme() is not { } theme)
+		{
+			return;
+		}
+
+		var spacing = SpacingSlider.Value;
+		var density = SelectedDensity;
+		if (theme.DefaultSpacing == spacing && theme.DefaultDensity == density)
+		{
+			UpdateReadouts();
+			return;
+		}
+
+		// Spacing tokens are values (double/Thickness) with no live instance to mutate, so —
+		// unlike a seed-color change — restyling takes two extra steps beyond setting the DPs:
+		//
+		// 1. Reload the theme's static control-style layer. Its per-control alias keys
+		//    (ButtonPadding → Space400HorizontalThickness, …) materialize lazily on first lookup
+		//    and are then cached for the dictionary's lifetime; re-setting Source re-creates the
+		//    layer so they re-resolve against the new scale. The DP setters below then rebuild
+		//    the dynamic token layers via the theme's property-changed callbacks, keeping the
+		//    theme's Colors/font configuration intact (nothing to copy).
+		theme.Source = new Uri(theme.Source.OriginalString);
+		theme.DefaultSpacing = spacing;
+		theme.DefaultDensity = density;
+
+		// 2. Force every live ThemeResource binding to re-resolve — the same machinery as a
+		//    dark/light switch — so already-rendered controls pick the new values up.
+		RefreshLiveTree();
+
+		UpdateReadouts();
+	}
+
+	private void RefreshLiveTree()
+	{
+		if (XamlRoot?.Content is not FrameworkElement root)
+		{
+			return;
+		}
+
+		var original = root.RequestedTheme;
+		root.RequestedTheme = root.ActualTheme == ElementTheme.Dark ? ElementTheme.Light : ElementTheme.Dark;
+		root.RequestedTheme = original;
+	}
+
+	private void UpdateReadouts()
+	{
+		var resources = Application.Current.Resources;
+		var spacing = SpacingSlider.Value;
+		var density = SelectedDensity;
+
+		EffectiveBaseText.Text = resources.TryGetValue("Space100", out var space100) && space100 is double basePx
+			? $"Effective base unit (Space100): {basePx:0.##} px = {spacing:0.##} × {DensityFactor(density):0.00} ({density})"
+			: string.Empty;
+
+		var values = new StringBuilder();
+		foreach (var token in ReadoutTokens)
+		{
+			if (resources.TryGetValue(token, out var value) && value is double px)
+			{
+				if (values.Length > 0)
+				{
+					values.Append("   ");
+				}
+
+				values.Append(token).Append(" = ").Append(px.ToString("0.##", CultureInfo.CurrentCulture));
+			}
+		}
+
+		TokenValuesText.Text = values.ToString();
+
+		var themeName = SemanticThemeHelper.GetTheme()?.GetType().Name ?? nameof(BaseTheme);
+		var spacingValue = spacing.ToString("0.##", CultureInfo.InvariantCulture);
+		var densityAttribute = density == Density.Regular
+			? string.Empty
+			: $"\n{new string(' ', themeName.Length + 2)}DefaultDensity=\"{density}\"";
+		XamlSnippet.Text = $"<{themeName} DefaultSpacing=\"{spacingValue}\"{densityAttribute} />";
+	}
+
+	private static double DensityFactor(Density density) => density switch
+	{
+		Density.Compact => 0.75,
+		Density.Comfy => 1.25,
+		_ => 1.0,
+	};
+}

--- a/src/samples/SamplesApp.Shared/SamplesApp.Shared.projitems
+++ b/src/samples/SamplesApp.Shared/SamplesApp.Shared.projitems
@@ -401,6 +401,13 @@
     <Compile Include="$(MSBuildThisFileDirectory)Content\Styles\SeedColorSamplePage.xaml.cs">
       <DependentUpon>SeedColorSamplePage.xaml</DependentUpon>
     </Compile>
+    <Page Include="$(MSBuildThisFileDirectory)Content\Styles\SpacingDensitySamplePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Compile Include="$(MSBuildThisFileDirectory)Content\Styles\SpacingDensitySamplePage.xaml.cs">
+      <DependentUpon>SpacingDensitySamplePage.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)Styles\Button.xaml">


### PR DESCRIPTION
GitHub Issue (If applicable): related to #1688

Follow-up to #1701 (`DefaultSpacing` base unit + Density as a pure mode) — originally authored as a stacked PR on `dev/sb/default-spacing`, rebased onto `master` after #1701 squash-merged.

## PR Type

- Feature (sample apps only — no library changes)

## Description

Adds the interactive counterpart to the Seed Color sample: a **Spacing & Density** sample page (Material + Simple) with a `DefaultSpacing` slider (0–12 px, 0.5 steps) and a `DefaultDensity` selector. Dragging the slider or switching the density mode applies the values to the **running app theme** and restyles the whole app live — spacing token bars, control paddings, everything — the same global-live UX the seed color picker provides.

### Why this needs more than setting the DPs

Spacing tokens are `double`/`Thickness` **values**: unlike semantic brushes (singleton instances whose `Color` is rewritten in place), there is no live instance to mutate, and the per-control alias keys (`ButtonPadding` → `Space400HorizontalThickness`) materialize lazily and are cached for the style layer's lifetime. The page therefore applies changes in three steps (sample code, existing public API only):

1. reload the theme's static style layer in place (`theme.Source = new Uri(theme.Source.OriginalString)`) so the alias keys re-materialize against the new scale — the theme instance keeps its `Colors`/font configuration, nothing to copy;
2. set `DefaultSpacing` / `DefaultDensity` — the property-changed callbacks rebuild the dynamic token layers;
3. force a synchronous `RequestedTheme` flip (opposite of `ActualTheme`, then restore) so every live `{ThemeResource}` binding re-resolves app-wide — the same machinery as a dark/light switch, no flash.

Known limitation (noted on the page): values baked with `{StaticResource Space*}` *inside* control templates refresh only when the template re-applies — the same coverage a dark/light switch achieves.

### Tests (Material head `Given_DesignTokens`, all passing)

- `When_FilledButton_WithCustomSpacingAndCompactDensity_Then_PaddingComposes` — `DefaultSpacing=6` × Compact → rendered `FilledButtonStyle` padding `(18,0,18,0)`
- `When_ThemeSwappedAndThemeFlipped_Then_RenderedButtonRestyles` — fresh-theme swap + flip restyles an already-rendered button (documents the fallback recipe)
- `When_SourceReloadedAfterSpacingChangeAndThemeFlipped_Then_RenderedButtonRestyles` — the in-place reload recipe the page uses
- `When_SpacingDensitySamplePage_KnobsChanged_Then_AppThemeRestylesLive` — end-to-end: drives the real page's slider/combo, asserts the app theme carries the values and the rendered preview button restyled live; restores the global theme in `finally`

Verified headlessly on `net10.0-desktop` (Debug): Material head `Given_DesignTokens` filter — 36 cases, 0 failed; Simple head full suite — 171 cases, 0 failed. Design notes and verification log in `specs/08-spacing-density-live-sample/progress.md`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
	- [x] Desktop (Skia/Win32) — headless runtime tests, Material + Simple heads
- [x] Updated the documentation as needed:
	- [x] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc) — `design-tokens.md` points to the interactive sample
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [x] Contains **No** breaking changes

## Other information

No new resource keys, no public API changes — sample UI, runtime tests, and one doc paragraph only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQkrJ94oVLPFQbRxAgeweD