### PR TITLE
fix(themes): walk MergedDictionaries recursively in Application.GetTheme()

### DIFF
--- a/doc/seed-colors.md
+++ b/doc/seed-colors.md
@@ -183,6 +183,24 @@ if (theme?.Colors is { } colors)
 
 `SemanticThemeHelper.GetTheme()` is equivalent to `Application.Current.GetTheme()`.
 
+Both find the theme **wherever the application's resource graph merges it**, not only at the top level. That matters because the recommended layout puts it one level down: `App.xaml` itself yields no reloadable type, so moving the design system into a `ResourceDictionary` of its own is what makes theme edits reach a running app through hot reload.
+
+```xml
+<!-- App.xaml -->
+<ResourceDictionary Source="Styles/AppTheme.xaml" />
+
+<!-- Styles/AppTheme.xaml — the theme is one level below Application.Resources -->
+<ResourceDictionary xmlns:material="using:Uno.Material">
+    <ResourceDictionary.MergedDictionaries>
+        <material:MaterialTheme />
+    </ResourceDictionary.MergedDictionaries>
+</ResourceDictionary>
+```
+
+`MergedDictionaries` is walked breadth-first, so the shallowest theme wins and a repeated dictionary — the diamonds resource graphs form by construction — is visited once.
+
+**Across load contexts:** the match is by type, so the lookup does not reach a hosted guest when the host isolates `Uno.Themes` per context — the guest's `BaseTheme` is then a different type, and the lookup returns `null` at any depth. A hosted application should resolve its own `Application` from inside its own context and call `GetTheme()` on that.
+
 > [!TIP]
 > The Material and Simple sample apps in this repository include a **Seed Color** page (under *Styles*) with a live color picker — drag it and watch the entire app re-theme in real time, and switch between the two generation modes to compare them.
 
@@ -214,21 +232,21 @@ Used as the value for `BaseTheme.Colors` (i.e., `MaterialTheme.Colors` or `Simpl
 
 Static convenience class for runtime theme configuration.
 
-| Member          | Type     | Description                                                                                        |
-|-----------------|----------|----------------------------------------------------------------------------------------------------|
-| `GetTheme()`    | Method   | Returns the `BaseTheme` instance from `Application.Current.Resources`, or `null` if none is found. |
-| `PrimarySeed`   | Property | Gets or sets the primary seed color on the active theme. Setting regenerates the full palette.     |
-| `SecondarySeed` | Property | Gets or sets the secondary seed color. `null` to auto-derive from primary.                         |
-| `TertiarySeed`  | Property | Gets or sets the tertiary seed color. `null` to auto-derive from primary.                          |
-| `SeedColorMode` | Property | Gets or sets the generation mode on the active theme: `Fidelity` (default) or `TonalSpot`.         |
+| Member          | Type     | Description                                                                                         |
+|-----------------|----------|-----------------------------------------------------------------------------------------------------|
+| `GetTheme()`    | Method   | Returns the `BaseTheme` from `Application.Current.Resources` at any merge depth, or `null` if none. |
+| `PrimarySeed`   | Property | Gets or sets the primary seed color on the active theme. Setting regenerates the full palette.      |
+| `SecondarySeed` | Property | Gets or sets the secondary seed color. `null` to auto-derive from primary.                          |
+| `TertiarySeed`  | Property | Gets or sets the tertiary seed color. `null` to auto-derive from primary.                           |
+| `SeedColorMode` | Property | Gets or sets the generation mode on the active theme: `Fidelity` (default) or `TonalSpot`.          |
 
 ### `ApplicationExtensions`
 
 Extension methods on `Application` for theme access.
 
-| Member                       | Type             | Description                                                                                          |
-|------------------------------|------------------|------------------------------------------------------------------------------------------------------|
-| `GetTheme(this Application)` | Extension method | Returns the `BaseTheme` instance from the given application's resources, or `null` if none is found. |
+| Member                       | Type             | Description                                                                                           |
+|------------------------------|------------------|-------------------------------------------------------------------------------------------------------|
+| `GetTheme(this Application)` | Extension method | Returns the `BaseTheme` from the given application's resources at any merge depth, or `null` if none. |
 
 ## Color Precedence
 

--- a/specs/03-seed-color-palette/seed-color-palette.md
+++ b/specs/03-seed-color-palette/seed-color-palette.md
@@ -94,7 +94,7 @@ Seed colors are configured exclusively via `ThemeColors` (the `BaseTheme.Colors`
 
 | Member | Type | Description |
 |---|---|---|
-| `GetTheme()` | `BaseTheme` | Returns the `BaseTheme` from `Application.Current.Resources`, or `null`. |
+| `GetTheme()` | `BaseTheme` | Returns the `BaseTheme` from `Application.Current.Resources` at any merge depth, or `null`. |
 | `PrimarySeed` | `Color?` | Gets/sets the primary seed color on the active theme. |
 | `SecondarySeed` | `Color?` | Gets/sets the secondary seed color on the active theme. |
 | `TertiarySeed` | `Color?` | Gets/sets the tertiary seed color on the active theme. |
@@ -103,7 +103,7 @@ Creates a `ThemeColors` instance automatically if the theme doesn't have one yet
 
 ### `ApplicationExtensions` (instance-based theme lookup)
 
-`Extensions/ApplicationExtensions.cs` exposes `GetTheme(this Application)`: the same first-level `MergedDictionaries` scan as `SemanticThemeHelper.GetTheme()`, but against the resources of the `Application` instance the caller holds. `SemanticThemeHelper.GetTheme()` is a pure delegation to it on `Application.Current`. The extension is null-tolerant (a `null` application yields `null`).
+`Extensions/ApplicationExtensions.cs` exposes `GetTheme(this Application)`: a `MergedDictionaries` search against the resources of the `Application` instance the caller holds. The search is **breadth-first over the whole graph** (issue #1704, see `specs/10-gettheme-nested-walk/progress.md`) — the shallowest theme wins, a repeated dictionary is visited once so diamonds are free and a cycle cannot hang, the top level is answered without allocating, `ThemeDictionaries` is deliberately not walked, and the descent is bounded at 32 levels as a guard against a pathological graph. `SemanticThemeHelper.GetTheme()` is a pure delegation to it on `Application.Current`. The extension is null-tolerant (a `null` application yields `null`).
 
 Motivation: hosts that run several applications (e.g. Hot Design's ALC-hosted guest apps, the ALC wrapper sample in `specs/05-alc-wrapper-app/`) cannot reach a guest's theme through `Application.Current`, which is the host application. A caller that resolves the guest's `Application` instance can now fetch its theme directly. Because `Uno.Themes.WinUI` resolves from the default load context in those hosting setups, `BaseTheme` type identity is shared and the plain `OfType<BaseTheme>` match works across the ALC boundary — no reflection needed. Runtime coverage: `Given_ApplicationExtensions` in `src/samples/SimpleSampleApp/RuntimeTests/`.
 

--- a/specs/10-gettheme-nested-walk/progress.md
+++ b/specs/10-gettheme-nested-walk/progress.md
@@ -1,0 +1,99 @@
+# `Application.GetTheme()` walks nested MergedDictionaries (issue #1704)
+
+Implements https://github.com/unoplatform/Uno.Themes/issues/1704.
+
+> Numbered 10 because `specs/08-…` is claimed by PR #1702 and `specs/09-…` by PR #1707.
+
+## The gap
+
+`GetTheme(this Application)` (added in #1699) scanned only the top level:
+
+```csharp
+application?.Resources?.MergedDictionaries.OfType<BaseTheme>().FirstOrDefault();
+```
+
+An application that keeps its design system in a `ResourceDictionary` of its own was therefore
+reported as having **no theme** — and that is the layout the hot-reload guidance steers apps toward,
+because `App.xaml` yields no reloadable type, so a design system declared inline there can be written
+to and reloaded with nothing re-rendering. `SemanticThemeHelper.GetTheme()` inherited the same reach,
+being a pure delegation.
+
+## Design
+
+Breadth-first over `MergedDictionaries`, in `ApplicationExtensions.GetTheme` / `FindNestedTheme`:
+
+- **Breadth-first, shallowest wins**, first match within a level. Chosen so the previous behaviour is
+  preserved *exactly* for any application that already had a top-level theme — the walk only ever
+  extends the search, never changes which theme an existing app resolves.
+- **The top level is answered without allocating.** The inline-in-`App.xaml` layout is the common one
+  and the one that already worked; only a miss pays for the queue and the visited set.
+- **Visited set with reference semantics.** `ResourceDictionary` does not override equality, and
+  identity is what makes a repeated dictionary cheap and a cycle finite. Resource graphs are diamonds
+  by construction (several dictionaries merging one shared palette), so this is the normal case, not
+  the pathological one.
+- **`ThemeDictionaries` is not walked.** A design system is not an appearance-specific resource, and
+  enumerating that collection throws on some platforms (see `specs/lessons.md`).
+- **Depth bound of 32 levels**, where level 1 is "merged straight into `Application.Resources`". The
+  visited set is what rules out a cycle; the bound keeps the cost predictable on a pathological graph.
+  Mirrors the depth bound Uno's own theme-resolution walk carries for the same reason.
+
+## What the walk does *not* do: cross an ALC boundary
+
+The match is `is BaseTheme`, i.e. by type identity, so whether a host can reach a hosted guest's
+theme is decided by the host's assembly-sharing policy and **not** by depth. Both policies are now
+pinned by tests, having been measured rather than inferred:
+
+| Host policy for `Uno.Themes.WinUI` | Guest theme is a host `BaseTheme`? | `hostSide.GetTheme()` over a nested guest theme |
+|---|---|---|
+| shared with the default context (Hot Design's shape) | yes | found — this walk is exactly what was missing |
+| isolated per guest (`!Uno.Themes.WinUI`, the wrapper sample's policy) | no | `null` at any depth |
+
+A guest theme constructs cleanly in a secondary collectible context that shares `Uno.UI`, and merges
+into the host's resource graph under both policies; only the type match differs. So the isolated case
+needs the guest to resolve its own `Application` from inside its own context (the pattern PR #1703
+introduces via `NavigationHelper.CurrentApplication`) or a name-based match; the recursive walk is
+necessary but not sufficient there, and the test pins that so the walk is never mistaken for
+cross-ALC support. Recorded in the XML docs on `GetTheme` and in `doc/seed-colors.md`.
+
+## Checklist
+
+- [x] Red tests first, extending `Given_ApplicationExtensions`
+  - [x] theme one and two levels down
+  - [x] the same layout via a `Source`-loaded dictionary whose `MergedDictionaries` the XAML parser
+        populated (fixture: `RuntimeTests/NestedThemeFixture.xaml`) — this repo has been bitten before
+        by XAML-backed dictionaries behaving differently from code-built ones
+  - [x] `SemanticThemeHelper.GetTheme()` inherits the reach
+  - [x] a diamond the walk must traverse without revisiting or recursing forever
+  - [x] both edges of the depth bound (31 dictionaries deep found, 32 not)
+- [x] Red ALC tests in `Given_AlcApplicationExtensions`, one per sharing policy, built on a
+      collectible guest context that shares `Uno.UI` and mirrors the wrapper's share/isolate markers
+- [x] Breadth-first walk with visited set, allocation-free top level, depth bound
+- [x] XML docs: order, cycle guard, why `ThemeDictionaries` is skipped, the ALC caveat
+- [x] `doc/seed-colors.md`: the nested layout, the walk's order, the ALC note
+- [x] `specs/03-seed-color-palette/seed-color-palette.md`: the extension's description corrected
+- [x] Release build of the base library clean; full Simple suite green
+
+## Review
+
+Verification (`net10.0-desktop` Debug, headless `--runtime-tests`, 2026-08-31):
+
+- Red before the fix: 6 failures — the five nested/diamond/helper cases and the shared-assembly ALC
+  case — with the three pre-existing tests still passing, so the gap was depth and nothing else.
+- Green after: full Simple suite **180 passed, 0 failed, 1 pre-existing `[Ignore]` skip**; Material
+  head unchanged. The depth-bound rows land exactly where the doc says (31 found, 32 not), so the
+  loop bound and the documented contract agree.
+- `Uno.Themes.WinUI` Release build carries the same two pre-existing `CS0618` warnings as `master`.
+
+Every test rearranges `Application.Current.Resources` and restores it exactly, detaching the theme
+before re-parenting it (a `ResourceDictionary` may not be nested under two parents); the ~170 other
+tests, most of which resolve through the application theme, are unaffected.
+
+## Open items
+
+- **Releasing it.** The issue also asks for the extension to ship in a released package so apps and
+  tooling can rely on it instead of each writing their own walk; that is a release action, not a code
+  change, and is not covered here.
+- **Conflict with PR #1703.** That PR rewrites the same paragraph of
+  `specs/03-seed-color-palette/seed-color-palette.md` (the ALC motivation) and adds the guest-side
+  hand-off plus a host-side name-based check in the wrapper smoke. Whichever lands second should fold
+  the two descriptions together; the facts recorded here and there agree.

--- a/src/library/Uno.Themes/Extensions/ApplicationExtensions.cs
+++ b/src/library/Uno.Themes/Extensions/ApplicationExtensions.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+using System.Collections.Generic;
 
 #if WinUI
 using Microsoft.UI.Xaml;
@@ -14,9 +14,113 @@ namespace Uno.Themes;
 public static class ApplicationExtensions
 {
 	/// <summary>
-	/// Gets the <see cref="BaseTheme"/> instance from the given application's resources.
+	/// How many levels of <see cref="ResourceDictionary.MergedDictionaries"/> the walk descends.
+	/// Real resource graphs are a handful of levels deep; the bound is a guard against a
+	/// pathological graph, so that a caller's cost stays predictable even though the visited set
+	/// below is what rules out a cycle.
+	/// </summary>
+	private const int MaxDepth = 32;
+
+	/// <summary>
+	/// Gets the <see cref="BaseTheme"/> instance from the given application's resources, wherever
+	/// its resource graph merges it: <see cref="ResourceDictionary.MergedDictionaries"/> is walked
+	/// breadth-first, so the shallowest theme wins, and within a level the first one does.
 	/// Returns <c>null</c> if no <see cref="BaseTheme"/> is found, or if <paramref name="application"/> is <c>null</c>.
 	/// </summary>
-	public static BaseTheme GetTheme(this Application application) =>
-		application?.Resources?.MergedDictionaries.OfType<BaseTheme>().FirstOrDefault();
+	/// <remarks>
+	/// <para>
+	/// The walk exists because an application that keeps its design system in a
+	/// <see cref="ResourceDictionary"/> of its own — the layout hot-reload guidance recommends,
+	/// since <c>App.xaml</c> itself yields no reloadable type — merges the theme one or more levels
+	/// below <c>Application.Resources</c>. Repeated dictionaries are visited once, so the diamonds
+	/// that resource graphs form by construction (several dictionaries merging one shared palette)
+	/// cost nothing extra and a cycle cannot hang the walk.
+	/// </para>
+	/// <para>
+	/// <see cref="ResourceDictionary.ThemeDictionaries"/> is deliberately not walked: a design
+	/// system is not an appearance-specific resource, and enumerating that collection is not
+	/// supported on all platforms.
+	/// </para>
+	/// <para>
+	/// The match is by type, so this does not reach across an assembly-load-context boundary when
+	/// the host isolates <c>Uno.Themes</c> per context — the guest's <see cref="BaseTheme"/> is
+	/// then a different type. A hosted application should resolve its own <see cref="Application"/>
+	/// from inside its own context and call this on that.
+	/// </para>
+	/// </remarks>
+	/// <param name="application">The application whose resources to search. May be <c>null</c>.</param>
+	/// <returns>The theme, or <c>null</c> when the application merges none.</returns>
+	public static BaseTheme GetTheme(this Application application)
+	{
+		if (application?.Resources is not { } resources)
+		{
+			return null;
+		}
+
+		var topLevel = resources.MergedDictionaries;
+
+		// The theme merged straight into Application.Resources is both the layout that already
+		// worked and the common one, so it is answered without allocating anything.
+		for (var i = 0; i < topLevel.Count; i++)
+		{
+			if (topLevel[i] is BaseTheme theme)
+			{
+				return theme;
+			}
+		}
+
+		return topLevel.Count > 0 ? FindNestedTheme(resources) : null;
+	}
+
+	/// <summary>
+	/// Continues the search below the top level, breadth-first.
+	/// </summary>
+	/// <param name="resources">The application's resources, whose own level has already been searched.</param>
+	/// <returns>The shallowest theme below the top level, or <c>null</c>.</returns>
+	private static BaseTheme FindNestedTheme(ResourceDictionary resources)
+	{
+		// Reference semantics: ResourceDictionary does not override equality, and identity is what
+		// makes a repeated dictionary cheap and a cycle finite.
+		var visited = new HashSet<ResourceDictionary>() { resources };
+		var current = new List<ResourceDictionary>();
+		var next = new List<ResourceDictionary>();
+
+		var topLevel = resources.MergedDictionaries;
+		for (var i = 0; i < topLevel.Count; i++)
+		{
+			if (visited.Add(topLevel[i]))
+			{
+				current.Add(topLevel[i]);
+			}
+		}
+
+		// The top level is already searched, so start one below it.
+		for (var depth = 2; depth <= MaxDepth && current.Count > 0; depth++)
+		{
+			foreach (var dictionary in current)
+			{
+				var merged = dictionary.MergedDictionaries;
+				for (var i = 0; i < merged.Count; i++)
+				{
+					var child = merged[i];
+					if (!visited.Add(child))
+					{
+						continue;
+					}
+
+					if (child is BaseTheme theme)
+					{
+						return theme;
+					}
+
+					next.Add(child);
+				}
+			}
+
+			(current, next) = (next, current);
+			next.Clear();
+		}
+
+		return null;
+	}
 }

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_AlcApplicationExtensions.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_AlcApplicationExtensions.cs
@@ -1,0 +1,170 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Themes;
+using Uno.UI.RuntimeTests;
+
+namespace Uno.Themes.Samples.RuntimeTests;
+
+/// <summary>
+/// Verifies <c>application.GetTheme()</c> against a theme built in a secondary
+/// <see cref="AssemblyLoadContext"/>, which is the arrangement multi-app hosts run
+/// (Hot Design's guest apps, the <c>ThemesSampleApp</c> wrapper in <c>specs/05-alc-wrapper-app</c>)
+/// — combined with the nested-dictionary layout of issue #1704.
+/// </summary>
+/// <remarks>
+/// Whether the extension can see a guest's theme at all is decided by the host's assembly-sharing
+/// policy, not by depth, so both policies are covered here. The share-vs-isolate markers mirrored
+/// below are the wrapper's own, from <c>ThemesSampleApp/GuestHosting/GuestSharedAssemblies.txt</c>.
+/// </remarks>
+[TestClass]
+public class Given_AlcApplicationExtensions
+{
+	/// <summary>
+	/// A guest load context that isolates the assemblies named in <c>isolated</c> and shares
+	/// everything else with the default context — above all <c>Uno.UI</c>, so
+	/// <see cref="ResourceDictionary"/> keeps one identity across the boundary.
+	/// </summary>
+	private sealed class GuestAlc(string directory, params string[] isolated)
+		: AssemblyLoadContext("GuestAlc-" + string.Join("+", isolated), isCollectible: true)
+	{
+		protected override Assembly Load(AssemblyName assemblyName)
+		{
+			if (assemblyName.Name is { } name && isolated.Contains(name, StringComparer.Ordinal))
+			{
+				var path = Path.Combine(directory, name + ".dll");
+				if (File.Exists(path))
+				{
+					return LoadFromAssemblyPath(path);
+				}
+			}
+
+			// Everything else resolves from the default context.
+			return null;
+		}
+	}
+
+	private static string OutputDirectory
+		=> Path.GetDirectoryName(typeof(Given_AlcApplicationExtensions).Assembly.Location)!;
+
+	/// <summary>
+	/// Builds a <c>SimpleTheme</c> inside <paramref name="alc"/>, as a hosted guest application's
+	/// own resources would.
+	/// </summary>
+	/// <param name="alc">The guest load context.</param>
+	/// <returns>The guest theme, as the shared <see cref="ResourceDictionary"/> base type.</returns>
+	private static ResourceDictionary CreateGuestTheme(GuestAlc alc)
+	{
+		var guestSimple = alc.LoadFromAssemblyPath(Path.Combine(OutputDirectory, "Uno.Simple.WinUI.dll"));
+		var guestThemeType = guestSimple.GetType("Uno.Simple.SimpleTheme")
+			?? throw new InvalidOperationException("Uno.Simple.SimpleTheme not found in the guest context.");
+
+		return (ResourceDictionary)Activator.CreateInstance(guestThemeType)!;
+	}
+
+	/// <summary>
+	/// Nests <paramref name="guestTheme"/> one level below the application's resources, with the
+	/// application's own top-level theme taken away, and returns what the extension resolves.
+	/// The application's resources are restored before returning.
+	/// </summary>
+	/// <param name="guestTheme">The theme to merge, one level down.</param>
+	/// <returns>The theme the extension found, or <c>null</c>.</returns>
+	private static BaseTheme ResolveWithGuestThemeNested(ResourceDictionary guestTheme)
+	{
+		var appResources = Application.Current.Resources;
+		var original = appResources.MergedDictionaries.ToArray();
+		var hostThemes = original.OfType<BaseTheme>().ToArray();
+		var wrapper = new ResourceDictionary();
+
+		try
+		{
+			foreach (var hostTheme in hostThemes)
+			{
+				appResources.MergedDictionaries.Remove(hostTheme);
+			}
+
+			wrapper.MergedDictionaries.Add(guestTheme);
+			appResources.MergedDictionaries.Add(wrapper);
+
+			return Application.Current.GetTheme();
+		}
+		finally
+		{
+			appResources.MergedDictionaries.Remove(wrapper);
+			wrapper.MergedDictionaries.Clear();
+
+			appResources.MergedDictionaries.Clear();
+			foreach (var dictionary in original)
+			{
+				appResources.MergedDictionaries.Add(dictionary);
+			}
+		}
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Themes assembly SHARED with the host (Hot Design's hosting shape): BaseTheme has one
+	// identity across the boundary, so reaching a guest's theme is purely a question of depth —
+	// which is the gap #1704 closes.
+	// ─────────────────────────────────────────────────────────────────────
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_GuestSharesTheThemesAssembly_Then_NestedGuestThemeIsFound()
+	{
+		var alc = new GuestAlc(OutputDirectory, "Uno.Simple.WinUI");
+
+		try
+		{
+			var guestTheme = CreateGuestTheme(alc);
+
+			Assert.IsInstanceOfType(guestTheme, typeof(BaseTheme),
+				"With Uno.Themes.WinUI shared, a guest theme is a BaseTheme of the host's own type.");
+			Assert.AreNotSame(typeof(Uno.Simple.SimpleTheme), guestTheme.GetType(),
+				"The guest's SimpleTheme must come from the guest context, or this proves nothing.");
+
+			Assert.IsNotNull(ResolveWithGuestThemeNested(guestTheme),
+				"A guest application's theme, merged one level down as the recommended layout does, " +
+				"must be reachable through the instance-based extension.");
+		}
+		finally
+		{
+			alc.Unload();
+		}
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Themes assembly ISOLATED per guest (the wrapper sample's policy, `!Uno.Themes.WinUI`):
+	// BaseTheme identity is NOT shared, so no amount of depth makes the guest's theme matchable
+	// from the host. Pinned so a recursive walk is never mistaken for cross-ALC support.
+	// ─────────────────────────────────────────────────────────────────────
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_GuestIsolatesTheThemesAssembly_Then_HostSideLookupFindsNothing()
+	{
+		var alc = new GuestAlc(OutputDirectory, "Uno.Simple.WinUI", "Uno.Themes.WinUI");
+
+		try
+		{
+			var guestTheme = CreateGuestTheme(alc);
+
+			Assert.IsNotInstanceOfType(guestTheme, typeof(BaseTheme),
+				"With Uno.Themes.WinUI isolated, the guest's BaseTheme is a different type entirely.");
+			Assert.IsInstanceOfType(guestTheme, typeof(ResourceDictionary),
+				"Uno.UI stays shared, so the guest theme still merges into the host's resource graph.");
+
+			Assert.IsNull(ResolveWithGuestThemeNested(guestTheme),
+				"A guest theme built from an isolated Uno.Themes.WinUI cannot be matched by type from " +
+				"the host, at any depth. Reaching it requires the guest to resolve its own Application " +
+				"from inside its own context, or a name-based match.");
+		}
+		finally
+		{
+			alc.Unload();
+		}
+	}
+}

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_ApplicationExtensions.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_ApplicationExtensions.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+using Microsoft.UI.Xaml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Simple;
 using Uno.UI.RuntimeTests;
@@ -41,5 +44,211 @@ public class Given_ApplicationExtensions
 	public void When_ApplicationIsNull_Then_ReturnsNull()
 	{
 		Assert.IsNull(ApplicationExtensions.GetTheme(null));
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Nested layouts (issue #1704). App.xaml itself receives no Hot Reload updates, so the
+	// guidance is to move the design system into a ResourceDictionary of its own and merge
+	// that — which puts the BaseTheme one or more levels below Application.Resources.
+	// ─────────────────────────────────────────────────────────────────────
+
+	/// <summary>
+	/// Rearranges the application's resources into the layout the guidance recommends: the theme is
+	/// removed from the top level and merged into a chain of <paramref name="depth"/> plain
+	/// dictionaries, the outermost of which is merged into <c>Application.Resources</c>. The returned
+	/// disposable puts the application's resources back exactly as they were.
+	/// </summary>
+	/// <param name="depth">How many dictionaries to interpose between the application and the theme.</param>
+	/// <returns>A scope that restores the application's resources when disposed.</returns>
+	private static IDisposable NestApplicationTheme(int depth)
+	{
+		var appResources = Application.Current.Resources;
+		var original = appResources.MergedDictionaries.ToArray();
+		var themes = original.OfType<BaseTheme>().ToArray();
+
+		Assert.IsTrue(themes.Length > 0,
+			"This fixture needs the sample app's theme at the top level to move it down a level.");
+
+		// Detach before re-parenting: a ResourceDictionary may not be nested under two parents.
+		foreach (var theme in themes)
+		{
+			appResources.MergedDictionaries.Remove(theme);
+		}
+
+		var innermost = new ResourceDictionary();
+		foreach (var theme in themes)
+		{
+			innermost.MergedDictionaries.Add(theme);
+		}
+
+		var outermost = innermost;
+		for (var i = 1; i < depth; i++)
+		{
+			var parent = new ResourceDictionary();
+			parent.MergedDictionaries.Add(outermost);
+			outermost = parent;
+		}
+
+		appResources.MergedDictionaries.Add(outermost);
+
+		return new RestoreApplicationResources(outermost, innermost, themes, original);
+	}
+
+	private sealed class RestoreApplicationResources(
+		ResourceDictionary outermost,
+		ResourceDictionary innermost,
+		BaseTheme[] themes,
+		ResourceDictionary[] original) : IDisposable
+	{
+		public void Dispose()
+		{
+			var appResources = Application.Current.Resources;
+
+			appResources.MergedDictionaries.Remove(outermost);
+
+			foreach (var theme in themes)
+			{
+				innermost.MergedDictionaries.Remove(theme);
+			}
+
+			appResources.MergedDictionaries.Clear();
+			foreach (var dictionary in original)
+			{
+				appResources.MergedDictionaries.Add(dictionary);
+			}
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(1, DisplayName = "theme one level down")]
+	[DataRow(2, DisplayName = "theme two levels down")]
+	public void When_ThemeIsNestedBelowApplicationResources_Then_ThemeIsStillFound(int depth)
+	{
+		using var _ = NestApplicationTheme(depth);
+
+		var theme = Application.Current.GetTheme();
+
+		Assert.IsNotNull(theme,
+			$"GetTheme() must walk MergedDictionaries recursively; the theme is {depth} level(s) below " +
+			"Application.Resources, which is the layout hot-reload guidance recommends.");
+		Assert.IsInstanceOfType(theme, typeof(SimpleTheme));
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_ThemeIsNestedInASourceLoadedDictionary_Then_ThemeIsStillFound()
+	{
+		var appResources = Application.Current.Resources;
+		var original = appResources.MergedDictionaries.ToArray();
+		var themes = original.OfType<BaseTheme>().ToArray();
+
+		Assert.IsTrue(themes.Length > 0,
+			"This test needs the sample app's theme at the top level to take it away.");
+
+		ResourceDictionary? nested = null;
+
+		try
+		{
+			foreach (var theme in themes)
+			{
+				appResources.MergedDictionaries.Remove(theme);
+			}
+
+			// Unlike the programmatic cases above, this dictionary's MergedDictionaries are
+			// populated by the XAML parser from a Source, which is how a real application arrives
+			// at this layout — and this repo has been bitten before by XAML-backed dictionaries
+			// behaving differently from code-built ones (see specs/lessons.md).
+			nested = new ResourceDictionary
+			{
+				Source = new Uri("ms-appx:///RuntimeTests/NestedThemeFixture.xaml"),
+			};
+			appResources.MergedDictionaries.Add(nested);
+
+			var found = Application.Current.GetTheme();
+
+			Assert.IsNotNull(found,
+				"GetTheme() must find a theme merged by a Source-loaded dictionary of the application's own — " +
+				"the layout reported in issue #1704.");
+			Assert.IsInstanceOfType(found, typeof(SimpleTheme));
+		}
+		finally
+		{
+			if (nested is not null)
+			{
+				appResources.MergedDictionaries.Remove(nested);
+			}
+
+			appResources.MergedDictionaries.Clear();
+			foreach (var dictionary in original)
+			{
+				appResources.MergedDictionaries.Add(dictionary);
+			}
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_ThemeIsNested_Then_StaticHelperFindsItToo()
+	{
+		using var _ = NestApplicationTheme(depth: 1);
+
+		Assert.IsNotNull(SemanticThemeHelper.GetTheme(),
+			"SemanticThemeHelper.GetTheme() delegates to the extension, so it inherits the same reach.");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_NestedGraphHasACycle_Then_GetThemeDoesNotHang()
+	{
+		var appResources = Application.Current.Resources;
+		var original = appResources.MergedDictionaries.ToArray();
+		var themes = original.OfType<BaseTheme>().ToArray();
+
+		var first = new ResourceDictionary();
+		var second = new ResourceDictionary();
+		var shared = new ResourceDictionary();
+
+		try
+		{
+			foreach (var theme in themes)
+			{
+				appResources.MergedDictionaries.Remove(theme);
+			}
+
+			// A diamond (both branches merge one shared dictionary) with the theme at the bottom of
+			// the second branch, so a recursive walk meets the same dictionary twice and must not
+			// revisit it or recurse forever.
+			first.MergedDictionaries.Add(shared);
+			second.MergedDictionaries.Add(shared);
+			foreach (var theme in themes)
+			{
+				second.MergedDictionaries.Add(theme);
+			}
+
+			appResources.MergedDictionaries.Add(first);
+			appResources.MergedDictionaries.Add(second);
+
+			Assert.IsNotNull(Application.Current.GetTheme(),
+				"A diamond in the resource graph must not stop the walk from reaching the theme.");
+		}
+		finally
+		{
+			appResources.MergedDictionaries.Remove(first);
+			appResources.MergedDictionaries.Remove(second);
+			first.MergedDictionaries.Clear();
+			second.MergedDictionaries.Clear();
+
+			foreach (var theme in themes)
+			{
+				second.MergedDictionaries.Remove(theme);
+			}
+
+			appResources.MergedDictionaries.Clear();
+			foreach (var dictionary in original)
+			{
+				appResources.MergedDictionaries.Add(dictionary);
+			}
+		}
 	}
 }

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_ApplicationExtensions.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_ApplicationExtensions.cs
@@ -137,6 +137,22 @@ public class Given_ApplicationExtensions
 
 	[TestMethod]
 	[RunsOnUIThread]
+	[DataRow(31, true, DisplayName = "at the deepest level the walk descends to")]
+	[DataRow(32, false, DisplayName = "one level beyond the walk's bound")]
+	public void When_ThemeIsNestedAtTheDepthBound_Then_TheBoundHolds(int depth, bool expectFound)
+	{
+		using var _ = NestApplicationTheme(depth);
+
+		var theme = Application.Current.GetTheme();
+
+		Assert.AreEqual(expectFound, theme is not null,
+			$"A theme {depth} dictionaries below the application sits at level {depth + 1}; the walk " +
+			"descends 32 levels, and the bound is a guard against a pathological graph rather than a " +
+			"limit any real application meets.");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
 	public void When_ThemeIsNestedInASourceLoadedDictionary_Then_ThemeIsStillFound()
 	{
 		var appResources = Application.Current.Resources;

--- a/src/samples/SimpleSampleApp/RuntimeTests/NestedThemeFixture.xaml
+++ b/src/samples/SimpleSampleApp/RuntimeTests/NestedThemeFixture.xaml
@@ -1,0 +1,17 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:simple="using:Uno.Simple">
+
+	<!--
+		Fixture for Given_ApplicationExtensions (issue #1704). Reproduces the layout the
+		hot-reload guidance recommends and the issue reports as broken: a dictionary of the
+		application's own, merged by Source, which in turn merges the design system. The
+		MergedDictionaries below are populated by the XAML parser rather than from code, which
+		is the arrangement a recursive walk has to cope with in a real application.
+	-->
+
+	<ResourceDictionary.MergedDictionaries>
+		<simple:SimpleTheme />
+	</ResourceDictionary.MergedDictionaries>
+
+</ResourceDictionary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1704

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Documentation content changes

## Description

`GetTheme(this Application)` searched only the top level of `MergedDictionaries`, so an application
that keeps its design system in a `ResourceDictionary` of its own was reported as having **no theme**
— and that is the layout hot-reload guidance steers apps toward, because `App.xaml` yields no
reloadable type. `SemanticThemeHelper.GetTheme()` inherited the same reach, being a pure delegation.

The search is now breadth-first over the whole graph. Four decisions worth naming:

- **Shallowest wins, first match within a level.** Deliberate, so any application that already had a
  top-level theme resolves *the same instance* as before — the walk only extends the search, it never
  changes an existing answer. The three pre-existing tests pass untouched.
- **The top level allocates nothing.** The inline-in-`App.xaml` layout is both the common one and the
  one that already worked; only a miss pays for the frontier lists and the visited set.
- **Visited set with reference semantics.** `ResourceDictionary` does not override equality, so
  identity is what makes a repeated dictionary cheap and a cycle finite. Diamonds — several
  dictionaries merging one shared palette — are the *normal* case here, not the pathological one.
- **`ThemeDictionaries` is deliberately not walked.** A design system is not an appearance-specific
  resource, and enumerating that collection throws on some platforms (`specs/lessons.md`).

The 32-level bound the issue asks for is in, with both the code comment and the spec explicit that
the *visited set* is what prevents a hang; the bound only keeps cost predictable on a pathological
graph. It mirrors the bound Uno's own theme-resolution walk carries.

### The ALC half, measured rather than assumed

The match is `is BaseTheme`, i.e. by type identity, so whether a host can reach a hosted guest's
theme is decided by the host's **assembly-sharing policy** and not by depth. Both policies are pinned
by tests built on a collectible guest load context that shares `Uno.UI` and mirrors the wrapper
sample's share/isolate markers:

| Host policy for `Uno.Themes.WinUI` | Guest theme is a host `BaseTheme`? | Host-side `GetTheme()` over a nested guest theme |
|---|---|---|
| shared with the default context (Hot Design's shape) | yes | **was `null`, now found** — the case this walk closes |
| isolated per guest (`!Uno.Themes.WinUI`, the wrapper's policy) | no | `null` at any depth — pinned to stay that way |

A guest theme constructs cleanly in a secondary context and merges into the host's resource graph
under both policies; only the type match differs. The isolated case therefore needs the guest to
resolve its own `Application` from inside its own context, and the test exists so the recursive walk
is never mistaken for cross-ALC support. Stated in the XML docs and in `doc/seed-colors.md` too.

## PR Checklist

Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [x] MacOS
	<!-- Verified on Skia desktop (net10.0-desktop) via the headless runtime-test harness; no platform-specific code paths are touched. -->
- [x] Updated the documentation as needed:
	- [x] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc) — `doc/seed-colors.md`
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [x] Contains **No** breaking changes

## Other information

**Red first, in its own commits.** The three commits are red tests → ALC coverage → fix, so the gap
is demonstrable at `69fb71dd`/`7896e64b` and closed at `4f1364c7`. Before the fix: 6 failures with
the three pre-existing tests still passing, so the gap was depth and nothing else. Cases pinned:
one and two levels down; the same layout reached through a **`Source`-loaded** dictionary whose
`MergedDictionaries` the XAML parser populated (this repo has been bitten before by XAML-backed
dictionaries behaving differently from code-built ones); `SemanticThemeHelper`; a diamond; both edges
of the depth bound (31 dictionaries deep found, 32 not, so the loop and the documented contract
cannot drift apart); and the two ALC policies.

Every test rearranges `Application.Current.Resources` and restores it exactly, detaching the theme
before re-parenting it (a `ResourceDictionary` may not be nested under two parents). The ~175 other
tests, most of which resolve through the application theme, are unaffected.

Verification (`net10.0-desktop` Debug, headless `--runtime-tests`): Simple head **182 passed, 0
failed**, 1 pre-existing `[Ignore]` skip; Material head **35/35**; `Uno.Themes.WinUI` Release builds
with the same two pre-existing `CS0618` warnings as `master`. `markdownlint` and `cspell` are clean on
everything touched — note that `doc/semantic-styles.md` already carries 204 `MD060` errors on
`master`, so a repo-wide markdownlint run fails independently of this change.

**Two things this PR does not do**, both recorded in `specs/10-gettheme-nested-walk/progress.md`:

- **The release half of the issue.** #1704 also asks for the extension to ship in a released package
  so apps and tooling stop writing their own walk. That is a release action, not a code change.
- **#1703 will conflict.** That PR rewrites the same paragraph of
  `specs/03-seed-color-palette/seed-color-palette.md` (the ALC motivation) that this one corrects, and
  adds the guest-side hand-off plus a host-side name-based check in the wrapper smoke. The facts
  recorded on both sides agree; whichever lands second folds the two descriptions together.

Spec numbering picked `specs/10-` because #1702 holds `08-` and #1707 holds `09-`. That scheme does
not survive parallel branches well and is worth renumbering once these land.

## Internal Issue (If applicable):

N/A
