### PR TITLE
chore!: Retarget Uno.Themes to Uno Platform 7.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,6 +5,6 @@
 	"msbuild-sdks": {
 		"MSBuild.Sdk.Extras": "3.0.44",
 		"Uno.Sdk": "6.4.53",
-		"Uno.Sdk.Private": "6.7.0-dev.815"
+		"Uno.Sdk.Private": "7.0.0-dev.645"
 	}
 }

--- a/src/library/Uno.Cupertino/Styles/Controls/CalendarDatePicker.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/CalendarDatePicker.xaml
@@ -4,7 +4,6 @@
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:wasm="http://uno.ui/wasm"
 					mc:Ignorable="ios android wasm not_win">
 

--- a/src/library/Uno.Cupertino/Styles/Controls/CalendarView.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/CalendarView.xaml
@@ -4,7 +4,6 @@
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:uno="using:Uno.UI.Xaml.Controls"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/src/library/Uno.Cupertino/Styles/Controls/CheckBox.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/CheckBox.xaml
@@ -5,9 +5,9 @@
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:not_ios="http://uno.ui/not_ios"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:xamarin="http://uno.ui/xamarin"
+					xmlns:not_win="http://uno.ui/not_win"
 					xmlns:mobile="http://uno.ui/mobile"
-					mc:Ignorable="android ios not_ios xamarin mobile">
+					mc:Ignorable="android ios not_ios mobile not_win">
 
 	<x:String x:Key="HyphenGlyphPathStyle">M0,0L32,0 32,5.3 0,5.3z</x:String>
 	<x:String x:Key="CheckGlyphPathStyle">M28.718018,0L32,3.2819897 10.666016,24.616999 0,13.951997 3.2810059,10.670007 10.666016,18.055033z</x:String>
@@ -101,14 +101,14 @@
 
 								<VisualState x:Name="CheckedPressed">
 									<!-- https://github.com/unoplatform/uno/issues/5099 -->
-									<xamarin:VisualState.Setters>
+									<not_win:VisualState.Setters>
 										<Setter Target="BackgroundBorder.Opacity"
 												Value="0" />
 										<Setter Target="CheckedBackgroundBorder.Opacity"
 												Value="1" />
 										<Setter Target="CheckGlyph.Opacity"
 												Value="1" />
-									</xamarin:VisualState.Setters>
+									</not_win:VisualState.Setters>
 									<win:Storyboard>
 										<DoubleAnimation Storyboard.TargetName="BackgroundBorder"
 														 Storyboard.TargetProperty="Opacity"
@@ -178,14 +178,14 @@
 
 								<VisualState x:Name="IndeterminatePressed">
 									<!-- https://github.com/unoplatform/uno/issues/5099 -->
-									<xamarin:VisualState.Setters>
+									<not_win:VisualState.Setters>
 										<Setter Target="BackgroundBorder.Opacity"
 												Value="0" />
 										<Setter Target="CheckedBackgroundBorder.Opacity"
 												Value="1" />
 										<Setter Target="HyphenGlyph.Opacity"
 												Value="1" />
-									</xamarin:VisualState.Setters>
+									</not_win:VisualState.Setters>
 									<win:Storyboard>
 										<DoubleAnimation Storyboard.TargetName="BackgroundBorder"
 														 Storyboard.TargetProperty="Opacity"

--- a/src/library/Uno.Cupertino/Styles/Controls/ComboBox.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/ComboBox.xaml
@@ -3,8 +3,8 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:uno="using:Uno.UI.Xaml.Controls"
 					xmlns:ut="using:Uno.Themes"
-					xmlns:xamarin="http://uno.ui/xamarin"
-					mc:Ignorable="xamarin">
+					xmlns:not_win="http://uno.ui/not_win"
+					mc:Ignorable="not_win">
 
 	<!-- Converters -->
 	<ut:FromNullToValueConverter x:Key="NullToVisible"
@@ -171,7 +171,7 @@
 				Value="Stretch" />
 		<Setter Property="ItemContainerStyle"
 				Value="{StaticResource CupertinoComboBoxItemStyle}" />
-		<xamarin:Setter Property="uno:ComboBox.DropDownPreferredPlacement"
+		<not_win:Setter Property="uno:ComboBox.DropDownPreferredPlacement"
 						Value="Below" />
 
 		<Setter Property="ItemsPanel">

--- a/src/library/Uno.Cupertino/Styles/Controls/DatePicker.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/DatePicker.xaml
@@ -4,7 +4,7 @@
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					xmlns:wasm="http://uno.ui/wasm"
 					mc:Ignorable="ios android wasm not_win">
 
@@ -100,7 +100,7 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="DatePickerFlyoutPresenter">
-					<toolkit:ElevatedView MaxHeight="398"
+					<uuxc:ElevatedView MaxHeight="398"
 										  Background="{ThemeResource CupertinoQuinaryGrayBrush}"
 										  BorderBrush="{TemplateBinding BorderBrush}"
 										  BorderThickness="{TemplateBinding BorderThickness}"
@@ -187,7 +187,7 @@
 
 							</Grid>
 						</Border>
-					</toolkit:ElevatedView>
+					</uuxc:ElevatedView>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>

--- a/src/library/Uno.Cupertino/Styles/Controls/Slider.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/Slider.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					xmlns:not_win="http://uno.ui/not_win"
 					mc:Ignorable="not_win">
 
@@ -206,7 +206,7 @@
 										 Grid.ColumnSpan="3" />
 
 								<!--  HorizontalThumb  -->
-								<toolkit:ElevatedView Grid.Row="0"
+								<uuxc:ElevatedView Grid.Row="0"
 													  Grid.RowSpan="3"
 													  Grid.Column="1"
 													  Width="28"
@@ -224,7 +224,7 @@
 										   Width="28"
 										   FocusVisualMargin="-14,-6,-14,-6"
 										   AutomationProperties.AccessibilityView="Raw" />
-								</toolkit:ElevatedView>
+								</uuxc:ElevatedView>
 							</Grid>
 
 							<!--  VerticalTemplate  -->
@@ -289,7 +289,7 @@
 										 Grid.RowSpan="3" />
 
 								<!--  VerticalThumb  -->
-								<toolkit:ElevatedView Grid.Row="1"
+								<uuxc:ElevatedView Grid.Row="1"
 													  Grid.Column="0"
 													  Grid.ColumnSpan="3"
 													  Width="28"
@@ -306,7 +306,7 @@
 										   Height="28"
 										   FocusVisualMargin="-6,-14,-6,-14"
 										   AutomationProperties.AccessibilityView="Raw" />
-								</toolkit:ElevatedView>
+								</uuxc:ElevatedView>
 							</Grid>
 						</Grid>
 					</Grid>

--- a/src/library/Uno.Cupertino/Styles/Controls/ToggleSwitch.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/ToggleSwitch.xaml
@@ -7,7 +7,6 @@
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:macos="http://uno.ui/macos"
 					mc:Ignorable="ios android xamarin wasm macos">
 

--- a/src/library/Uno.Cupertino/Styles/Controls/ToggleSwitch.xaml
+++ b/src/library/Uno.Cupertino/Styles/Controls/ToggleSwitch.xaml
@@ -3,12 +3,11 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:android="http://uno.ui/android"
-					xmlns:xamarin="http://uno.ui/xamarin"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:macos="http://uno.ui/macos"
-					mc:Ignorable="ios android xamarin wasm macos">
+					mc:Ignorable="ios android wasm macos">
 
 	<!-- Toggle On -->
 	<SolidColorBrush x:Key="CupertinoToggleSwitchOnButtonBrush"

--- a/src/library/Uno.Cupertino/Uno.Cupertino.WinUI.csproj
+++ b/src/library/Uno.Cupertino/Uno.Cupertino.WinUI.csproj
@@ -1,5 +1,5 @@
 
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
 	<Import Project="..\tfm-common-winui.props" />
 
 	<PropertyGroup>

--- a/src/library/Uno.Material.WinUI.Markup/Uno.Material.WinUI.Markup.csproj
+++ b/src/library/Uno.Material.WinUI.Markup/Uno.Material.WinUI.Markup.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
 	<Import Project="..\tfm-common-winui.props" />
 
 	<!--

--- a/src/library/Uno.Material/Styles/Controls/v1/CheckBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/CheckBox.xaml
@@ -5,9 +5,9 @@
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:not_ios="http://uno.ui/not_ios"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:xamarin="http://uno.ui/xamarin"
+					xmlns:not_win="http://uno.ui/not_win"
 					xmlns:mobile="http://uno.ui/mobile"
-					mc:Ignorable="android ios not_ios xamarin mobile">
+					mc:Ignorable="android ios not_ios mobile not_win">
 
 	<x:String x:Key="CheckBoxHyphenGlyphPathStyle">M0,0L32,0 32,5.3 0,5.3z</x:String>
 	<x:String x:Key="CheckBoxCheckGlyphPathStyle">M28.718018,0L32,3.2819897 10.666016,24.616999 0,13.951997 3.2810059,10.670007 10.666016,18.055033z</x:String>
@@ -144,14 +144,14 @@
 
 								<VisualState x:Name="CheckedPressed">
 									<!-- https://github.com/unoplatform/uno/issues/5099 -->
-									<xamarin:VisualState.Setters>
+									<not_win:VisualState.Setters>
 										<Setter Target="BackgroundBorder.Opacity"
 												Value="0" />
 										<Setter Target="CheckedBackgroundBorder.Opacity"
 												Value="1" />
 										<Setter Target="CheckGlyph.Opacity"
 												Value="1" />
-									</xamarin:VisualState.Setters>
+									</not_win:VisualState.Setters>
 									<win:Storyboard>
 										<DoubleAnimation Storyboard.TargetName="BackgroundBorder"
 														 Storyboard.TargetProperty="Opacity"
@@ -221,14 +221,14 @@
 
 								<VisualState x:Name="IndeterminatePressed">
 									<!-- https://github.com/unoplatform/uno/issues/5099 -->
-									<xamarin:VisualState.Setters>
+									<not_win:VisualState.Setters>
 										<Setter Target="BackgroundBorder.Opacity"
 												Value="0" />
 										<Setter Target="CheckedBackgroundBorder.Opacity"
 												Value="1" />
 										<Setter Target="HyphenGlyph.Opacity"
 												Value="1" />
-									</xamarin:VisualState.Setters>
+									</not_win:VisualState.Setters>
 									<win:Storyboard>
 										<DoubleAnimation Storyboard.TargetName="BackgroundBorder"
 														 Storyboard.TargetProperty="Opacity"

--- a/src/library/Uno.Material/Styles/Controls/v1/ComboBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/ComboBox.xaml
@@ -4,9 +4,9 @@
 					xmlns:um="using:Uno.Material"
 					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					xmlns:ut="using:Uno.Themes"
-					xmlns:xamarin="http://uno.ui/xamarin"
+					xmlns:not_win="http://uno.ui/not_win"
 					xmlns:uno="using:Uno.UI.Xaml.Controls"
-					mc:Ignorable="xamarin">
+					mc:Ignorable="not_win">
 
 	<!-- Converters -->
 	<ut:FromNullToValueConverter x:Key="NullToScaleConverter"
@@ -244,7 +244,7 @@
 				Value="Stretch" />
 		<Setter Property="ItemContainerStyle"
 				Value="{StaticResource MaterialComboBoxItemStyle}" />
-		<xamarin:Setter Property="uno:ComboBox.DropDownPreferredPlacement"
+		<not_win:Setter Property="uno:ComboBox.DropDownPreferredPlacement"
 						Value="Below" />
 
 		<!-- Workaround for WinUI issue: https://github.com/microsoft/microsoft-ui-xaml/issues/6388 -->

--- a/src/library/Uno.Material/Styles/Controls/v1/ComboBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/ComboBox.xaml
@@ -2,7 +2,7 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:um="using:Uno.Material"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					xmlns:ut="using:Uno.Themes"
 					xmlns:xamarin="http://uno.ui/xamarin"
 					xmlns:uno="using:Uno.UI.Xaml.Controls"
@@ -377,7 +377,7 @@
 						</VisualStateManager.VisualStateGroups>
 
 						<!-- Elevated View -->
-						<toolkit:ElevatedView x:Name="ElevatedView"
+						<uuxc:ElevatedView x:Name="ElevatedView"
 											  Background="{TemplateBinding Background}"
 											  HorizontalAlignment="Stretch"
 											  CornerRadius="{StaticResource MaterialComboBoxCornerRadius}"
@@ -521,7 +521,7 @@
 									</Border>
 								</Popup>
 							</Grid>
-						</toolkit:ElevatedView>
+						</uuxc:ElevatedView>
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>

--- a/src/library/Uno.Material/Styles/Controls/v1/CommandBar.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/CommandBar.xaml
@@ -2,7 +2,8 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:um="using:Uno.Material"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
+					xmlns:uux="using:Uno.UI.Xaml"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:android="http://uno.ui/android"
 					xmlns:ios="http://uno.ui/ios"
@@ -60,7 +61,7 @@
 				</Grid.ColumnDefinitions>
 
 				<!-- note: NavigationCommand is an AppBarButton, not ICommand -->
-				<ContentControl Content="{Binding (toolkit:CommandBarExtensions.NavigationCommand), RelativeSource={RelativeSource TemplatedParent}}"
+				<ContentControl Content="{Binding (uuxc:CommandBarExtensions.NavigationCommand), RelativeSource={RelativeSource TemplatedParent}}"
 								Foreground="{TemplateBinding Foreground}"
 								Height="{StaticResource MaterialCommandBarHeight}"
 								Width="{StaticResource MaterialCommandBarHeight}"
@@ -114,7 +115,7 @@
 		<Setter Property="Background" Value="{StaticResource MaterialPrimaryBrush}" />
 		<Setter Property="Foreground" Value="{StaticResource MaterialOnPrimaryBrush}" />
 
-		<android:Setter Property="(toolkit:UIElementExtensions.Elevation)"
+		<android:Setter Property="(uux:UIElementExtensions.Elevation)"
 						Value="{StaticResource MaterialCommandBarElevation}" />
 		<Setter Property="Height" Value="{StaticResource MaterialCommandBarHeight}" />
 

--- a/src/library/Uno.Material/Styles/Controls/v1/DatePicker.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/DatePicker.xaml
@@ -4,7 +4,7 @@
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					xmlns:wasm="http://uno.ui/wasm"
 					mc:Ignorable="ios android wasm not_win">
 
@@ -102,7 +102,7 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="DatePickerFlyoutPresenter">
-					<toolkit:ElevatedView MaxHeight="398"
+					<uuxc:ElevatedView MaxHeight="398"
 										  Background="{TemplateBinding Background}"
 										  BorderBrush="{TemplateBinding BorderBrush}"
 										  BorderThickness="{TemplateBinding BorderThickness}"
@@ -180,7 +180,7 @@
 								</Grid>
 							</Grid>
 						</Border>
-					</toolkit:ElevatedView>
+					</uuxc:ElevatedView>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>

--- a/src/library/Uno.Material/Styles/Controls/v1/FloatingActionButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/FloatingActionButton.xaml
@@ -4,7 +4,7 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:um="using:Uno.Material"
 					xmlns:ut="using:Uno.Themes"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					mc:Ignorable="d">
 
 	<!-- Need full color for disabled state or else the elevated view looks weird -->
@@ -80,7 +80,7 @@
 				<ControlTemplate TargetType="Button">
 					<Grid>
 
-						<toolkit:ElevatedView x:Name="ElevatedView"
+						<uuxc:ElevatedView x:Name="ElevatedView"
 											  Margin="0,0,6,6"
 											  Elevation="6"
 											  CornerRadius="{TemplateBinding CornerRadius}"
@@ -128,7 +128,7 @@
 									<Border x:Name="FabFocusBorder" />
 								</Grid>
 							</um:Ripple>
-						</toolkit:ElevatedView>
+						</uuxc:ElevatedView>
 
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">
@@ -227,7 +227,7 @@
 				<ControlTemplate TargetType="Button">
 					<Grid>
 
-						<toolkit:ElevatedView x:Name="ElevatedView"
+						<uuxc:ElevatedView x:Name="ElevatedView"
 											  Margin="0,0,4,4"
 											  Elevation="4"
 											  CornerRadius="{TemplateBinding CornerRadius}"
@@ -275,7 +275,7 @@
 									<Border x:Name="FabFocusBorder" />
 								</Grid>
 							</um:Ripple>
-						</toolkit:ElevatedView>
+						</uuxc:ElevatedView>
 
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">

--- a/src/library/Uno.Material/Styles/Controls/v1/InfoBar.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/InfoBar.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 					mc:Ignorable="">
@@ -38,7 +38,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="muxc:InfoBar">
 
-					<toolkit:ElevatedView x:Name="Root"
+					<uuxc:ElevatedView x:Name="Root"
 										  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
 										  VerticalAlignment="{TemplateBinding VerticalAlignment}"
 										  Background="{TemplateBinding Background}"
@@ -213,7 +213,7 @@
 												  ContentTemplate="{TemplateBinding ContentTemplate}" />
 							</Grid>
 						</Grid>
-					</toolkit:ElevatedView>
+					</uuxc:ElevatedView>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>

--- a/src/library/Uno.Material/Styles/Controls/v1/ListView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/ListView.xaml
@@ -3,8 +3,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:xamarin="http://uno.ui/xamarin"
-	mc:Ignorable="xamarin">
+	xmlns:not_win="http://uno.ui/not_win"
+	mc:Ignorable="not_win">
 
 
 	<Style x:Key="MaterialListViewItemStyle" TargetType="ListViewItem">
@@ -359,7 +359,7 @@
 							<ContentPresenter x:Name="ContentPresenter"
 											  ContentTransitions="{TemplateBinding ContentTransitions}"
 											  ContentTemplate="{TemplateBinding ContentTemplate}"
-											  xamarin:ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+											  not_win:ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
 											  Content="{TemplateBinding Content}"
 											  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 											  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -405,7 +405,7 @@
 							<FontIcon x:Name="MultiSelectCheck"
 									  FontFamily="{ThemeResource SymbolThemeFontFamily}"
 									  win:Glyph="&#xE73E;"
-									  xamarin:Glyph="&#xE081;"
+									  not_win:Glyph="&#xE081;"
 									  FontSize="16"
 									  Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
 									  Visibility="Collapsed"

--- a/src/library/Uno.Material/Styles/Controls/v1/NavigationView/NavigationView_MUX.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/NavigationView/NavigationView_MUX.xaml
@@ -5,15 +5,14 @@
 					xmlns:media="using:Microsoft.UI.Xaml.Media"
 					xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 					xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
-					xmlns:skia="http://uno.ui/skia"
-					xmlns:xamarin="http://uno.ui/xamarin"
+					xmlns:not_win="http://uno.ui/not_win"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:contract4NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,4)"
 					xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
 					xmlns:primitiveContract7Present="using:Microsoft.UI.Xaml.Controls.Primitives"
-					mc:Ignorable="skia xamarin contract4NotPresent contract7NotPresent">
+					mc:Ignorable="contract4NotPresent contract7NotPresent not_win">
 
 	<!--
 		Source taken/modified from: https://github.com/unoplatform/uno/tree/2e4c84310d8f88f24d2cae284cec8f5c93375a22
@@ -365,7 +364,7 @@
 	<!--#region NavigationView-->
 
 	<!-- to reset default style on SplitView from Uno.Material -->
-	<xamarin:Style x:Key="MaterialMUXNavigationViewResetSplitViewStyle"
+	<not_win:Style x:Key="MaterialMUXNavigationViewResetSplitViewStyle"
 				   TargetType="SplitView">
 		<Setter Property="HorizontalContentAlignment" Value="Stretch" />
 		<Setter Property="VerticalContentAlignment" Value="Stretch" />
@@ -388,7 +387,7 @@
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HCPaneBorder" Storyboard.TargetProperty="Visibility">
 												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
 											</ObjectAnimationUsingKeyFrames>
-											<xamarin:DoubleAnimation Storyboard.TargetName="PaneTransform"
+											<not_win:DoubleAnimation Storyboard.TargetName="PaneTransform"
 																	 Storyboard.TargetProperty="TranslateX"
 																	 From="{Binding TemplateSettings.NegativeOpenPaneLength, RelativeSource={RelativeSource Mode=TemplatedParent}}"
 																	 To="0"
@@ -413,7 +412,7 @@
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HCPaneBorder" Storyboard.TargetProperty="Visibility">
 												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
 											</ObjectAnimationUsingKeyFrames>
-											<xamarin:DoubleAnimation Storyboard.TargetName="PaneTransform"
+											<not_win:DoubleAnimation Storyboard.TargetName="PaneTransform"
 																	 Storyboard.TargetProperty="TranslateX"
 																	 From="{Binding TemplateSettings.OpenPaneLength, RelativeSource={RelativeSource Mode=TemplatedParent}}"
 																	 To="0"
@@ -484,7 +483,7 @@
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HCPaneBorder" Storyboard.TargetProperty="Visibility">
 												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
 											</ObjectAnimationUsingKeyFrames>
-											<xamarin:DoubleAnimation Storyboard.TargetName="PaneTransform"
+											<not_win:DoubleAnimation Storyboard.TargetName="PaneTransform"
 																	 Storyboard.TargetProperty="TranslateX"
 																	 From="0"
 																	 To="{Binding TemplateSettings.NegativeOpenPaneLength, RelativeSource={RelativeSource Mode=TemplatedParent}}"
@@ -506,7 +505,7 @@
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HCPaneBorder" Storyboard.TargetProperty="Visibility">
 												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
 											</ObjectAnimationUsingKeyFrames>
-											<xamarin:DoubleAnimation Storyboard.TargetName="PaneTransform"
+											<not_win:DoubleAnimation Storyboard.TargetName="PaneTransform"
 																	 Storyboard.TargetProperty="TranslateX"
 																	 To="{Binding TemplateSettings.OpenPaneLength, RelativeSource={RelativeSource Mode=TemplatedParent}}"
 																	 Duration="0:0:0.12" />
@@ -555,10 +554,10 @@
 									<VisualTransition From="OpenCompactOverlayRight"
 													  To="ClosedCompactRight">
 										<Storyboard>
-											<xamarin:ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Clip"
+											<not_win:ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Clip"
 																				   Storyboard.TargetName="PaneRoot">
 												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{Binding TemplateSettings.RightClip, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
-											</xamarin:ObjectAnimationUsingKeyFrames>
+											</not_win:ObjectAnimationUsingKeyFrames>
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColumnDefinition1" Storyboard.TargetProperty="Width">
 												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="*" />
 											</ObjectAnimationUsingKeyFrames>
@@ -611,10 +610,10 @@
 										<Setter Target="PaneTransform.TranslateX" Value="0" />
 									</VisualState.Setters>
 									<Storyboard>
-										<xamarin:ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Clip"
+										<not_win:ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Clip"
 																			   Storyboard.TargetName="PaneRoot">
 											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{Binding TemplateSettings.LeftClip, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
-										</xamarin:ObjectAnimationUsingKeyFrames>
+										</not_win:ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColumnDefinition1" Storyboard.TargetProperty="Width">
 											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{Binding TemplateSettings.CompactPaneGridLength, FallbackValue=0, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
 										</ObjectAnimationUsingKeyFrames>
@@ -635,10 +634,10 @@
 								</VisualState>
 								<VisualState x:Name="ClosedCompactRight">
 									<Storyboard>
-										<xamarin:ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Clip"
+										<not_win:ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Clip"
 																			   Storyboard.TargetName="PaneRoot">
 											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{Binding TemplateSettings.RightClip, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
-										</xamarin:ObjectAnimationUsingKeyFrames>
+										</not_win:ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColumnDefinition1" Storyboard.TargetProperty="Width">
 											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="*" />
 										</ObjectAnimationUsingKeyFrames>
@@ -700,10 +699,10 @@
 										<Setter Target="PaneTransform.TranslateX" Value="0" />
 									</VisualState.Setters>
 									<Storyboard>
-										<xamarin:ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Clip"
+										<not_win:ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Clip"
 																			   Storyboard.TargetName="PaneRoot">
 											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Null}" />
-										</xamarin:ObjectAnimationUsingKeyFrames>
+										</not_win:ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="(Grid.Column)">
 											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="1" />
 										</ObjectAnimationUsingKeyFrames>
@@ -816,7 +815,7 @@
 							<win:Rectangle x:Name="LightDismissLayer"
 										   Fill="{StaticResource SplitViewDismissBackgroundColor}"
 										   Visibility="Collapsed" />
-							<xamarin:Button x:Name="LightDismissLayer"
+							<not_win:Button x:Name="LightDismissLayer"
 											Visibility="Collapsed"
 											HorizontalAlignment="Stretch"
 											VerticalAlignment="Stretch">
@@ -825,7 +824,7 @@
 										<Border Background="{StaticResource SplitViewDismissBackgroundColor}" />
 									</ControlTemplate>
 								</Button.Template>
-							</xamarin:Button>
+							</not_win:Button>
 						</Grid>
 
 						<!-- Pane Content Area -->
@@ -857,7 +856,7 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</xamarin:Style>
+	</not_win:Style>
 
 	<Style x:Key="MaterialMUXNavigationViewPaneToggleButtonStyle"
 		   TargetType="Button">
@@ -1261,7 +1260,7 @@
 									   IsTabStop="False"
 									   OpenPaneLength="{TemplateBinding OpenPaneLength}"
 									   PaneBackground="{ThemeResource MaterialMUXNavigationViewDefaultPaneBackground}"
-									   xamarin:Style="{StaticResource MaterialMUXNavigationViewResetSplitViewStyle}"
+									   not_win:Style="{StaticResource MaterialMUXNavigationViewResetSplitViewStyle}"
 									   Grid.Row="1">
 
 								<SplitView.Pane>
@@ -1572,9 +1571,9 @@
 								BorderThickness="{TemplateBinding BorderThickness}" />
 						<Border Margin="{TemplateBinding Padding}">
 							<!-- dont apply Margin on Ripple, as it will be applied twice (on the Ripple and on its template root) -->
-							<!-- material#446: skia:Opacity to workaround Ripple opacity issue -->
+							<!-- material#446: not_win:Opacity to workaround Ripple opacity issue -->
 							<um:Ripple Feedback="{StaticResource MaterialMUXNavigationViewRippleFeedback}"
-											 skia:Opacity="0.12"
+											 not_win:Opacity="0.12"
 											 CornerRadius="{TemplateBinding CornerRadius}" />
 						</Border>
 

--- a/src/library/Uno.Material/Styles/Controls/v1/ToggleButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/ToggleButton.xaml
@@ -5,8 +5,8 @@
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:um="using:Uno.Material"
 					xmlns:ut="using:Uno.Themes"
-					xmlns:xamarin="http://uno.ui/xamarin"
-					mc:Ignorable="d xamarin">
+					xmlns:not_win="http://uno.ui/not_win"
+					mc:Ignorable="d not_win">
 
 	<!-- ToggleButton Brushes -->
 	<SolidColorBrush x:Key="ToggleButtonTextLabelBrush"
@@ -72,7 +72,7 @@
 									</Storyboard>
 								</VisualState>
 
-								<xamarin:VisualState x:Name="Pressed">
+								<not_win:VisualState x:Name="Pressed">
 									<!-- https://github.com/unoplatform/uno/issues/5099 -->
 									<VisualState.Setters>
 										<Setter Target="HoverOverlay.Opacity"
@@ -80,7 +80,7 @@
 										<Setter Target="FocusedOverlay.Opacity"
 												Value="0" />
 									</VisualState.Setters>
-								</xamarin:VisualState>
+								</not_win:VisualState>
 								<win:VisualState x:Name="Pressed">
 									<Storyboard>
 										<DoubleAnimation Storyboard.TargetName="HoverOverlay"

--- a/src/library/Uno.Material/Styles/Controls/v1/ToggleSwitch.Base.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/ToggleSwitch.Base.xaml
@@ -3,12 +3,11 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:android="http://uno.ui/android"
-					xmlns:xamarin="http://uno.ui/xamarin"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:macos="http://uno.ui/macos"
-					mc:Ignorable="ios android xamarin wasm macos">
+					mc:Ignorable="ios android wasm macos">
 
 	<!-- Brushes for thumbtint colors -->
 	<SolidColorBrush x:Key="MaterialPrimaryVariantLowThumbColorBrush"

--- a/src/library/Uno.Material/Styles/Controls/v1/ToggleSwitch.Base.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/ToggleSwitch.Base.xaml
@@ -7,7 +7,6 @@
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:macos="http://uno.ui/macos"
 					mc:Ignorable="ios android xamarin wasm macos">
 

--- a/src/library/Uno.Material/Styles/Controls/v1/ToggleSwitch.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/ToggleSwitch.xaml
@@ -4,13 +4,12 @@
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:android="http://uno.ui/android"
-					xmlns:xamarin="http://uno.ui/xamarin"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					xmlns:macos="http://uno.ui/macos"
-					mc:Ignorable="ios android xamarin wasm macos">
+					mc:Ignorable="ios android wasm macos">
 
 	<Style x:Key="MaterialToggleSwitchStyle"
 		   TargetType="ToggleSwitch">

--- a/src/library/Uno.Material/Styles/Controls/v1/ToggleSwitch.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v1/ToggleSwitch.xaml
@@ -8,7 +8,7 @@
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					xmlns:macos="http://uno.ui/macos"
 					mc:Ignorable="ios android xamarin wasm macos">
 
@@ -375,7 +375,7 @@
 									 Height="40"
 									 Opacity="0" />
 
-							<toolkit:ElevatedView  Width="20"
+							<uuxc:ElevatedView  Width="20"
 												   Height="20"
 												   Elevation="4"
 												   CornerRadius="10"
@@ -395,7 +395,7 @@
 											 Width="20"
 											 Height="20" />
 								</Grid>
-							</toolkit:ElevatedView>
+							</uuxc:ElevatedView>
 						</Grid>
 
 						<Thumb x:Name="SwitchThumb"

--- a/src/library/Uno.Material/Styles/Controls/v2/AppBarButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/AppBarButton.xaml
@@ -2,7 +2,6 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:um="using:Uno.Material"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:android="http://uno.ui/android"
 					xmlns:ios="http://uno.ui/ios"

--- a/src/library/Uno.Material/Styles/Controls/v2/Button.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/Button.xaml
@@ -5,7 +5,7 @@
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:um="using:Uno.Material"
 					xmlns:ut="using:Uno.Themes"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					xmlns:not_win="http://uno.ui/not_win"
 					mc:Ignorable="d not_win">
 
@@ -315,7 +315,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="Button">
 
-					<toolkit:ElevatedView x:Name="ElevatedView"
+					<uuxc:ElevatedView x:Name="ElevatedView"
 										  Margin="{ThemeResource ElevatedButtonMargin}"
 										  Elevation="{Binding Path=(ut:ControlExtensions.Elevation), RelativeSource={RelativeSource TemplatedParent}}"
 										  CornerRadius="{TemplateBinding CornerRadius}"
@@ -420,7 +420,7 @@
 								</um:Ripple.Content>
 							</um:Ripple>
 						</Grid>
-					</toolkit:ElevatedView>
+					</uuxc:ElevatedView>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
@@ -439,7 +439,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="Button">
 
-					<toolkit:ElevatedView x:Name="ElevatedView"
+					<uuxc:ElevatedView x:Name="ElevatedView"
 										  Margin="{ThemeResource ButtonMargin}"
 										  Elevation="{ThemeResource ButtonElevation}"
 										  CornerRadius="{TemplateBinding CornerRadius}"
@@ -541,7 +541,7 @@
 								</um:Ripple.Content>
 							</um:Ripple>
 						</Grid>
-					</toolkit:ElevatedView>
+					</uuxc:ElevatedView>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
@@ -560,7 +560,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="Button">
 
-					<toolkit:ElevatedView x:Name="ElevatedView"
+					<uuxc:ElevatedView x:Name="ElevatedView"
 										  Margin="{ThemeResource ButtonMargin}"
 										  Elevation="{ThemeResource ButtonElevation}"
 										  CornerRadius="{TemplateBinding CornerRadius}"
@@ -663,7 +663,7 @@
 								</um:Ripple.Content>
 							</um:Ripple>
 						</Grid>
-					</toolkit:ElevatedView>
+					</uuxc:ElevatedView>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>

--- a/src/library/Uno.Material/Styles/Controls/v2/CheckBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/CheckBox.xaml
@@ -7,9 +7,8 @@
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:not_ios="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:xamarin="http://uno.ui/xamarin"
 					xmlns:mobile="http://uno.ui/mobile"
-					mc:Ignorable="android ios xamarin mobile">
+					mc:Ignorable="android ios mobile">
 
 	<ResourceDictionary.ThemeDictionaries>
 		<ResourceDictionary x:Key="Default">

--- a/src/library/Uno.Material/Styles/Controls/v2/ComboBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ComboBox.xaml
@@ -1,7 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:um="using:Uno.Material"
 					xmlns:ut="using:Uno.Themes"
 					xmlns:xamarin="http://uno.ui/xamarin"

--- a/src/library/Uno.Material/Styles/Controls/v2/ComboBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ComboBox.xaml
@@ -3,9 +3,9 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:um="using:Uno.Material"
 					xmlns:ut="using:Uno.Themes"
-					xmlns:xamarin="http://uno.ui/xamarin"
+					xmlns:not_win="http://uno.ui/not_win"
 					xmlns:uno="using:Uno.UI.Xaml.Controls"
-					mc:Ignorable="xamarin">
+					mc:Ignorable="not_win">
 
 	<ResourceDictionary.ThemeDictionaries>
 
@@ -442,7 +442,7 @@
 		<Setter Property="HorizontalContentAlignment" Value="Stretch" />
 		<Setter Property="HorizontalAlignment" Value="Stretch" />
 		<Setter Property="ItemContainerStyle" Value="{StaticResource MaterialComboBoxItemStyle}" />
-		<xamarin:Setter Property="uno:ComboBox.DropDownPreferredPlacement"
+		<not_win:Setter Property="uno:ComboBox.DropDownPreferredPlacement"
 						Value="Below" />
 
 		<!-- Workaround for WinUI issue: https://github.com/microsoft/microsoft-ui-xaml/issues/6388 -->

--- a/src/library/Uno.Material/Styles/Controls/v2/CommandBar.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/CommandBar.xaml
@@ -2,7 +2,6 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:um="using:Uno.Material"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:android="http://uno.ui/android"
 					xmlns:ios="http://uno.ui/ios"

--- a/src/library/Uno.Material/Styles/Controls/v2/ContentDialog.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ContentDialog.xaml
@@ -1,7 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					mc:Ignorable="">
 
 	<!-- 28-CornerRadius doesnt match the general 24-Spacing; this is indeed correct. -->
@@ -168,7 +168,7 @@
 							<Border x:Name="BackgroundElement"
 									Opacity="0"
 									Visibility="Collapsed" />
-							<toolkit:ElevatedView x:Name="RealBackgroundElement"
+							<uuxc:ElevatedView x:Name="RealBackgroundElement"
 												  Background="{TemplateBinding Background}"
 												  BackgroundSizing="InnerBorderEdge"
 												  BorderBrush="{TemplateBinding BorderBrush}"
@@ -181,9 +181,9 @@
 												  Margin="{StaticResource MaterialContentDialogEdgeMargin}"
 												  HorizontalAlignment="Center"
 												  VerticalAlignment="Center">
-								<toolkit:ElevatedView.RenderTransform>
+								<uuxc:ElevatedView.RenderTransform>
 									<ScaleTransform x:Name="ScaleTransform" />
-								</toolkit:ElevatedView.RenderTransform>
+								</uuxc:ElevatedView.RenderTransform>
 								
 								<Grid>
 									
@@ -284,7 +284,7 @@
 										</Grid>
 									</Grid>
 								</Grid>
-							</toolkit:ElevatedView>
+							</uuxc:ElevatedView>
 						</Grid>
 					</Border>
 				</ControlTemplate>

--- a/src/library/Uno.Material/Styles/Controls/v2/DatePicker.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/DatePicker.xaml
@@ -4,7 +4,7 @@
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					xmlns:wasm="http://uno.ui/wasm"
 					mc:Ignorable="ios android wasm not_win">
 
@@ -184,7 +184,7 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="DatePickerFlyoutPresenter">
-					<toolkit:ElevatedView MaxHeight="{TemplateBinding MaxHeight}"
+					<uuxc:ElevatedView MaxHeight="{TemplateBinding MaxHeight}"
 										  Background="{TemplateBinding Background}"
 										  BorderBrush="{TemplateBinding BorderBrush}"
 										  BorderThickness="{TemplateBinding BorderThickness}"
@@ -261,7 +261,7 @@
 								</Grid>
 							</Grid>
 						</Border>
-					</toolkit:ElevatedView>
+					</uuxc:ElevatedView>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>

--- a/src/library/Uno.Material/Styles/Controls/v2/FloatingActionButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/FloatingActionButton.xaml
@@ -2,7 +2,7 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					xmlns:um="using:Uno.Material"
 					xmlns:ut="using:Uno.Themes"
 					mc:Ignorable="d">
@@ -203,7 +203,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="Button">
 					<Grid>
-						<toolkit:ElevatedView x:Name="ElevatedView"
+						<uuxc:ElevatedView x:Name="ElevatedView"
 											  Margin="0,0,6,6"
 											  Background="Transparent"
 											  CornerRadius="{TemplateBinding CornerRadius}"
@@ -254,7 +254,7 @@
 									<Border x:Name="StateOverlay" />
 								</Grid>
 							</um:Ripple>
-						</toolkit:ElevatedView>
+						</uuxc:ElevatedView>
 
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">
@@ -319,7 +319,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="Button">
 					<Grid>
-						<toolkit:ElevatedView x:Name="ElevatedView"
+						<uuxc:ElevatedView x:Name="ElevatedView"
 											  Margin="0,0,6,6"
 											  Background="Transparent"
 											  CornerRadius="{TemplateBinding CornerRadius}"
@@ -370,7 +370,7 @@
 									<Border x:Name="StateOverlay" />
 								</Grid>
 							</um:Ripple>
-						</toolkit:ElevatedView>
+						</uuxc:ElevatedView>
 
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">
@@ -435,7 +435,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="Button">
 					<Grid>
-						<toolkit:ElevatedView x:Name="ElevatedView"
+						<uuxc:ElevatedView x:Name="ElevatedView"
 											  Margin="0,0,6,6"
 											  Background="Transparent"
 											  CornerRadius="{TemplateBinding CornerRadius}"
@@ -486,7 +486,7 @@
 									<Border x:Name="StateOverlay" />
 								</Grid>
 							</um:Ripple>
-						</toolkit:ElevatedView>
+						</uuxc:ElevatedView>
 
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">
@@ -551,7 +551,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="Button">
 					<Grid>
-						<toolkit:ElevatedView x:Name="ElevatedView"
+						<uuxc:ElevatedView x:Name="ElevatedView"
 											  Margin="0,0,6,6"
 											  Background="Transparent"
 											  CornerRadius="{TemplateBinding CornerRadius}"
@@ -602,7 +602,7 @@
 									<Border x:Name="StateOverlay" />
 								</Grid>
 							</um:Ripple>
-						</toolkit:ElevatedView>
+						</uuxc:ElevatedView>
 
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">

--- a/src/library/Uno.Material/Styles/Controls/v2/ListView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ListView.xaml
@@ -3,8 +3,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:xamarin="http://uno.ui/xamarin"
-	mc:Ignorable="xamarin">
+	xmlns:not_win="http://uno.ui/not_win"
+	mc:Ignorable="not_win">
 
 
 	<Style x:Key="MaterialListViewItemStyle" TargetType="ListViewItem">
@@ -359,7 +359,7 @@
 							<ContentPresenter x:Name="ContentPresenter"
 											  ContentTransitions="{TemplateBinding ContentTransitions}"
 											  ContentTemplate="{TemplateBinding ContentTemplate}"
-											  xamarin:ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+											  not_win:ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
 											  Content="{TemplateBinding Content}"
 											  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 											  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"

--- a/src/library/Uno.Material/Styles/Controls/v2/NavigationView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/NavigationView.xaml
@@ -5,7 +5,7 @@
 					xmlns:animatedvisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
 					xmlns:media="using:Microsoft.UI.Xaml.Media"
 					xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:uub="using:Uno.UI.Behaviors"
 					xmlns:um="using:Uno.Material"
 					xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,4)"
 					xmlns:contract4NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,4)"
@@ -1536,7 +1536,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="local:NavigationView">
 					<Grid x:Name="RootGrid"
-						  toolkit:VisibleBoundsPadding.PaddingMask="All"
+						  uub:VisibleBoundsPadding.PaddingMask="All"
 						  Background="{TemplateBinding Background}">
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="DisplayModeGroup">

--- a/src/library/Uno.Material/Styles/Controls/v2/ToggleButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ToggleButton.xaml
@@ -5,8 +5,8 @@
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:um="using:Uno.Material"
 					xmlns:ut="using:Uno.Themes"
-					xmlns:xamarin="http://uno.ui/xamarin"
-					mc:Ignorable="d xamarin">
+					xmlns:not_win="http://uno.ui/not_win"
+					mc:Ignorable="d not_win">
 
 	<ResourceDictionary.ThemeDictionaries>
 		<ResourceDictionary x:Key="Default">
@@ -317,7 +317,7 @@
 									</VisualState.Setters>
 								</VisualState>
 
-								<xamarin:VisualState x:Name="Pressed">
+								<not_win:VisualState x:Name="Pressed">
 									<!-- https://github.com/unoplatform/uno/issues/5099 -->
 									<VisualState.Setters>
 										<Setter Target="HoverOverlay.Opacity" Value="0" />
@@ -327,7 +327,7 @@
 										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TextToggleButtonForegroundPressed}" />
 										<Setter Target="ContentPresenter.BorderBrush" Value="{ThemeResource TextToggleButtonBorderBrushPressed}" />
 									</VisualState.Setters>
-								</xamarin:VisualState>
+								</not_win:VisualState>
 								<win:VisualState x:Name="Pressed">
 									<Storyboard>
 										<DoubleAnimation Storyboard.TargetName="HoverOverlay"

--- a/src/library/Uno.Material/Uno.Material.WinUI.csproj
+++ b/src/library/Uno.Material/Uno.Material.WinUI.csproj
@@ -1,5 +1,5 @@
 
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
 	<Import Project="..\tfm-common-winui.props" />
 
 	<PropertyGroup>

--- a/src/library/Uno.Simple.WinUI.Markup/Uno.Simple.WinUI.Markup.csproj
+++ b/src/library/Uno.Simple.WinUI.Markup/Uno.Simple.WinUI.Markup.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Uno.Sdk.Private">
 	<Import Project="..\tfm-common-winui.props" />
 
 	<!--

--- a/src/library/Uno.Simple.WinUI/Uno.Simple.WinUI.csproj
+++ b/src/library/Uno.Simple.WinUI/Uno.Simple.WinUI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Uno.Sdk.Private">
 	<Import Project="..\tfm-common-winui.props" />
 
 	<PropertyGroup>

--- a/src/library/Uno.Themes.WinUI.Markup/Uno.Themes.WinUI.Markup.csproj
+++ b/src/library/Uno.Themes.WinUI.Markup/Uno.Themes.WinUI.Markup.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
 
 	<Import Project="..\tfm-common-winui.props" />
 	<!--

--- a/src/library/Uno.Themes/Helpers/ControlHelper.cs
+++ b/src/library/Uno.Themes/Helpers/ControlHelper.cs
@@ -13,11 +13,7 @@ namespace Uno.Themes;
 public static class ControlHelper
 {
 	public static TControl GetTemplateChild<TControl>(this Control control, Func<string, DependencyObject> getTemplateChildImpl, string childName)
-#if HAS_UNO
-		where TControl : class, DependencyObject
-#else
 		where TControl : DependencyObject
-#endif
 	{
 		var child = getTemplateChildImpl(childName) ?? throw new Exception($"Unable to find template child ({childName}) in the control template of '{control.GetType().Name}'.");
 		return child as TControl ?? throw new InvalidCastException($"Unable to cast template child ({childName}) from type of '{child.GetType()}' to '{typeof(TControl)}'.");

--- a/src/library/Uno.Themes/Uno.Themes.WinUI.csproj
+++ b/src/library/Uno.Themes/Uno.Themes.WinUI.csproj
@@ -1,5 +1,5 @@
 
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
 	<Import Project="..\tfm-common-winui.props" />
 
 	<PropertyGroup>

--- a/src/library/tfm-common-winui.props
+++ b/src/library/tfm-common-winui.props
@@ -1,21 +1,20 @@
 <Project>
 	<!--
-		Expand platform suffix overrides to versioned TFMs for library projects (net9.0).
+		Expand platform suffix overrides to versioned TFMs for library projects (net10.0).
 		This allows crosstargeting_override.props to use platform suffixes (e.g., 'ios', 'android')
-		that work for both libraries (net9.0-*) and sample apps (net10.0-*).
+		that work for both libraries (net10.0-*) and sample apps (net10.0-*).
 	-->
 	<PropertyGroup Condition="'$(TargetFrameworkOverride)'!=''">
-		<!-- Always include net9.0 for library projects -->
-		<TargetFrameworks>net9.0</TargetFrameworks>
-		<TargetFrameworks Condition="$(TargetFrameworkOverride.Contains('ios'))">$(TargetFrameworks);net9.0-ios</TargetFrameworks>
-		<TargetFrameworks Condition="$(TargetFrameworkOverride.Contains('android'))">$(TargetFrameworks);net9.0-android</TargetFrameworks>
-		<TargetFrameworks Condition="$(TargetFrameworkOverride.Contains('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041</TargetFrameworks>
-		<TargetFrameworks Condition="$(TargetFrameworkOverride.Contains('maccatalyst'))">$(TargetFrameworks);net9.0-maccatalyst</TargetFrameworks>
+		<!-- Always include net10.0 for library projects -->
+		<TargetFrameworks>net10.0</TargetFrameworks>
+		<TargetFrameworks Condition="$(TargetFrameworkOverride.Contains('ios'))">$(TargetFrameworks);net10.0-ios</TargetFrameworks>
+		<TargetFrameworks Condition="$(TargetFrameworkOverride.Contains('android'))">$(TargetFrameworks);net10.0-android</TargetFrameworks>
+		<TargetFrameworks Condition="$(TargetFrameworkOverride.Contains('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFrameworkOverride)'==''">
-		<TargetFrameworks>$(TargetFrameworks);net9.0;</TargetFrameworks>
-		<TargetFrameworks Condition="'$(Build_iOS)'=='true'">$(TargetFrameworks);net9.0-ios</TargetFrameworks>
-		<TargetFrameworks Condition="'$(Build_Android)'=='true'">$(TargetFrameworks);net9.0-android</TargetFrameworks>
-		<TargetFrameworks Condition="'$(Build_Windows)'=='true'">$(TargetFrameworks);net9.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks>$(TargetFrameworks);net10.0;</TargetFrameworks>
+		<TargetFrameworks Condition="'$(Build_iOS)'=='true'">$(TargetFrameworks);net10.0-ios</TargetFrameworks>
+		<TargetFrameworks Condition="'$(Build_Android)'=='true'">$(TargetFrameworks);net10.0-android</TargetFrameworks>
+		<TargetFrameworks Condition="'$(Build_Windows)'=='true'">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
 	</PropertyGroup>
 </Project>

--- a/src/samples/SamplesApp.Shared/Content/Controls/DatePickerSamplePage.xaml
+++ b/src/samples/SamplesApp.Shared/Content/Controls/DatePickerSamplePage.xaml
@@ -8,8 +8,8 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:sample="using:Uno.Themes.Samples"
       xmlns:smtx="using:ShowMeTheXAML"
-      xmlns:xamarin="http://uno.ui/xamarin"
-      mc:Ignorable="d android ios xamarin">
+      xmlns:not_win="http://uno.ui/not_win"
+      mc:Ignorable="d android ios not_win">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<sample:SamplePageLayout>
@@ -27,7 +27,7 @@
 
 							<DatePicker x:Name="myDatePicker"
 							            HorizontalAlignment="Left"
-							            xamarin:UseNativeStyle="False"
+							            not_win:UseNativeStyle="False"
 							            Header="Enter Date"
 							            Style="{StaticResource MaterialDatePickerStyle}" />
 						</smtx:XamlDisplay>
@@ -37,7 +37,7 @@
 
 							<DatePicker x:Name="myDatePicker1"
 							            HorizontalAlignment="Left"
-							            xamarin:UseNativeStyle="False"
+							            not_win:UseNativeStyle="False"
 							            Header="Enter Date" />
 						</smtx:XamlDisplay>
 						
@@ -51,7 +51,7 @@
 						                  UniqueKey="DatePickerSamplePage_Material_Disabled">
 							
 							<DatePicker HorizontalAlignment="Left"
-							            xamarin:UseNativeStyle="False"
+							            not_win:UseNativeStyle="False"
 							            Header="Enter Date"
 							            IsEnabled="False"
 							            Style="{StaticResource MaterialDatePickerStyle}" />
@@ -73,7 +73,7 @@
 
 							<DatePicker x:Name="myDatePicker"
 							            HorizontalAlignment="Left"
-							            xamarin:UseNativeStyle="False"
+							            not_win:UseNativeStyle="False"
 							            Header="Enter Date"
 							            Style="{StaticResource MaterialDatePickerStyle}" />
 						</smtx:XamlDisplay>
@@ -88,7 +88,7 @@
 						                  UniqueKey="M3_DatePickerSamplePage_Material_Disabled">
 
 							<DatePicker HorizontalAlignment="Left"
-							            xamarin:UseNativeStyle="False"
+							            not_win:UseNativeStyle="False"
 							            Header="Enter Date"
 							            IsEnabled="False"
 							            Style="{StaticResource MaterialDatePickerStyle}" />
@@ -104,7 +104,7 @@
 
 							<DatePicker x:Name="myDatePicker2"
 							            HorizontalAlignment="Left"
-							            xamarin:UseNativeStyle="False"
+							            not_win:UseNativeStyle="False"
 							            Header="Enter Date"
 							            Style="{StaticResource CupertinoDatePickerStyle}" />
 						</smtx:XamlDisplay>

--- a/src/samples/SamplesApp.Shared/Content/Controls/FlyoutSamplePage.xaml
+++ b/src/samples/SamplesApp.Shared/Content/Controls/FlyoutSamplePage.xaml
@@ -6,7 +6,8 @@
 	  xmlns:ut="using:Uno.Themes"
 	  xmlns:sample="using:Uno.Themes.Samples"
 	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-	  xmlns:toolkit="using:Uno.UI.Toolkit">
+	  xmlns:uuxc="using:Uno.UI.Xaml.Controls"
+	  xmlns:uub="using:Uno.UI.Behaviors">
 	<Page.Resources>
 		<x:String x:Key="FlyoutCloseGlyphPathData">M1.442037,0L16.002031,14.585751 30.588022,0.025996563 32.001024,1.4409965 17.414783,16.001002 31.97503,30.587006 30.560022,32 15.999268,17.413969 1.4130009,31.973999 0,30.558998 14.586494,15.998742 0.027028472,1.4140019z</x:String>
 	</Page.Resources>
@@ -33,9 +34,9 @@
 												<RowDefinition Height="*" />
 											</Grid.RowDefinitions>
 											<CommandBar Content="FullScreen Flyout Example"
-														toolkit:VisibleBoundsPadding.PaddingMask="Top"
+														uub:VisibleBoundsPadding.PaddingMask="Top"
 														Style="{StaticResource MaterialCommandBarStyle}">
-												<toolkit:CommandBarExtensions.NavigationCommand>
+												<uuxc:CommandBarExtensions.NavigationCommand>
 													<AppBarButton Click="CloseFlyout"
 																  Tag="{Binding ElementName=ShowFullScreenFlyoutButton}"
 																  Style="{StaticResource MaterialAppBarButton}">
@@ -43,7 +44,7 @@
 															<PathIcon Data="{StaticResource FlyoutCloseGlyphPathData}" />
 														</AppBarButton.Icon>
 													</AppBarButton>
-												</toolkit:CommandBarExtensions.NavigationCommand>
+												</uuxc:CommandBarExtensions.NavigationCommand>
 											</CommandBar>
 
 											<TextBlock Grid.Row="1"
@@ -77,9 +78,9 @@
 												<RowDefinition Height="*" />
 											</Grid.RowDefinitions>
 											<CommandBar Content="Modal Centered Flyout Example"
-														toolkit:VisibleBoundsPadding.PaddingMask="Top"
+														uub:VisibleBoundsPadding.PaddingMask="Top"
 														Style="{StaticResource MaterialCommandBarStyle}">
-												<toolkit:CommandBarExtensions.NavigationCommand>
+												<uuxc:CommandBarExtensions.NavigationCommand>
 													<AppBarButton Click="CloseFlyout"
 																  Tag="{Binding ElementName=ShowModalCenteredFlyoutButton}"
 																  Style="{StaticResource MaterialAppBarButton}">
@@ -87,7 +88,7 @@
 															<PathIcon Data="{StaticResource CloseGlyphPathData}" />
 														</AppBarButton.Icon>
 													</AppBarButton>
-												</toolkit:CommandBarExtensions.NavigationCommand>
+												</uuxc:CommandBarExtensions.NavigationCommand>
 											</CommandBar>
 
 											<TextBlock Grid.Row="1"
@@ -332,9 +333,9 @@
 												<RowDefinition Height="*" />
 											</Grid.RowDefinitions>
 											<CommandBar Content="FullScreen Flyout Example"
-														toolkit:VisibleBoundsPadding.PaddingMask="Top"
+														uub:VisibleBoundsPadding.PaddingMask="Top"
 														Style="{StaticResource MaterialCommandBarStyle}">
-												<toolkit:CommandBarExtensions.NavigationCommand>
+												<uuxc:CommandBarExtensions.NavigationCommand>
 													<AppBarButton Click="CloseFlyout"
 																  Tag="{Binding ElementName=ShowFullScreenFlyoutButton}"
 																  Style="{StaticResource MaterialAppBarButton}">
@@ -342,7 +343,7 @@
 															<PathIcon Data="{StaticResource FlyoutCloseGlyphPathData}" />
 														</AppBarButton.Icon>
 													</AppBarButton>
-												</toolkit:CommandBarExtensions.NavigationCommand>
+												</uuxc:CommandBarExtensions.NavigationCommand>
 											</CommandBar>
 
 											<TextBlock Grid.Row="1"
@@ -376,9 +377,9 @@
 												<RowDefinition Height="*" />
 											</Grid.RowDefinitions>
 											<CommandBar Content="Modal Centered Flyout Example"
-														toolkit:VisibleBoundsPadding.PaddingMask="Top"
+														uub:VisibleBoundsPadding.PaddingMask="Top"
 														Style="{StaticResource MaterialCommandBarStyle}">
-												<toolkit:CommandBarExtensions.NavigationCommand>
+												<uuxc:CommandBarExtensions.NavigationCommand>
 													<AppBarButton Click="CloseFlyout"
 																  Tag="{Binding ElementName=ShowModalCenteredFlyoutButton}"
 																  Style="{StaticResource MaterialAppBarButton}">
@@ -386,7 +387,7 @@
 															<PathIcon Data="{StaticResource FlyoutCloseGlyphPathData}" />
 														</AppBarButton.Icon>
 													</AppBarButton>
-												</toolkit:CommandBarExtensions.NavigationCommand>
+												</uuxc:CommandBarExtensions.NavigationCommand>
 											</CommandBar>
 
 											<TextBlock Grid.Row="1"

--- a/src/samples/SamplesApp.Shared/Content/Controls/SliderSamplePage.xaml
+++ b/src/samples/SamplesApp.Shared/Content/Controls/SliderSamplePage.xaml
@@ -9,7 +9,7 @@
 	  xmlns:sample="using:Uno.Themes.Samples"
 	  xmlns:smtx="using:ShowMeTheXAML"
 	  mc:Ignorable="d android ios"
-	  xmlns:toolkit="using:Uno.UI.Toolkit">
+	  xmlns:uuxc="using:Uno.UI.Xaml.Controls">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<sample:SamplePageLayout>
@@ -109,7 +109,7 @@
 										Style="{StaticResource MaterialSecondarySliderStyle}"
 										Value="25" />
 
-								<toolkit:ElevatedView Width="28"
+								<uuxc:ElevatedView Width="28"
 													  Height="28"
 													  Background="Transparent"
 													  CornerRadius="14"
@@ -119,7 +119,7 @@
 											Width="28"
 											Height="28"
 											CornerRadius="14" />
-								</toolkit:ElevatedView>
+								</uuxc:ElevatedView>
 							</StackPanel>
 						</smtx:XamlDisplay>
 					</StackPanel>

--- a/src/samples/SamplesApp.Shared/Content/NestedSamples/MediaPlayerElementSample_NestedPage1.xaml
+++ b/src/samples/SamplesApp.Shared/Content/NestedSamples/MediaPlayerElementSample_NestedPage1.xaml
@@ -3,7 +3,8 @@
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:local="using:Uno.Themes.Samples.Content.NestedSamples"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	  xmlns:toolkit="using:Uno.UI.Toolkit"
+	  xmlns:uuxc="using:Uno.UI.Xaml.Controls"
+	  xmlns:uub="using:Uno.UI.Behaviors"
 	  xmlns:smtx="using:ShowMeTheXAML"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  mc:Ignorable="d"
@@ -17,9 +18,9 @@
 		</Grid.RowDefinitions>
 
 		<CommandBar Content="MediaPlayerElement sample"
-					toolkit:VisibleBoundsPadding.PaddingMask="Top"
+					uub:VisibleBoundsPadding.PaddingMask="Top"
 					Style="{StaticResource MaterialCommandBarStyle}">
-			<toolkit:CommandBarExtensions.NavigationCommand>
+			<uuxc:CommandBarExtensions.NavigationCommand>
 				<AppBarButton Click="NavigateBack"
 							  Style="{StaticResource MaterialAppBarButton}">
 					<AppBarButton.Icon>
@@ -27,7 +28,7 @@
 									ShowAsMonochrome="False" />
 					</AppBarButton.Icon>
 				</AppBarButton>
-			</toolkit:CommandBarExtensions.NavigationCommand>
+			</uuxc:CommandBarExtensions.NavigationCommand>
 		</CommandBar>
 
 		<TextBlock Grid.Row="1"

--- a/src/samples/SamplesApp.Shared/Content/NestedSamples/MediaPlayerElementSample_NestedPage2.xaml
+++ b/src/samples/SamplesApp.Shared/Content/NestedSamples/MediaPlayerElementSample_NestedPage2.xaml
@@ -3,7 +3,8 @@
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:local="using:Uno.Themes.Samples.Content.NestedSamples"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	  xmlns:toolkit="using:Uno.UI.Toolkit"
+	  xmlns:uuxc="using:Uno.UI.Xaml.Controls"
+	  xmlns:uub="using:Uno.UI.Behaviors"
 	  xmlns:smtx="using:ShowMeTheXAML"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  mc:Ignorable="d"
@@ -17,9 +18,9 @@
 		</Grid.RowDefinitions>
 
 		<CommandBar Content="MediaPlayerElement sample"
-					toolkit:VisibleBoundsPadding.PaddingMask="Top"
+					uub:VisibleBoundsPadding.PaddingMask="Top"
 					Style="{StaticResource MaterialCommandBarStyle}">
-			<toolkit:CommandBarExtensions.NavigationCommand>
+			<uuxc:CommandBarExtensions.NavigationCommand>
 				<AppBarButton Click="NavigateBack"
 							  Style="{StaticResource MaterialAppBarButton}">
 					<AppBarButton.Icon>
@@ -27,7 +28,7 @@
 									ShowAsMonochrome="False" />
 					</AppBarButton.Icon>
 				</AppBarButton>
-			</toolkit:CommandBarExtensions.NavigationCommand>
+			</uuxc:CommandBarExtensions.NavigationCommand>
 		</CommandBar>
 
 		<TextBlock Grid.Row="1"

--- a/src/samples/SamplesApp.Shared/Content/NestedSamples/MediaPlayerElementSample_NestedPage3.xaml
+++ b/src/samples/SamplesApp.Shared/Content/NestedSamples/MediaPlayerElementSample_NestedPage3.xaml
@@ -2,7 +2,8 @@
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:local="using:Uno.Themes.Samples.Content.NestedSamples"
-	  xmlns:toolkit="using:Uno.UI.Toolkit"
+	  xmlns:uuxc="using:Uno.UI.Xaml.Controls"
+	  xmlns:uub="using:Uno.UI.Behaviors"
 	  xmlns:smtx="using:ShowMeTheXAML"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -17,9 +18,9 @@
 		</Grid.RowDefinitions>
 
 		<CommandBar Content="MediaPlayerElement sample"
-					toolkit:VisibleBoundsPadding.PaddingMask="Top"
+					uub:VisibleBoundsPadding.PaddingMask="Top"
 					Style="{StaticResource MaterialCommandBarStyle}">
-			<toolkit:CommandBarExtensions.NavigationCommand>
+			<uuxc:CommandBarExtensions.NavigationCommand>
 				<AppBarButton Click="NavigateBack"
 							  Style="{StaticResource MaterialAppBarButton}">
 					<AppBarButton.Icon>
@@ -27,7 +28,7 @@
 									ShowAsMonochrome="False" />
 					</AppBarButton.Icon>
 				</AppBarButton>
-			</toolkit:CommandBarExtensions.NavigationCommand>
+			</uuxc:CommandBarExtensions.NavigationCommand>
 		</CommandBar>
 
 		<TextBlock Grid.Row="1"

--- a/src/samples/SamplesApp.Shared/Content/NestedSamples/MediaPlayerElementSample_NestedPage4.xaml
+++ b/src/samples/SamplesApp.Shared/Content/NestedSamples/MediaPlayerElementSample_NestedPage4.xaml
@@ -1,7 +1,8 @@
 ﻿<Page x:Class="Uno.Themes.Samples.Content.NestedSamples.MediaPlayerElementSample_NestedPage4"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:toolkit="using:Uno.UI.Toolkit"
+	  xmlns:uuxc="using:Uno.UI.Xaml.Controls"
+	  xmlns:uub="using:Uno.UI.Behaviors"
 	  xmlns:smtx="using:ShowMeTheXAML"
 	  xmlns:local="using:Uno.Themes.Samples.Content.NestedSamples"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -17,9 +18,9 @@
 		</Grid.RowDefinitions>
 
 		<CommandBar Content="MediaPlayerElement sample"
-					toolkit:VisibleBoundsPadding.PaddingMask="Top"
+					uub:VisibleBoundsPadding.PaddingMask="Top"
 					Style="{StaticResource MaterialCommandBarStyle}">
-			<toolkit:CommandBarExtensions.NavigationCommand>
+			<uuxc:CommandBarExtensions.NavigationCommand>
 				<AppBarButton Click="NavigateBack"
 							  Style="{StaticResource MaterialAppBarButton}">
 					<AppBarButton.Icon>
@@ -27,7 +28,7 @@
 									ShowAsMonochrome="False" />
 					</AppBarButton.Icon>
 				</AppBarButton>
-			</toolkit:CommandBarExtensions.NavigationCommand>
+			</uuxc:CommandBarExtensions.NavigationCommand>
 		</CommandBar>
 
 		<TextBlock Grid.Row="1"

--- a/src/samples/SamplesApp.Shared/Content/NestedSamples/MediaPlayerElementSample_NestedPage5.xaml
+++ b/src/samples/SamplesApp.Shared/Content/NestedSamples/MediaPlayerElementSample_NestedPage5.xaml
@@ -1,7 +1,8 @@
 ﻿<Page x:Class="Uno.Themes.Samples.Content.NestedSamples.MediaPlayerElementSample_NestedPage5"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:toolkit="using:Uno.UI.Toolkit"
+	  xmlns:uuxc="using:Uno.UI.Xaml.Controls"
+	  xmlns:uub="using:Uno.UI.Behaviors"
 	  xmlns:smtx="using:ShowMeTheXAML"
 	  xmlns:local="using:Uno.Themes.Samples.Content.NestedSamples"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -17,9 +18,9 @@
 		</Grid.RowDefinitions>
 
 		<CommandBar Content="MediaPlayerElement sample"
-					toolkit:VisibleBoundsPadding.PaddingMask="Top"
+					uub:VisibleBoundsPadding.PaddingMask="Top"
 					Style="{StaticResource MaterialCommandBarStyle}">
-			<toolkit:CommandBarExtensions.NavigationCommand>
+			<uuxc:CommandBarExtensions.NavigationCommand>
 				<AppBarButton Click="NavigateBack"
 							  Style="{StaticResource MaterialAppBarButton}">
 					<AppBarButton.Icon>
@@ -27,7 +28,7 @@
 									ShowAsMonochrome="False" />
 					</AppBarButton.Icon>
 				</AppBarButton>
-			</toolkit:CommandBarExtensions.NavigationCommand>
+			</uuxc:CommandBarExtensions.NavigationCommand>
 		</CommandBar>
 
 		<TextBlock Grid.Row="1"

--- a/src/samples/SamplesApp.Shared/Shell.xaml
+++ b/src/samples/SamplesApp.Shared/Shell.xaml
@@ -3,8 +3,8 @@
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-			 xmlns:xamarin="http://uno.ui/xamarin"
-			 mc:Ignorable="xamarin">
+			 xmlns:not_win="http://uno.ui/not_win"
+			 mc:Ignorable="not_win">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<Grid.RowDefinitions>
@@ -39,7 +39,7 @@
 		<Frame x:Name="NestedSampleFrame"
 			   Grid.RowSpan="3"
 			   Visibility="Collapsed"
-			   xamarin:Style="{StaticResource NativeDefaultFrame}" />
+			   not_win:Style="{StaticResource NativeDefaultFrame}" />
 
 		<StackPanel Grid.Row="2"
 					x:Name="DebuggingToolPanel"

--- a/src/samples/SamplesApp.Shared/Styles/Button.xaml
+++ b/src/samples/SamplesApp.Shared/Styles/Button.xaml
@@ -3,11 +3,10 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:xamarin="http://uno.ui/xamarin"
 					xmlns:android="http://uno.ui/android"
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:wasm="http://uno.ui/wasm"
-					mc:Ignorable="xamarin android ios wasm not_win">
+					mc:Ignorable="android ios wasm not_win">
 
 	<Style x:Key="SeeSourceFlyoutButtonStyle"
 		   BasedOn="{StaticResource DefaultButtonStyle}"

--- a/src/samples/global.json
+++ b/src/samples/global.json
@@ -2,7 +2,7 @@
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
     "Uno.Sdk": "6.4.53",
-    "Uno.Sdk.Private": "6.7.0-dev.815"
+    "Uno.Sdk.Private": "7.0.0-dev.645"
   },
   "sdk": {
     "allowPrerelease": false


### PR DESCRIPTION
**GitHub Issue:** relates to unoplatform/uno-private#2073

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes
- Refactoring (no functional changes, no api changes)
- Other... Please describe: **breaking retarget of every shipped package to Uno Platform 7.0**

## Description

> [!CAUTION]
> **This must not merge yet.** `Uno.Sdk.Private 7.0.0-dev.645`'s own `packages.json` still pins
> the Themes group at `7.1.0-dev.1` and the Toolkit group at `9.1.0-dev.2` — builds produced
> *before* this retarget, which target `net9.0` and bind to the pre-rename `Uno.UI.Toolkit`
> assembly. Merging before a 7.0-compatible `Uno.Sdk` version table exists would publish
> `net10.0` Themes packages that no shipping SDK version table points at. There is also no
> public `Uno.Sdk` 7.x at all yet (latest public is `6.8.0-dev.30`), which is why the library
> projects here move to `Sdk="Uno.Sdk.Private"` rather than staying on `Uno.Sdk`.

Retargets all seven shipped packages from Uno Platform 6.x / `net9.0` to Uno Platform 7.0 /
`net10.0`, and fixes the three 7.0 breaking changes this repository actually hits.

### 1. `chore!: Retarget libraries to Uno Platform 7.0`

- `global.json` and `src/samples/global.json`: `Uno.Sdk.Private` `6.7.0-dev.815` to `7.0.0-dev.645`.
- All **seven** library projects move to `Sdk="Uno.Sdk.Private"`. Five were already on `Uno.Sdk`;
  `Uno.Simple.WinUI` and `Uno.Simple.WinUI.Markup` were on `Microsoft.NET.Sdk` and are easy to
  miss — left alone they resolve the wrong `Uno.UI` flavour for `net10.0-android` and fail
  codegen with a wall of `CS0029 Grid -> Android.Views.View`.
- `src/library/tfm-common-winui.props`: `net9.0` to `net10.0` across the board, and Mac Catalyst
  is dropped — Uno Platform 7.0 ships neither a `lib` nor a `buildTransitive` asset for it.

### 2. `fix: Drop class constraint on GetTemplateChild`

`DependencyObject` is a class in 7.0, so `where TControl : class, DependencyObject` is `CS0450`.
Both sides of the old `#if HAS_UNO` now read identically, so the conditional goes with it.

### 3. `refactor!: Bind XAML to the renamed Extras namespaces`

The `Uno.UI.Toolkit` assembly is renamed to `Uno.UI.Extras` in 7.0 — renamed, not deleted, and it
still ships inside `Uno.WinUI` (verified: `Uno.WinUI/7.0.0-dev.645/lib/net10.0/Uno.UI.Extras.dll`
and the matching `net10.0-windows10.0.19041.0` asset). Its types did **not** move to a flat
`Uno.UI.Extras` namespace; each kept its natural `Uno.UI.*` one, so `using:Uno.UI.Toolkit` maps to
three different namespaces depending on the type:

| Type | 7.0 namespace | Prefix used here |
|---|---|---|
| `ElevatedView`, `CommandBarExtensions` | `Uno.UI.Xaml.Controls` | `uuxc` |
| `VisibleBoundsPadding` | `Uno.UI.Behaviors` | `uub` |
| `UIElementExtensions` | `Uno.UI.Xaml` | `uux` |

The prefixes match the ones Uno Platform's own markup uses for these namespaces. Seven files
declared `xmlns:toolkit` without ever using it; those declarations are simply removed.

### 4. `fix(xaml)!: Replace the removed xamarin/skia prefixes`

7.0 renamed the conditional XAML prefix vocabulary after the target frameworks. `skia` became
`not_winappsdk` (with `not_win` kept as a synonym), and `xamarin` was removed outright. In 6.x
`xamarin` was unconditionally included by the Uno XAML generator and stripped on WinAppSDK via
`mc:Ignorable`, and `skia` resolved to "rendered by Uno rather than WinUI" — both meant exactly
"every target except WinAppSDK", which is what `not_win` still means. So this is a rename, not a
behaviour change, and it matches the `not_win` spelling this repository already uses elsewhere.

**This one fails silently if left alone**, which is why it is in scope. An unknown prefix that is
listed in `mc:Ignorable` is stripped by markup-compatibility processing with no diagnostic at all.
Proven both directions on `net10.0` with `EmitCompilerGeneratedFiles=true`:

- with `not_win:` — `MaterialMUXNavigationViewResetSplitViewStyle` **is present** in the generated
  `mergedpages_v1_*.cs`;
- with `xamarin:` restored on that one file — it is **absent**, and the build still exits 0 with
  zero errors.

So on 7.0 the old spelling would have quietly deleted the guarded styles, setters, storyboards and
visual states from every target while CI stayed green.

## Correction to the working hypothesis: the Windows TFM keeps its 3-part form

The retarget note that seeded this work said the Windows TFM needed a trailing `.0`
(`net10.0-windows10.0.19041.0`) and that the bare form emits two `lib` folders. **Measured, that is
inverted**, so this PR uses the bare `net10.0-windows10.0.19041` — the minimal delta from `master`.
Two full package builds, differing only in that string:

| TFM string | `lib/` folders in `Uno.Material.WinUI.nupkg` |
|---|---|
| `net10.0-windows10.0.19041` | `net10.0`, `net10.0-android36.0`, `net10.0-ios26.0`, `net10.0-windows10.0.19041` |
| `net10.0-windows10.0.19041.0` | the same four, plus a second `net10.0-windows10.0.19041.0` |

NuGet normalises the *assembly* folder to the 3-part short name, but `GenerateLibraryLayout`
content is packed under the raw `$(TargetFramework)`. With the 4-part spelling the two disagree and
the Lottie assets (`Uno.Material.WinUI/Assets/*.json`, and the Cupertino equivalents) land in a
folder that holds no assembly. With the bare spelling they sit next to the DLL, exactly as they did
on `net9.0-windows10.0.19041`. Both spellings build green; only the layout differs.

## PR Checklist

Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/Uno.Themes/tree/master/doc)
	- [ ] [material-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/material-controls-styles.md)
	- [ ] [cupertino-controls-styles.md](https://github.com/unoplatform/Uno.Themes/blob/master/doc/cupertino-controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/Uno.Themes/blob/master/doc/lightweight-styling.md)
- [ ] Contains **No** breaking changes
  > **This PR is breaking.** Consumers move from `net9.0` to `net10.0` and from Uno Platform 6.x to
  > 7.0; there is no 6.x-compatible build of these packages after this change. Mac Catalyst is no
  > longer produced. The `xamarin:` and `skia:` XAML prefixes are gone from the shipped styles.

## Validation — exactly what was and was not run

**Ran (Compile + pack).** The Packages stage, the same solution filter and target CI uses, on this
branch's HEAD, with real `MSBuild.exe` (`dotnet build` cannot do the WinAppSDK TFM):

```
MSBuild.exe Uno.Themes-packages.slnf -p:Configuration=Release "-t:Restore;Build"
  -p:GeneratePackageOnBuild=true -m -v:m -p:PackageOutputPath=<out>
```

MSBuild 18.9.1, .NET SDK 10.0.400. **Exit code 0, 0 errors, 411 warnings, all 7 `.nupkg` produced**,
each carrying all four CI target frameworks (`net10.0`, `net10.0-android36.0`, `net10.0-ios26.0`,
`net10.0-windows10.0.19041`). All 411 warnings are pre-existing classes — `NU1507` (package source
mapping), `NU5104` (prerelease dependency under the local `1.0.0` version; CI passes a prerelease
`PackageVersion`), and `CS0618` on the repository's own already-obsolete members.

**Not run — needs a reviewer or CI to cover.**

- The WASM, iOS, Android and Desktop **sample-head** stages. The heads already target `net10.0-*`
  and pick up the new SDK through `src/samples/global.json`, but none of them was built here.
- **Runtime tests**, and any runtime behaviour at all. Nothing in this PR was executed — the
  generated-code checks above are compile-time evidence, not runtime evidence.
- Visual verification of the styles whose `xamarin:`/`skia:` markup moved to `not_win:`. The markup
  is proven to reach the generated code; that it *renders* the same has not been checked.
- `src/samples/SamplesApp.Shared/Shell.xaml` references `NativeDefaultFrame` behind what is now
  `not_win:`. That resource came from the native renderers 7.0 removes, so it may no longer
  resolve. Sample-app only, and untested here.

## Other information

Deliberately left alone, having been checked and found harmless:

- `macos:` / `not_macos:` (~47 constructs). `macos` was already unconditionally *excluded* and
  `not_macos` unconditionally *included* in 6.x, and both still resolve that way in 7.0 —
  `macos` through `mc:Ignorable`, `not_macos` through the default presentation namespace. Dead
  weight, but not a silent failure, so cleaning it up belongs in its own PR.
- `netstdref:` in `NavigationView_MUX.xaml` — inside an XML comment.
- `_IsNetCore` / `_IsNetStd` in `PlatformItemGroups.props` still test for `net9.0`; both properties
  are unreferenced anywhere in the repository.

## Internal Issue (If applicable):

Tracked internally; see the issue reference at the top of this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vRaBaNK2HnyWeg3TBzEu6
