### PR TITLE
ci: Validate conventional commits on servicing/* branches

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - servicing/*
       - release/*/*
       - feature/*
 


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type

- Build or CI related changes

## What is the current behavior?

`Validate Conventional Commits` is a **required status check** on `master`, but the workflow only listens for PRs targeting `master`, `release/*/*` and `feature/*`. A PR into a `servicing/*` branch never gets that check.

## What is the new behavior?

Adds `servicing/*` to the workflow's `pull_request.branches` list.

Prerequisite for giving [`servicing/7.2`](https://github.com/unoplatform/Uno.Themes/tree/servicing/7.2) the same branch protection as `master`: a required check that never reports leaves the PR stuck at *"Expected — waiting for status"*, unmergeable short of an admin override.

The ADO check (`Uno.Themes - CI`) already covers `servicing/*` via #1713.

## PR Checklist

- [x] Tested with current supported SDKs — workflow trigger configuration only
- [ ] Docs — n/a
- [ ] Tests — n/a
- [x] Contains **NO** breaking changes
- [x] Commits follow Conventional Commits