### PR TITLE
ci: Build and publish from servicing/* branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,7 @@
   branches:
     include:
       - master
+      - servicing/*
       - stable
       - release/stable/*
       - legacy/*
@@ -11,6 +12,7 @@ pr:
   branches:
     include:
       - master
+      - servicing/*
       - stable
       - release/stable/*
       - legacy/*
@@ -75,9 +77,13 @@ stages:
 ## Publishing
 ##
 
+# A servicing/* branch continues a previous version line after master has moved on
+# to a newer one, so it publishes dev packages the same way master does. The same
+# pattern is added to the CI triggers, the dev-feed push step and version.json's
+# publicReleaseRefSpec.
 - stage: Publish_Dev
   displayName: 'Publish - Dev NuGet.org'
-  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature')), not(eq(variables['build.reason'], 'PullRequest')))
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature')), not(eq(variables['build.reason'], 'PullRequest')))
   dependsOn: Packages
   jobs:
   - template: build/publish/publish-nuget-dev.yml

--- a/build/templates/nuget-publish-dev.yml
+++ b/build/templates/nuget-publish-dev.yml
@@ -1,7 +1,9 @@
 steps:
+  # A servicing/* branch continues a previous version line after master has moved on
+  # to a newer one, so its packages reach the dev feed the same way master's do.
   - task: NuGetCommand@2
     displayName: 'Publish to Uno Dev Feed'
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/')), not(eq(variables['build.reason'], 'PullRequest')))
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/')), not(eq(variables['build.reason'], 'PullRequest')))
     inputs:
       command: 'push'
       packagesToPush: '$(Pipeline.Workspace)/NuGet_Packages/**/*.nupkg'

--- a/version.json
+++ b/version.json
@@ -7,6 +7,7 @@
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/feature/.*$",
+    "^refs/heads/servicing/.*$",
     "^refs/heads/release/stable/\\d+(?:\\.\\d+)?$"
   ],
   "cloudBuild": {


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Release-process plumbing, internal maintenance for Uno 7.0 preparation. -->

## PR Type

- Build or CI related changes

## What is the current behavior?

`master` is the only branch that publishes a Themes dev channel. `servicing/*` is not wired into this pipeline, so such a branch builds nothing.

## What is the new behavior?

Teaches the pipeline about `servicing/*` branches — a branch that continues a previous version line after `master` has moved on, so clients still on Uno 6.x keep getting dev packages to validate fixes against before we backport them to a service release.

| Change | Why |
|---|---|
| `servicing/*` in `trigger.branches` and `pr.branches` (`azure-pipelines.yml`) | the branch builds at all, and PRs into it run |
| `servicing/` in the `Publish_Dev` stage condition | the dev publish stage runs for it |
| `servicing/` in the dev-feed push step (`build/templates/nuget-publish-dev.yml`) | packages also reach the internal dev feed, matching `master` |
| `^refs/heads/servicing/.*$` in `publicReleaseRefSpec` (`version.json`) | NBGV emits a clean `X.Y.0-dev.N` rather than appending a commit hash |

`build/templates/nuget-publish-public.yml` needs no change — its condition is already "not a feature branch and not a PR", which `servicing/*` satisfies.

## Inert on `master`

Every edit adds a branch pattern inside an existing `or(...)`, or appends a list entry. **No version change** — `master` stays `8.0-dev`. Nothing `master` matches today behaves differently; the only observable difference is for branches named `servicing/*`.

## Context: how Themes is split

`master` (`8.0-dev`) becomes the **Uno 7.0** line. The 6.x line continues on **[`servicing/7.2`](https://github.com/unoplatform/Uno.Themes/tree/servicing/7.2)**, cut from `d20cd743` — the commit that shipped as `7.2.0-dev.3` — so it resumes exactly where the published 7.2 dev channel stopped, at `7.2.0-dev.4`. No version offset, no gap, and no already-published version changes meaning.

Deliberately **not** included on the servicing branch, to be backported only if needed for 6.x:

| Commit | |
|---|---|
| `60888c8c` | Color Fidelity (#1697) |
| `723154f4` | `feat!` DefaultSpacing base unit + Density as a pure mode (#1701) |
| `0438da03` | instance-based `Application.GetTheme()` extension (#1699) |

Unlike the other repos in this effort, Themes needs **no version bump**: `8.0` was already cut for its own breaking changes, and `7.2-dev` versus `8.0-dev` are already distinct version spaces, so the two branches cannot collide on NBGV height.

## PR Checklist

- [x] Tested with current supported SDKs — no product code changed
- [ ] Docs — n/a
- [ ] Tests — n/a, pipeline and version metadata only
- [x] Contains **NO** breaking changes
- [x] Commits follow Conventional Commits

## Other information

Same pattern already merged in [`unoplatform/uno#24361`](https://github.com/unoplatform/uno/pull/24361), [`uno.csharpmarkup#904`](https://github.com/unoplatform/uno.csharpmarkup/pull/904) and [`uno.app-mcp#143`](https://github.com/unoplatform/uno.app-mcp/pull/143), with [`uno.toolkit.ui#1634`](https://github.com/unoplatform/uno.toolkit.ui/pull/1634) open.

For reference, the 7.0 work still ahead on this repo: ~84 removed conditional XAML prefix occurrences (42 `xamarin:`, 18 `macos:`, 18 `not_macos:`, 4 `netstdref:`, 2 `skia:`) and 27 `Uno.UI.Toolkit` references, several in shipped `Uno.Material` / `Uno.Cupertino` style files. Themes already targets net10, so no target-framework move is needed.
