### PR TITLE
fix(themes): read generated spacing and shape tokens through ThemeResource

### DIFF
--- a/doc/design-tokens.md
+++ b/doc/design-tokens.md
@@ -92,12 +92,10 @@ This generates all `Radius*` / `Space*` tokens as multiples of the base value. T
 
 For spacing, the [density mode](#density-modes) (`DefaultDensity`) composes with the base unit rather than replacing it: the effective spacing base is `DefaultSpacing × density factor` (`Compact` ×0.75, `Regular` ×1, `Comfy` ×1.25). With the default base of 4, the modes yield 3 / 4 / 5.
 
-> [!IMPORTANT]
-> `DefaultCornerRadius`, `DefaultSpacing`, and `DefaultDensity` are **construction-time settings**. Set them where the theme is declared — normally `App.xaml` — and treat them as fixed for the lifetime of the theme.
+> [!NOTE]
+> `DefaultCornerRadius`, `DefaultSpacing`, and `DefaultDensity` are **runtime-settable**. Assigning one regenerates the `Radius*` / `Space*` token resources, and controls created afterwards pick the new scale up through their styles.
 >
-> Assigning them later does regenerate the `Radius*` and `Space*` token resources, but it does **not** restyle controls: neither the ones already on screen nor ones created afterwards. Unlike colors — which *can* change live, see [Runtime Seed Color Changes](seed-colors.md#runtime-seed-color-changes) — these tokens are `CornerRadius` / `Thickness` / `double` **values**, and the per-control keys that consume them (`ButtonCornerRadius`, `ButtonPadding`, …) are resolved once when the theme's control-style dictionaries are first parsed. There is no live instance to update, so the new value never reaches the control templates.
->
-> If you need to offer density or shape as a user setting, change the property and then recreate the root content (or re-navigate) so the styles are applied fresh.
+> Controls **already on screen** keep the values they resolved when they loaded: these tokens are `CornerRadius` / `Thickness` / `double` **values**, so unlike a seed color — whose brushes are live instances the theme rewrites in place, see [Runtime Seed Color Changes](seed-colors.md#runtime-seed-color-changes) — there is nothing to mutate. Their styles read the tokens through `{ThemeResource}`, so a theme-change pass re-resolves them: toggle the root element's `RequestedTheme` away from its `ActualTheme` and back, or recreate the root content.
 
 ### Via Lightweight Styling
 
@@ -115,12 +113,12 @@ To override individual tokens without changing the whole scale, use standard XAM
 
 | Property              | Type         | Description                                                                                                                                 |
 |-----------------------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| `DefaultCornerRadius` | `double`     | Base corner radius unit; generates the full `Radius*` scale. Construction-time.                                                             |
-| `DefaultSpacing`      | `double`     | Base spacing unit (default 4); generates the full `Space*` scale, scaled by the `DefaultDensity` mode. Construction-time.                   |
-| `DefaultDensity`      | `Density`    | Density mode that scales the spacing base unit (`Compact` ×0.75, `Regular` ×1, `Comfy` ×1.25). Construction-time.                           |
+| `DefaultCornerRadius` | `double`     | Base corner radius unit; generates the full `Radius*` scale. Runtime-settable.                                                              |
+| `DefaultSpacing`      | `double`     | Base spacing unit (default 4); generates the full `Space*` scale, scaled by the `DefaultDensity` mode. Runtime-settable.                    |
+| `DefaultDensity`      | `Density`    | Density mode that scales the spacing base unit (`Compact` ×0.75, `Regular` ×1, `Comfy` ×1.25). Runtime-settable.                            |
 | `DefaultFontFamily`   | `FontFamily` | The font the type scale is generated from: the `DefaultFontFamily` token and every `*FontFamily` key derived from it. Runtime-settable.     |
 
-These properties are defined on `BaseTheme` and inherited by `MaterialTheme`, `SimpleTheme`, and their toolkit wrappers (`MaterialToolkitTheme`, `SimpleToolkitTheme`). The three scale measures are construction-time settings — see the note above. `DefaultFontFamily` and the color configuration on the separate `Colors` property (`ThemeColors`) *do* support runtime changes — see [Typography Font Swap](#typography-font-swap) and [Seed Color Palette](seed-colors.md).
+These properties are defined on `BaseTheme` and inherited by `MaterialTheme`, `SimpleTheme`, and their toolkit wrappers (`MaterialToolkitTheme`, `SimpleToolkitTheme`). All four regenerate their tokens when assigned at runtime; content already on screen re-resolves on a theme-change pass — see the note above and [Typography Font Swap](#typography-font-swap). The color configuration on the separate `Colors` property (`ThemeColors`) changes live — see [Seed Color Palette](seed-colors.md).
 
 ### Density Modes
 
@@ -141,7 +139,7 @@ It is a *mode*, not a value: it scales the `DefaultSpacing` base unit (effective
 <SimpleTheme xmlns="using:Uno.Simple" DefaultSpacing="6" DefaultDensity="Comfy" />
 ```
 
-Pick the density where the theme is declared. Switching it at runtime does not restyle existing or newly-created controls — see [Via Scalar Properties](#via-scalar-properties).
+Switching it at runtime regenerates the `Space*` tokens; controls created afterwards use them, and controls already on screen re-resolve on a theme-change pass — see [Via Scalar Properties](#via-scalar-properties).
 
 ### Typography Font Swap
 
@@ -158,11 +156,12 @@ overridden individually. Left unset, the design system's own typeface stands. Po
 that resolves multiple weights — a variable font, or a font shipping a font manifest — so the
 per-scale `*FontWeight` tokens (`DisplayLargeFontWeight`, …) render as designed.
 
-Unlike the scale measures above, this is **runtime-settable**: assigning it regenerates the derived
+Like the scale measures above, this is **runtime-settable**: assigning it regenerates the derived
 family keys, and text laid out afterwards picks the new font up. Text **already on screen** keeps the
 family it resolved when it loaded — a `FontFamily` is an immutable value, so unlike a seed color
 (whose brushes are live instances the theme rewrites in place) there is nothing to mutate. To move
-text that is already rendered, recreate the root content, or trigger the application-wide resource
+text that is already rendered, run a theme-change pass (toggle the root's `RequestedTheme` away from
+its `ActualTheme` and back), recreate the root content, or trigger the application-wide resource
 refresh a hot reload performs.
 
 > [!NOTE]

--- a/specs/07-default-spacing/progress.md
+++ b/specs/07-default-spacing/progress.md
@@ -63,3 +63,30 @@ Verification (Simple host, net10.0-desktop Debug, headless `--runtime-tests` run
   guard, unrelated).
 - Build clean: no new warnings in `BaseTheme.cs` / `Given_DesignTokens.cs` (only the two
   pre-existing CS0618 obsolete-member warnings in `BaseTheme.cs`).
+
+## Review addendum (2026-09-03) — the seam now reaches realized controls
+
+`doc/design-tokens.md` had recorded the three scale measures as construction-time: "assigning them
+later does regenerate the tokens but does not restyle controls". That was a defect, not a property
+of the design. The generated `Space*` / `Radius*` keys were fine; the control styles read them —
+directly or through per-control aliases such as `SimpleButtonCornerRadius` and
+`MaterialContentDialogPanelPadding` — with `{StaticResource}`, which snapshots at parse time.
+
+- **Sweep.** Alias closure over every `<StaticResource x:Key ResourceKey>` declaration rooted at a
+  generated key, then every `{StaticResource K}` consumer of that closure, across Simple and
+  Material v2: 98 sites in 22 files (78 Simple, 20 Material v2), all rewritten to
+  `{ThemeResource}`. Density constants (`ControlHeight*`, `IconSize*`, `TouchTargetMinSize`) are
+  regenerated with fixed values and were left as they are.
+- **Red / green.** `Given_DesignTokens.When_ScaleMeasuresChangeAtRuntime_Then_RealizedButtonFollows`
+  (Simple head): a realized `SimpleFilledButtonStyle` button kept `Padding` 12 / `CornerRadius` 8
+  after `DefaultSpacing` = 10, `DefaultDensity` = Compact, `DefaultCornerRadius` = 1 — expected
+  22.5 / 2 — and a button created after the change is asserted too.
+  `Given_DesignTokens.When_ScaleMeasuresChangeAtRuntime_Then_RealizedContentDialogFollows`
+  (Material head): a realized `MaterialContentDialogStyle` dialog kept `CornerRadius` 28 — expected
+  7. Both red before the rewrite, green after. Both mutate the application theme (the scope a
+  designer edits) and restore it in `finally`; realized content re-resolves on a `RequestedTheme`
+  flip, the same route `FontFamilyTunerControl` uses.
+- **Suites.** Simple head 256 / 0 failed; Material head 63 / 0 failed (net10.0-desktop Debug,
+  headless `--runtime-tests`). Build clean, no new warnings.
+- **Docs.** `doc/design-tokens.md`: the scale measures are documented as runtime-settable with the
+  already-realized caveat and the theme-change-pass route, matching the `DefaultFontFamily` wording.

--- a/specs/lessons.md
+++ b/specs/lessons.md
@@ -65,11 +65,20 @@ dictionary. `{ThemeResource}` keeps the reference and re-resolves on a theme-cha
   Whenever a fix's claim is "the control follows", assert the rendered `FontFamily` / `Padding` /
   `CornerRadius` on a realized control after the property changes, not the resource lookup. This is
   the same trap the `SharedTypography` lesson below records, hit from the other side.
-- **Still open elsewhere:** ~16 `{StaticResource}` setters in Simple's control styles read the
-  generated spacing/shape keys (`SimpleSpace300Thickness`, `ControlHeightMedium`,
-  `Simple*CornerRadius`). By the same mechanism a runtime `DefaultSpacing` / `DefaultDensity` /
-  `DefaultCornerRadius` change should not reach them — inferred, **not measured**; it belongs with
-  the density/spacing seam (spec 07/08), not #1705.
+- **The same defect held for the spacing/shape seam, and was measured before it was fixed.** A
+  sweep over Simple and Material v2 (alias closure over `<StaticResource x:Key ResourceKey>`
+  declarations rooted at the generated `Space*` / `Radius*` keys, then every `{StaticResource K}`
+  consumer of that closure) found 98 sites in 22 files — 78 Simple, 20 Material v2. Red: a
+  realized Simple button kept `Padding` 12 after `DefaultSpacing` moved it to 22.5; a realized
+  Material `ContentDialog` kept `CornerRadius` 28 after `DefaultCornerRadius` moved it to 7. The
+  sweep is the way to find these: grep for the *generated* key alone misses every per-control
+  alias (`SimpleButtonCornerRadius`, `MaterialContentDialogPanelPadding`, …) that stands between
+  the token and the setter. Density constants (`ControlHeight*`, `IconSize*`,
+  `TouchTargetMinSize`) are regenerated with fixed values, so a `{StaticResource}` read of those
+  is harmless and was left alone.
+- **`doc/design-tokens.md` had documented the defect as a design property** ("construction-time
+  settings … the new value never reaches the control templates"). A limitation written into the
+  docs is still a claim; check it against the mechanism before carrying it forward.
 
 ---
 

--- a/src/library/Uno.Material/Styles/Controls/v2/AppBarButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/AppBarButton.xaml
@@ -88,7 +88,7 @@
 										Orientation="Vertical"
 										VerticalAlignment="Center"
 										HorizontalAlignment="Stretch"
-										Spacing="{StaticResource Space200}">
+										Spacing="{ThemeResource Space200}">
 								<!-- Icon content wrapped in Viewbox (shown when Icon is set) -->
 								<Viewbox x:Name="ContentViewbox"
 										 MaxHeight="{ThemeResource AppBarButtonContentHeight}"

--- a/src/library/Uno.Material/Styles/Controls/v2/CalendarView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/CalendarView.xaml
@@ -271,7 +271,7 @@
 									<ColumnDefinition Width="*" />
 								</Grid.ColumnDefinitions>
 								<Button x:Name="HeaderButton"
-										Padding="{StaticResource Space300LeftThickness}"
+										Padding="{ThemeResource Space300LeftThickness}"
 										HorizontalContentAlignment="Left"
 										Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.HeaderText}"
 										Foreground="{TemplateBinding Foreground}"

--- a/src/library/Uno.Material/Styles/Controls/v2/ContentDialog.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ContentDialog.xaml
@@ -43,7 +43,7 @@
 
 		<Setter Property="Background" Value="{StaticResource MaterialContentDialogBackground}" />
 		<Setter Property="Foreground" Value="{StaticResource MaterialContentDialogContentForeground}" />
-		<Setter Property="CornerRadius" Value="{StaticResource MaterialContentDialogCornerRadius}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource MaterialContentDialogCornerRadius}" />
 
 		<Setter Property="HorizontalAlignment" Value="Stretch" />
 		<Setter Property="VerticalAlignment" Value="Stretch" />
@@ -197,7 +197,7 @@
 											MinWidth="{StaticResource MaterialContentDialogMinWidth}"
 											MinHeight="{StaticResource MaterialContentDialogMinHeight}" />
 									
-									<Grid x:Name="DialogSpace" Margin="{StaticResource MaterialContentDialogPanelPadding}">
+									<Grid x:Name="DialogSpace" Margin="{ThemeResource MaterialContentDialogPanelPadding}">
 										<Grid.RowDefinitions>
 											<!-- 0: Title, 1: Content, 2: CommandSpace -->
 											<RowDefinition Height="Auto" />
@@ -213,7 +213,7 @@
 														FontFamily="{ThemeResource HeadlineSmallFontFamily}"
 														FontSize="{StaticResource HeadlineSmallFontSize}"
 														FontWeight="{ThemeResource HeadlineSmallFontWeight}"
-														Margin="{StaticResource MaterialContentDialogTitleToContentMargin}"
+														Margin="{ThemeResource MaterialContentDialogTitleToContentMargin}"
 														HorizontalAlignment="Center"
 														VerticalAlignment="Top"
 														IsTabStop="False">
@@ -247,7 +247,7 @@
 										</ScrollViewer>
 										<Grid x:Name="CommandSpace"
 											  Grid.Row="2"
-											  Margin="{StaticResource MaterialContentDialogCommandSpaceToContentMargin}"
+											  Margin="{ThemeResource MaterialContentDialogCommandSpaceToContentMargin}"
 											  HorizontalAlignment="Right"
 											  VerticalAlignment="Bottom"
 											  XYFocusKeyboardNavigation="Enabled">

--- a/src/library/Uno.Material/Styles/Controls/v2/Flyout.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/Flyout.xaml
@@ -124,7 +124,7 @@
 					  Width="{StaticResource MaterialFlyoutMenuToggleCheckGlyphWidth}"
 					  Height="{StaticResource MaterialFlyoutMenuToggleCheckGlyphHeight}"
 					  VerticalAlignment="Center"
-					  Margin="{StaticResource Space300HorizontalThickness}"
+					  Margin="{ThemeResource Space300HorizontalThickness}"
 					  Data="{StaticResource MaterialFlyoutCheckGlyphPathStyle}"
 					  Fill="{ThemeResource OnSurfaceVariantBrush}"
 					  Opacity="0"
@@ -385,7 +385,7 @@
 
 						<Viewbox x:Name="IconRoot"
 						         Width="{StaticResource MaterialFlyoutMenuItemIconWidth}"
-					         Margin="{StaticResource Space300LeftThickness}"
+					         Margin="{ThemeResource Space300LeftThickness}"
 					         HorizontalAlignment="Left"
 					         VerticalAlignment="Center"
 					         Visibility="Collapsed">
@@ -396,7 +396,7 @@
 
 					<TextBlock x:Name="TextBlock"
 					           Grid.Column="1"
-					           Margin="{StaticResource Space300LeftThickness}"
+					           Margin="{ThemeResource Space300LeftThickness}"
 						           VerticalAlignment="Center"
 						           Foreground="{TemplateBinding Foreground}"
 						           Style="{StaticResource MaterialLabelLarge}"
@@ -555,7 +555,7 @@
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 
-<Grid Margin="{StaticResource Space300LeftThickness}">
+<Grid Margin="{ThemeResource Space300LeftThickness}">
 							<Grid.ColumnDefinitions>
 								<ColumnDefinition Width="*" />
 								<ColumnDefinition Width="Auto" />

--- a/src/library/Uno.Material/Styles/Controls/v2/ListView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/ListView.xaml
@@ -388,7 +388,7 @@
 								BorderThickness="2"
 								Width="20"
 								Height="20"
-								Margin="{StaticResource Space300LeftThickness}"
+								Margin="{ThemeResource Space300LeftThickness}"
 								VerticalAlignment="Center"
 								HorizontalAlignment="Left"
 								Visibility="Collapsed">

--- a/src/library/Uno.Material/Styles/Controls/v2/NavigationView.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/NavigationView.xaml
@@ -1971,7 +1971,7 @@
 										<Grid x:Name="AutoSuggestArea"
 											  Grid.Row="3"
 											  Height="{ThemeResource NavigationViewAutoSuggestAreaHeight}"
-											  Margin="{StaticResource Space200BottomThickness}"
+											  Margin="{ThemeResource Space200BottomThickness}"
 											  VerticalAlignment="Center">
 
 											<ContentControl x:Name="PaneAutoSuggestBoxPresenter"
@@ -3072,7 +3072,7 @@
 							</todo:Grid>
 
 							<Grid x:Name="ContentGrid"
-								  Padding="{StaticResource Space400Thickness}">
+								  Padding="{ThemeResource Space400Thickness}">
 								<Grid.ColumnDefinitions>
 									<!-- 0: Icon, 1: Content, 2: InfoBadge, 3: Chevron -->
 									<ColumnDefinition x:Name="IconColumn"
@@ -3355,7 +3355,7 @@
 							<Viewbox x:Name="IconBox"
 									 Height="16"
 									 Width="16"
-									 Margin="{StaticResource Space300LeftThickness}"
+									 Margin="{ThemeResource Space300LeftThickness}"
 									 VerticalAlignment="Center"
 									 HorizontalAlignment="Center">
 								<ContentPresenter x:Name="Icon"
@@ -3621,7 +3621,7 @@
 								<Viewbox x:Name="IconBox"
 										 Height="16"
 										 Width="16"
-										 Margin="{StaticResource Space400LeftThickness}"
+										 Margin="{ThemeResource Space400LeftThickness}"
 										 VerticalAlignment="Center"
 										 HorizontalAlignment="Center">
 									<ContentPresenter x:Name="Icon"
@@ -3774,7 +3774,7 @@
 						</VisualStateManager.VisualStateGroups>
 
 						<Grid x:Name="InnerHeaderGrid"
-							  Padding="{StaticResource Space400Thickness}"
+							  Padding="{ThemeResource Space400Thickness}"
 							  HorizontalAlignment="Left"
 							  Margin="{ThemeResource NavigationViewItemInnerHeaderMargin}">
 							<TextBlock x:Name="HeaderText"

--- a/src/library/Uno.Material/Styles/Controls/v2/PasswordBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/PasswordBox.xaml
@@ -624,7 +624,7 @@
 							</Viewbox>
 							<!-- ContentElement -->
 							<Grid Grid.Column="1"
-								  Margin="{StaticResource Space200HorizontalThickness}">
+								  Margin="{ThemeResource Space200HorizontalThickness}">
 								<ScrollViewer x:Name="ContentElement"
 											  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
 											  AutomationProperties.AccessibilityView="Raw"

--- a/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/v2/TextBox.xaml
@@ -520,7 +520,7 @@
 
 							<Button x:Name="DeleteButton"
 									Grid.Column="2"
-									Margin="{StaticResource Space200LeftThickness}"
+									Margin="{ThemeResource Space200LeftThickness}"
 									Foreground="{ThemeResource FilledTextBoxDeleteButtonForeground}"
 									IsTabStop="False"
 									Style="{StaticResource MaterialDeleteButtonStyle}"
@@ -685,7 +685,7 @@
 							</Viewbox>
 
 							<!-- 1: Text Elements Container -->
-							<Grid Grid.Column="1" Margin="{StaticResource Space200HorizontalThickness}">
+							<Grid Grid.Column="1" Margin="{ThemeResource Space200HorizontalThickness}">
 								<!--
 									We need to center this in both Singleline and Multiline mode:
 									- SingleLine via Border.MinHeight + SV.HAlign

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/AppBarButton.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/AppBarButton.xaml
@@ -119,7 +119,7 @@
 		<Setter Property="Foreground" Value="{ThemeResource AppBarButtonForeground}" />
 		<Setter Property="BorderBrush" Value="{ThemeResource AppBarButtonBorderBrush}" />
 		<Setter Property="BorderThickness" Value="0" />
-		<Setter Property="Padding" Value="{StaticResource SimpleAppBarButtonPadding}" />
+		<Setter Property="Padding" Value="{ThemeResource SimpleAppBarButtonPadding}" />
 		<Setter Property="HorizontalAlignment" Value="Left" />
 		<Setter Property="VerticalAlignment" Value="Top" />
 		<Setter Property="MinHeight" Value="{ThemeResource AppBarButtonHeight}" />
@@ -178,7 +178,7 @@
 									Orientation="Vertical"
 									VerticalAlignment="Center"
 									HorizontalAlignment="Center"
-									Spacing="{StaticResource SimpleAppBarButtonContentSpacing}">
+									Spacing="{ThemeResource SimpleAppBarButtonContentSpacing}">
 
 							<!-- Icon content wrapped in Viewbox (shown when Icon is set) -->
 							<Viewbox x:Name="ContentViewbox"

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/Button.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/Button.xaml
@@ -201,8 +201,8 @@
 		<Setter Property="FontSize" Value="{StaticResource LabelLargeFontSize}" />
 		<Setter Property="FontWeight" Value="{StaticResource SimpleButtonFontWeight}" />
 		<Setter Property="MinHeight" Value="{StaticResource ControlHeightMedium}" />
-		<Setter Property="Padding" Value="{StaticResource SimpleSpace300Thickness}" />
-		<Setter Property="CornerRadius" Value="{StaticResource SimpleButtonCornerRadius}" />
+		<Setter Property="Padding" Value="{ThemeResource SimpleSpace300Thickness}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource SimpleButtonCornerRadius}" />
 		<Setter Property="BorderThickness" Value="{StaticResource SimpleButtonBorderThickness}" />
 		<Setter Property="HorizontalAlignment" Value="Left" />
 		<Setter Property="VerticalAlignment" Value="Center" />
@@ -268,7 +268,7 @@
 						<StackPanel Orientation="Horizontal"
 									HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 									VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-									Spacing="{StaticResource SimpleButtonIconSpacing}">
+									Spacing="{ThemeResource SimpleButtonIconSpacing}">
 
 							<ContentPresenter x:Name="LeadingIconPresenter"
 											  Content="{Binding Path=(ut:ControlExtensions.LeadingIcon), RelativeSource={RelativeSource TemplatedParent}}"
@@ -352,7 +352,7 @@
 						<StackPanel Orientation="Horizontal"
 									HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 									VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-									Spacing="{StaticResource SimpleButtonIconSpacing}">
+									Spacing="{ThemeResource SimpleButtonIconSpacing}">
 
 							<ContentPresenter x:Name="LeadingIconPresenter"
 											  Content="{Binding Path=(ut:ControlExtensions.LeadingIcon), RelativeSource={RelativeSource TemplatedParent}}"
@@ -436,7 +436,7 @@
 						<StackPanel Orientation="Horizontal"
 									HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 									VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-									Spacing="{StaticResource SimpleButtonIconSpacing}">
+									Spacing="{ThemeResource SimpleButtonIconSpacing}">
 
 							<ContentPresenter x:Name="LeadingIconPresenter"
 											  Content="{Binding Path=(ut:ControlExtensions.LeadingIcon), RelativeSource={RelativeSource TemplatedParent}}"
@@ -520,7 +520,7 @@
 						<StackPanel Orientation="Horizontal"
 									HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 									VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-									Spacing="{StaticResource SimpleButtonIconSpacing}">
+									Spacing="{ThemeResource SimpleButtonIconSpacing}">
 
 							<ContentPresenter x:Name="LeadingIconPresenter"
 											  Content="{Binding Path=(ut:ControlExtensions.LeadingIcon), RelativeSource={RelativeSource TemplatedParent}}"
@@ -604,7 +604,7 @@
 						<StackPanel Orientation="Horizontal"
 									HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 									VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-									Spacing="{StaticResource SimpleButtonIconSpacing}">
+									Spacing="{ThemeResource SimpleButtonIconSpacing}">
 
 							<ContentPresenter x:Name="LeadingIconPresenter"
 											  Content="{Binding Path=(ut:ControlExtensions.LeadingIcon), RelativeSource={RelativeSource TemplatedParent}}"
@@ -661,8 +661,8 @@
 		<Setter Property="MinWidth" Value="{StaticResource SimpleIconLarge}" />
 		<Setter Property="MaxHeight" Value="{StaticResource SimpleIconLarge}" />
 		<Setter Property="MaxWidth" Value="{StaticResource SimpleIconLarge}" />
-		<Setter Property="Padding" Value="{StaticResource SimpleSpace200Thickness}" />
-		<Setter Property="CornerRadius" Value="{StaticResource SimpleIconButtonCornerRadius}" />
+		<Setter Property="Padding" Value="{ThemeResource SimpleSpace200Thickness}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource SimpleIconButtonCornerRadius}" />
 		<Setter Property="BorderThickness" Value="{StaticResource SimpleIconButtonBorderThickness}" />
 		<Setter Property="HorizontalAlignment" Value="Center" />
 		<Setter Property="VerticalAlignment" Value="Center" />

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/CheckBox.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/CheckBox.xaml
@@ -337,8 +337,8 @@
 						<!-- CheckBox Visual -->
 						<Grid x:Name="CheckBoxContainer"
 							  Grid.Column="0"
-							  Width="{StaticResource SimpleCheckBoxSize}"
-							  Height="{StaticResource SimpleCheckBoxSize}"
+							  Width="{ThemeResource SimpleCheckBoxSize}"
+							  Height="{ThemeResource SimpleCheckBoxSize}"
 							  HorizontalAlignment="Center"
 							  VerticalAlignment="Center">
 
@@ -375,7 +375,7 @@
 						<!-- Content -->
 						<ContentPresenter x:Name="ContentPresenter"
 										  Grid.Column="1"
-										  Margin="{StaticResource SimpleCheckBoxContentMargin}"
+										  Margin="{ThemeResource SimpleCheckBoxContentMargin}"
 										  Content="{TemplateBinding Content}"
 										  ContentTemplate="{TemplateBinding ContentTemplate}"
 										  ContentTransitions="{TemplateBinding ContentTransitions}"

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/ComboBox.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/ComboBox.xaml
@@ -142,7 +142,7 @@
 		<Setter Property="VerticalAlignment" Value="Top" />
 		<Setter Property="HorizontalContentAlignment" Value="Left" />
 		<Setter Property="VerticalContentAlignment" Value="Center" />
-		<Setter Property="CornerRadius" Value="{StaticResource SimpleComboBoxCornerRadius}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource SimpleComboBoxCornerRadius}" />
 		<Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
 		<Setter Property="FocusVisualMargin" Value="-3" />
 		<Setter Property="ItemContainerStyle" Value="{StaticResource SimpleComboBoxItemStyle}" />
@@ -269,8 +269,8 @@
 									Background="{ThemeResource ComboBoxDropDownBackground}"
 									BorderBrush="{ThemeResource ComboBoxDropDownBorderBrush}"
 									BorderThickness="{ThemeResource SimpleStrokeBorderThickness}"
-									CornerRadius="{StaticResource SimpleComboBoxCornerRadius}"
-									Padding="{StaticResource SimpleComboBoxPopupPadding}"
+									CornerRadius="{ThemeResource SimpleComboBoxCornerRadius}"
+									Padding="{ThemeResource SimpleComboBoxPopupPadding}"
 									MaxHeight="{StaticResource SimpleComboBoxPopupMaxHeight}">
 								<Border.Shadow>
 									<ThemeShadow />

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/ContentDialog.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/ContentDialog.xaml
@@ -75,7 +75,7 @@
 		<Setter Property="Foreground" Value="{ThemeResource OnSurfaceMediumBrush}" />
 		<Setter Property="BorderBrush" Value="{ThemeResource OutlineBrush}" />
 		<Setter Property="BorderThickness" Value="1" />
-		<Setter Property="CornerRadius" Value="{StaticResource SimpleContentDialogCornerRadius}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource SimpleContentDialogCornerRadius}" />
 
 		<Setter Property="HorizontalAlignment" Value="Stretch" />
 		<Setter Property="VerticalAlignment" Value="Stretch" />
@@ -221,7 +221,7 @@
 											MinHeight="{StaticResource SimpleContentDialogMinHeight}" />
 
 									<Grid x:Name="DialogSpace"
-										  Margin="{StaticResource SimpleContentDialogPanelPadding}">
+										  Margin="{ThemeResource SimpleContentDialogPanelPadding}">
 
 										<Grid.RowDefinitions>
 											<RowDefinition Height="Auto" />
@@ -238,7 +238,7 @@
 												FontFamily="{ThemeResource HeadlineSmallFontFamily}"
 												FontSize="{ThemeResource HeadlineSmallFontSize}"
 														FontWeight="SemiBold"
-														Margin="{StaticResource SimpleContentDialogTitleToContentMargin}"
+														Margin="{ThemeResource SimpleContentDialogTitleToContentMargin}"
 														HorizontalAlignment="Left"
 														VerticalAlignment="Top"
 														IsTabStop="False">
@@ -275,7 +275,7 @@
 										<!-- Command buttons -->
 										<Grid x:Name="CommandSpace"
 											  Grid.Row="2"
-											  Margin="{StaticResource SimpleContentDialogCommandSpaceToContentMargin}"
+											  Margin="{ThemeResource SimpleContentDialogCommandSpaceToContentMargin}"
 											  HorizontalAlignment="Right"
 											  VerticalAlignment="Bottom"
 											  XYFocusKeyboardNavigation="Enabled">

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/Expander.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/Expander.xaml
@@ -71,7 +71,7 @@
 	<!-- ═══════════════════════════════════════════════════════════════════════ -->
 	<Style x:Key="SimpleExpanderHeaderDownStyle"
 		   TargetType="ToggleButton">
-		<Setter Property="Padding" Value="{StaticResource SimpleExpanderHeaderPadding}" />
+		<Setter Property="Padding" Value="{ThemeResource SimpleExpanderHeaderPadding}" />
 		<Setter Property="HorizontalContentAlignment" Value="Left" />
 		<Setter Property="BackgroundSizing" Value="InnerBorderEdge" />
 		<Setter Property="Template">
@@ -339,14 +339,14 @@
 								Width="{StaticResource SimpleExpanderChevronButtonSize}"
 								Height="{StaticResource SimpleExpanderChevronButtonSize}"
 								Margin="{StaticResource SimpleExpanderChevronMargin}"
-								CornerRadius="{StaticResource SimpleExpanderCornerRadius}"
+								CornerRadius="{ThemeResource SimpleExpanderCornerRadius}"
 								Background="Transparent"
 								BorderBrush="Transparent"
 								BorderThickness="0">
 							<FontIcon x:Name="ExpandCollapseChevron"
 									  Glyph="{StaticResource SimpleExpanderChevronDownGlyph}"
 									  FontFamily="{StaticResource SymbolThemeFontFamily}"
-									  FontSize="{StaticResource SimpleExpanderChevronGlyphSize}"
+									  FontSize="{ThemeResource SimpleExpanderChevronGlyphSize}"
 									  Foreground="{ThemeResource OnSurfaceBrush}"
 									  HorizontalAlignment="Center"
 									  VerticalAlignment="Center"
@@ -634,14 +634,14 @@
 								Width="{StaticResource SimpleExpanderChevronButtonSize}"
 								Height="{StaticResource SimpleExpanderChevronButtonSize}"
 								Margin="{StaticResource SimpleExpanderChevronMargin}"
-								CornerRadius="{StaticResource SimpleExpanderCornerRadius}"
+								CornerRadius="{ThemeResource SimpleExpanderCornerRadius}"
 								Background="Transparent"
 								BorderBrush="Transparent"
 								BorderThickness="0">
 							<FontIcon x:Name="ExpandCollapseChevron"
 									  Glyph="{StaticResource SimpleExpanderChevronDownGlyph}"
 									  FontFamily="{StaticResource SymbolThemeFontFamily}"
-									  FontSize="{StaticResource SimpleExpanderChevronGlyphSize}"
+									  FontSize="{ThemeResource SimpleExpanderChevronGlyphSize}"
 									  Foreground="{ThemeResource OnSurfaceBrush}"
 									  HorizontalAlignment="Center"
 									  VerticalAlignment="Center"
@@ -669,13 +669,13 @@
 		<Setter Property="Background" Value="{ThemeResource SurfaceBrush}" />
 		<Setter Property="BackgroundSizing" Value="InnerBorderEdge" />
 		<Setter Property="MinWidth" Value="{ThemeResource FlyoutThemeMinWidth}" />
-		<Setter Property="MinHeight" Value="{StaticResource SimpleExpanderMinHeight}" />
+		<Setter Property="MinHeight" Value="{ThemeResource SimpleExpanderMinHeight}" />
 		<Setter Property="BorderThickness" Value="{StaticResource SimpleExpanderContentBorderThickness}" />
 		<Setter Property="BorderBrush" Value="{ThemeResource OutlineBrush}" />
-		<Setter Property="Padding" Value="{StaticResource SimpleExpanderContentPadding}" />
+		<Setter Property="Padding" Value="{ThemeResource SimpleExpanderContentPadding}" />
 		<Setter Property="HorizontalAlignment" Value="Stretch" />
 		<Setter Property="VerticalAlignment" Value="Center" />
-		<Setter Property="CornerRadius" Value="{StaticResource SimpleExpanderCornerRadius}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource SimpleExpanderCornerRadius}" />
 		<Setter Property="Foreground" Value="{ThemeResource OnSurfaceBrush}" />
 		<Setter Property="FontFamily" Value="{ThemeResource BodyLargeFontFamily}" />
 		<Setter Property="FontSize" Value="{ThemeResource BodyLargeFontSize}" />
@@ -811,10 +811,10 @@
 									  BorderBrush="{ThemeResource OutlineBrush}"
 									  BorderThickness="{StaticResource SimpleExpanderHeaderBorderThickness}"
 									  CornerRadius="{TemplateBinding CornerRadius}"
-									  MinHeight="{StaticResource SimpleExpanderMinHeight}"
+									  MinHeight="{ThemeResource SimpleExpanderMinHeight}"
 									  MinWidth="{TemplateBinding MinWidth}"
 									  MaxWidth="{TemplateBinding MaxWidth}"
-									  Padding="{StaticResource SimpleExpanderHeaderPadding}"
+									  Padding="{ThemeResource SimpleExpanderHeaderPadding}"
 									  FontFamily="{ThemeResource BodyLargeFontFamily}"
 									  FontSize="{ThemeResource BodyLargeFontSize}"
 									  FontWeight="{ThemeResource SimpleSemiBoldFontWeight}"

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/MenuFlyout.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/MenuFlyout.xaml
@@ -161,7 +161,7 @@
 								 Grid.Column="0"
 								 Width="{ThemeResource SimpleSpace400}"
 								 Height="{ThemeResource SimpleSpace400}"
-								 Margin="{StaticResource SimpleMenuFlyoutItemIconMargin}"
+								 Margin="{ThemeResource SimpleMenuFlyoutItemIconMargin}"
 								 HorizontalAlignment="Left"
 								 VerticalAlignment="Center"
 								 Visibility="Collapsed">
@@ -179,7 +179,7 @@
 
 						<TextBlock x:Name="KeyboardAcceleratorTextBlock"
 								   Grid.Column="2"
-								   Margin="{StaticResource SimpleMenuFlyoutItemAcceleratorMargin}"
+								   Margin="{ThemeResource SimpleMenuFlyoutItemAcceleratorMargin}"
 								   VerticalAlignment="Center"
 								   Foreground="{ThemeResource OnSurfaceMediumBrush}"
 								   Text="{TemplateBinding KeyboardAcceleratorTextOverride}"
@@ -275,7 +275,7 @@
 								  Glyph="&#xE73E;"
 								  FontSize="{ThemeResource BodySmallFontSize}"
 								  Foreground="{ThemeResource OnSurfaceBrush}"
-								  Margin="{StaticResource SimpleMenuFlyoutCheckGlyphMargin}"
+								  Margin="{ThemeResource SimpleMenuFlyoutCheckGlyphMargin}"
 								  Opacity="0"
 								  VerticalAlignment="Center" />
 
@@ -283,7 +283,7 @@
 								 Grid.Column="1"
 								 Width="{ThemeResource SimpleSpace400}"
 								 Height="{ThemeResource SimpleSpace400}"
-								 Margin="{StaticResource SimpleMenuFlyoutItemIconMargin}"
+								 Margin="{ThemeResource SimpleMenuFlyoutItemIconMargin}"
 								 HorizontalAlignment="Left"
 								 VerticalAlignment="Center"
 								 Visibility="Collapsed">
@@ -301,7 +301,7 @@
 
 						<TextBlock x:Name="KeyboardAcceleratorTextBlock"
 								   Grid.Column="3"
-								   Margin="{StaticResource SimpleMenuFlyoutItemAcceleratorMargin}"
+								   Margin="{ThemeResource SimpleMenuFlyoutItemAcceleratorMargin}"
 								   VerticalAlignment="Center"
 								   Foreground="{ThemeResource OnSurfaceMediumBrush}"
 								   Text="{TemplateBinding KeyboardAcceleratorTextOverride}"
@@ -397,7 +397,7 @@
 								 Grid.Column="0"
 								 Width="{ThemeResource SimpleSpace400}"
 								 Height="{ThemeResource SimpleSpace400}"
-								 Margin="{StaticResource SimpleMenuFlyoutItemIconMargin}"
+								 Margin="{ThemeResource SimpleMenuFlyoutItemIconMargin}"
 								 HorizontalAlignment="Left"
 								 VerticalAlignment="Center"
 								 Visibility="Collapsed">
@@ -419,7 +419,7 @@
 								  Glyph="&#xE76C;"
 								  FontSize="{ThemeResource BodySmallFontSize}"
 								  Foreground="{ThemeResource OnSurfaceBrush}"
-								  Margin="{StaticResource SimpleMenuFlyoutItemAcceleratorMargin}"
+								  Margin="{ThemeResource SimpleMenuFlyoutItemAcceleratorMargin}"
 								  VerticalAlignment="Center" />
 					</Grid>
 				</ControlTemplate>
@@ -516,7 +516,7 @@
 							  Grid.Column="0"
 							  Width="14"
 							  Height="14"
-							  Margin="{StaticResource SimpleMenuFlyoutCheckGlyphMargin}"
+							  Margin="{ThemeResource SimpleMenuFlyoutCheckGlyphMargin}"
 							  VerticalAlignment="Center">
 							<Ellipse Stroke="{ThemeResource OnSurfaceBrush}"
 									 StrokeThickness="1.5"
@@ -533,7 +533,7 @@
 								 Grid.Column="1"
 								 Width="{ThemeResource SimpleSpace400}"
 								 Height="{ThemeResource SimpleSpace400}"
-								 Margin="{StaticResource SimpleMenuFlyoutItemIconMargin}"
+								 Margin="{ThemeResource SimpleMenuFlyoutItemIconMargin}"
 								 HorizontalAlignment="Left"
 								 VerticalAlignment="Center"
 								 Visibility="Collapsed">
@@ -551,7 +551,7 @@
 
 						<TextBlock x:Name="KeyboardAcceleratorTextBlock"
 								   Grid.Column="3"
-								   Margin="{StaticResource SimpleMenuFlyoutItemAcceleratorMargin}"
+								   Margin="{ThemeResource SimpleMenuFlyoutItemAcceleratorMargin}"
 								   VerticalAlignment="Center"
 								   Foreground="{ThemeResource OnSurfaceMediumBrush}"
 								   Text="{TemplateBinding KeyboardAcceleratorTextOverride}"

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/ProgressBar.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/ProgressBar.xaml
@@ -50,7 +50,7 @@
 		<Setter Property="Background" Value="{ThemeResource ProgressBarBackground}" />
 		<Setter Property="Maximum" Value="100" />
 		<Setter Property="MinWidth" Value="{StaticResource SimpleProgressBarMinWidth}" />
-		<Setter Property="Height" Value="{StaticResource SimpleProgressBarHeight}" />
+		<Setter Property="Height" Value="{ThemeResource SimpleProgressBarHeight}" />
 		<Setter Property="CornerRadius" Value="2" />
 	</Style>
 

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/RadioButton.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/RadioButton.xaml
@@ -189,23 +189,23 @@
 						<!-- Radio Circle -->
 						<Grid x:Name="RadioContainer"
 							  Grid.Column="0"
-							  Width="{StaticResource SimpleRadioButtonSize}"
-							  Height="{StaticResource SimpleRadioButtonSize}"
+							  Width="{ThemeResource SimpleRadioButtonSize}"
+							  Height="{ThemeResource SimpleRadioButtonSize}"
 							  HorizontalAlignment="Center"
 							  VerticalAlignment="Center">
 
 							<!-- Unchecked outer circle -->
 							<Ellipse x:Name="RadioBorder"
-									 Width="{StaticResource SimpleRadioButtonSize}"
-									 Height="{StaticResource SimpleRadioButtonSize}"
+									 Width="{ThemeResource SimpleRadioButtonSize}"
+									 Height="{ThemeResource SimpleRadioButtonSize}"
 									 Fill="{ThemeResource RadioButtonOuterEllipseFill}"
 									 Stroke="{ThemeResource RadioButtonOuterEllipseStroke}"
 									 StrokeThickness="{StaticResource SimpleRadioButtonStrokeThickness}" />
 
 							<!-- Checked outer circle (hidden by default) -->
 							<Ellipse x:Name="RadioBorder_Checked"
-									 Width="{StaticResource SimpleRadioButtonSize}"
-									 Height="{StaticResource SimpleRadioButtonSize}"
+									 Width="{ThemeResource SimpleRadioButtonSize}"
+									 Height="{ThemeResource SimpleRadioButtonSize}"
 									 Fill="{ThemeResource RadioButtonOuterEllipseCheckedFill}"
 									 Stroke="{ThemeResource RadioButtonOuterEllipseCheckedStroke}"
 									 StrokeThickness="{StaticResource SimpleRadioButtonStrokeThickness}"
@@ -213,8 +213,8 @@
 
 							<!-- Inner dot (hidden by default) -->
 							<Ellipse x:Name="RadioDot"
-									 Width="{StaticResource SimpleRadioButtonDotSize}"
-									 Height="{StaticResource SimpleRadioButtonDotSize}"
+									 Width="{ThemeResource SimpleRadioButtonDotSize}"
+									 Height="{ThemeResource SimpleRadioButtonDotSize}"
 									 Fill="{ThemeResource OnPrimaryBrush}"
 									 HorizontalAlignment="Center"
 									 VerticalAlignment="Center"
@@ -224,7 +224,7 @@
 						<!-- Content (label) -->
 						<ContentPresenter x:Name="ContentPresenter"
 										  Grid.Column="1"
-										  Margin="{StaticResource SimpleRadioButtonContentMargin}"
+										  Margin="{ThemeResource SimpleRadioButtonContentMargin}"
 										  Content="{TemplateBinding Content}"
 										  ContentTemplate="{TemplateBinding ContentTemplate}"
 										  ContentTransitions="{TemplateBinding ContentTransitions}"

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/Slider.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/Slider.xaml
@@ -124,7 +124,7 @@
 					<Border Background="{TemplateBinding Background}"
 							BorderBrush="{TemplateBinding BorderBrush}"
 							BorderThickness="{TemplateBinding BorderThickness}"
-							CornerRadius="{StaticResource SliderThumbCornerRadius}" />
+							CornerRadius="{ThemeResource SliderThumbCornerRadius}" />
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
@@ -143,7 +143,7 @@
 		<Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
 		<Setter Property="FocusVisualMargin" Value="{StaticResource SliderFocusVisualMargin}" />
 		<Setter Property="IsFocusEngagementEnabled" Value="True" />
-		<Setter Property="CornerRadius" Value="{StaticResource SliderCornerRadius}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource SliderCornerRadius}" />
 
 		<Setter Property="Template">
 			<Setter.Value>
@@ -224,7 +224,7 @@
 										  ContentTemplate="{TemplateBinding HeaderTemplate}"
 										  FontFamily="{ThemeResource BodyLargeFontFamily}"
 										  Foreground="{ThemeResource OnSurfaceBrush}"
-										  Margin="{StaticResource SliderHeaderMargin}"
+										  Margin="{ThemeResource SliderHeaderMargin}"
 										  TextWrapping="Wrap"
 										  Visibility="Collapsed"
 										  x:DeferLoadStrategy="Lazy" />
@@ -255,14 +255,14 @@
 								<Rectangle x:Name="HorizontalTrackRect"
 										   Grid.Row="1"
 										   Grid.ColumnSpan="3"
-										   Height="{StaticResource SliderTrackThickness}"
+										   Height="{ThemeResource SliderTrackThickness}"
 										   Fill="{TemplateBinding Background}"
 										   RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
 										   RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" />
 
 								<!-- Filled (decrease) track -->
 								<Border Grid.Row="1"
-										Height="{StaticResource SliderFillThickness}"
+										Height="{ThemeResource SliderFillThickness}"
 										CornerRadius="{StaticResource SliderHorizontalFillCornerRadius}">
 									<Rectangle x:Name="HorizontalDecreaseRect"
 											   Fill="{TemplateBinding Foreground}" />
@@ -273,8 +273,8 @@
 									   Grid.Row="0"
 									   Grid.RowSpan="3"
 									   Grid.Column="1"
-									   Width="{StaticResource SliderThumbWidth}"
-									   Height="{StaticResource SliderThumbHeight}"
+									   Width="{ThemeResource SliderThumbWidth}"
+									   Height="{ThemeResource SliderThumbHeight}"
 									   AutomationProperties.AccessibilityView="Raw"
 									   DataContext="{TemplateBinding Value}"
 									   FocusVisualMargin="{StaticResource SliderHorizontalFocusVisualMargin}"
@@ -300,7 +300,7 @@
 
 								<!-- Background track -->
 								<Rectangle x:Name="VerticalTrackRect"
-										   Width="{StaticResource SliderTrackThickness}"
+										   Width="{ThemeResource SliderTrackThickness}"
 										   Grid.RowSpan="3"
 										   Grid.Column="1"
 										   Fill="{TemplateBinding Background}"
@@ -312,7 +312,7 @@
 										Grid.Column="1"
 										CornerRadius="{StaticResource SliderVerticalFillCornerRadius}">
 									<Rectangle x:Name="VerticalDecreaseRect"
-											   Width="{StaticResource SliderFillThickness}"
+											   Width="{ThemeResource SliderFillThickness}"
 											   Fill="{TemplateBinding Foreground}" />
 								</Border>
 
@@ -321,8 +321,8 @@
 									   Grid.Row="1"
 									   Grid.Column="0"
 									   Grid.ColumnSpan="3"
-									   Width="{StaticResource SliderThumbWidth}"
-									   Height="{StaticResource SliderThumbHeight}"
+									   Width="{ThemeResource SliderThumbWidth}"
+									   Height="{ThemeResource SliderThumbHeight}"
 									   AutomationProperties.AccessibilityView="Raw"
 									   DataContext="{TemplateBinding Value}"
 									   FocusVisualMargin="{StaticResource SliderVerticalFocusVisualMargin}"

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/TextBox.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/TextBox.xaml
@@ -285,7 +285,7 @@
 										  FontSize="{ThemeResource BodyMediumFontSize}"
 										  FontWeight="SemiBold"
 										  Foreground="{ThemeResource FilledTextBoxHeaderForeground}"
-										  Margin="{StaticResource SimpleTextBoxHeaderMargin}"
+										  Margin="{ThemeResource SimpleTextBoxHeaderMargin}"
 										  TextWrapping="Wrap"
 										  Visibility="Collapsed"
 										  x:DeferLoadStrategy="Lazy" />
@@ -432,7 +432,7 @@
 										  FontSize="{ThemeResource BodyMediumFontSize}"
 										  FontWeight="SemiBold"
 										  Foreground="{ThemeResource OutlinedTextBoxHeaderForeground}"
-										  Margin="{StaticResource SimpleTextBoxHeaderMargin}"
+										  Margin="{ThemeResource SimpleTextBoxHeaderMargin}"
 										  TextWrapping="Wrap"
 										  Visibility="Collapsed"
 										  x:DeferLoadStrategy="Lazy" />

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/ToggleButton.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/ToggleButton.xaml
@@ -153,8 +153,8 @@
 		<Setter Property="FontSize" Value="{StaticResource LabelLargeFontSize}" />
 		<Setter Property="FontWeight" Value="{StaticResource SimpleToggleButtonFontWeight}" />
 		<Setter Property="MinHeight" Value="{StaticResource ControlHeightMedium}" />
-		<Setter Property="Padding" Value="{StaticResource SimpleSpace300Thickness}" />
-		<Setter Property="CornerRadius" Value="{StaticResource SimpleToggleButtonCornerRadius}" />
+		<Setter Property="Padding" Value="{ThemeResource SimpleSpace300Thickness}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource SimpleToggleButtonCornerRadius}" />
 		<Setter Property="BorderThickness" Value="{StaticResource SimpleToggleButtonBorderThickness}" />
 		<Setter Property="HorizontalAlignment" Value="Left" />
 		<Setter Property="VerticalAlignment" Value="Center" />
@@ -290,7 +290,7 @@
 						<StackPanel Orientation="Horizontal"
 									HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 									VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-									Spacing="{StaticResource SimpleToggleButtonIconSpacing}">
+									Spacing="{ThemeResource SimpleToggleButtonIconSpacing}">
 
 							<ContentPresenter x:Name="LeadingIconPresenter"
 											  Content="{Binding Path=(ut:ControlExtensions.LeadingIcon), RelativeSource={RelativeSource TemplatedParent}}"
@@ -329,8 +329,8 @@
 		<Setter Property="MinWidth" Value="{StaticResource SimpleIconLarge}" />
 		<Setter Property="MaxHeight" Value="{StaticResource SimpleIconLarge}" />
 		<Setter Property="MaxWidth" Value="{StaticResource SimpleIconLarge}" />
-		<Setter Property="Padding" Value="{StaticResource SimpleSpace200Thickness}" />
-		<Setter Property="CornerRadius" Value="{StaticResource SimpleIconButtonCornerRadius}" />
+		<Setter Property="Padding" Value="{ThemeResource SimpleSpace200Thickness}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource SimpleIconButtonCornerRadius}" />
 		<Setter Property="BorderThickness" Value="{StaticResource SimpleIconButtonBorderThickness}" />
 		<Setter Property="HorizontalAlignment" Value="Center" />
 		<Setter Property="VerticalAlignment" Value="Center" />

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/ToggleSwitch.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/ToggleSwitch.xaml
@@ -172,7 +172,7 @@
 										  Content="{TemplateBinding Header}"
 										  ContentTemplate="{TemplateBinding HeaderTemplate}"
 										  Foreground="{ThemeResource ToggleSwitchContentForeground}"
-										  Margin="{StaticResource SimpleToggleSwitchHeaderMargin}"
+										  Margin="{ThemeResource SimpleToggleSwitchHeaderMargin}"
 										  VerticalAlignment="Top"
 										  Visibility="Collapsed" />
 
@@ -188,8 +188,8 @@
 							<Rectangle x:Name="OuterBorder"
 									   Width="{StaticResource SimpleToggleSwitchTrackWidth}"
 									   Height="{StaticResource SimpleToggleSwitchTrackHeight}"
-									   RadiusX="{StaticResource SimpleToggleSwitchTrackRadius}"
-									   RadiusY="{StaticResource SimpleToggleSwitchTrackRadius}"
+									   RadiusX="{ThemeResource SimpleToggleSwitchTrackRadius}"
+									   RadiusY="{ThemeResource SimpleToggleSwitchTrackRadius}"
 									   Fill="{ThemeResource ToggleSwitchOuterBorderFill}"
 									   Stroke="{ThemeResource ToggleSwitchOuterBorderStroke}"
 									   StrokeThickness="{StaticResource SimpleToggleSwitchStrokeThickness}"
@@ -199,8 +199,8 @@
 							<Rectangle x:Name="SwitchKnobBounds"
 									   Width="{StaticResource SimpleToggleSwitchTrackWidth}"
 									   Height="{StaticResource SimpleToggleSwitchTrackHeight}"
-									   RadiusX="{StaticResource SimpleToggleSwitchTrackRadius}"
-									   RadiusY="{StaticResource SimpleToggleSwitchTrackRadius}"
+									   RadiusX="{ThemeResource SimpleToggleSwitchTrackRadius}"
+									   RadiusY="{ThemeResource SimpleToggleSwitchTrackRadius}"
 									   Fill="{ThemeResource ToggleSwitchKnobBoundsFill}"
 									   HorizontalAlignment="Center"
 									   Opacity="0" />
@@ -214,8 +214,8 @@
 								<Grid x:Name="SwitchKnobOn"
 									  HorizontalAlignment="Left">
 									<Ellipse x:Name="KnobOn"
-											 Width="{StaticResource SimpleToggleSwitchThumbSize}"
-											 Height="{StaticResource SimpleToggleSwitchThumbSize}"
+											 Width="{ThemeResource SimpleToggleSwitchThumbSize}"
+											 Height="{ThemeResource SimpleToggleSwitchThumbSize}"
 											 Fill="{ThemeResource ToggleSwitchKnobOnFill}"
 											 Margin="{StaticResource SimpleToggleSwitchThumbOnMargin}"
 											 HorizontalAlignment="Left"
@@ -227,8 +227,8 @@
 								<Grid x:Name="SwitchKnobOff"
 									  HorizontalAlignment="Left">
 									<Ellipse x:Name="KnobOff"
-											 Width="{StaticResource SimpleToggleSwitchThumbSize}"
-											 Height="{StaticResource SimpleToggleSwitchThumbSize}"
+											 Width="{ThemeResource SimpleToggleSwitchThumbSize}"
+											 Height="{ThemeResource SimpleToggleSwitchThumbSize}"
 											 Fill="{ThemeResource ToggleSwitchKnobOffFill}"
 											 Margin="{StaticResource SimpleToggleSwitchThumbOffMargin}"
 											 HorizontalAlignment="Left"

--- a/src/library/Uno.Simple.WinUI/Styles/Controls/ToolTip.xaml
+++ b/src/library/Uno.Simple.WinUI/Styles/Controls/ToolTip.xaml
@@ -55,7 +55,7 @@
 		<Setter Property="Foreground" Value="{ThemeResource OnSurfaceBrush}" />
 		<Setter Property="BorderThickness" Value="{StaticResource SimpleToolTipBorderThickness}" />
 		<Setter Property="Padding" Value="{StaticResource SimpleToolTipPadding}" />
-		<Setter Property="CornerRadius" Value="{StaticResource SimpleToolTipCornerRadius}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource SimpleToolTipCornerRadius}" />
 		<Setter Property="FontFamily" Value="{ThemeResource BodyMediumFontFamily}" />
 		<Setter Property="FontSize" Value="{ThemeResource BodyMediumFontSize}" />
 		<Setter Property="MaxWidth" Value="320" />

--- a/src/samples/MaterialSampleApp/RuntimeTests/Given_DesignTokens.cs
+++ b/src/samples/MaterialSampleApp/RuntimeTests/Given_DesignTokens.cs
@@ -330,4 +330,60 @@ public class Given_DesignTokens
 			"FilledButton CornerRadius should be 30 at base=6 (Radius500 = 6×5)");
 	}
 
+	// ═══════════════════════════════════════════════════════════════════════
+	// 9. RUNTIME SEAM — the scale measures move controls, not only tokens.
+	// Regenerated Space*/Radius* keys reach a control only if its template reads them through
+	// {ThemeResource}; a {StaticResource} attribute snapshots the value at parse time. Asserted on
+	// the application theme (the scope a designer edits), restored in finally. ContentDialog is
+	// the Material v2 control whose panel padding and corner radius were read statically.
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_ScaleMeasuresChangeAtRuntime_Then_RealizedContentDialogFollows()
+	{
+		var theme = SemanticThemeHelper.GetTheme();
+		Assert.IsNotNull(theme, "The Material sample app must have a BaseTheme in its application resources.");
+
+		var originalSpacing = theme.DefaultSpacing;
+		var originalRadius = theme.DefaultCornerRadius;
+
+		// Declared in the tree like a page-level dialog; its style applies without showing it.
+		var root = new Grid();
+		var dialog = new ContentDialog
+		{
+			Title = "probe",
+			Content = "probe",
+			Style = (Style)Application.Current.Resources["MaterialContentDialogStyle"],
+		};
+		root.Children.Add(dialog);
+
+		UnitTestsUIContentHelper.Content = root;
+		await UnitTestsUIContentHelper.WaitForLoaded(dialog);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		try
+		{
+			var radiusBefore = dialog.CornerRadius;
+
+			theme.DefaultSpacing = 10;      // Space600Thickness = 60
+			theme.DefaultCornerRadius = 1;  // Radius700CornerRadius = 7
+
+			root.RequestedTheme = ElementTheme.Light;
+			await UnitTestsUIContentHelper.WaitForIdle();
+			root.RequestedTheme = ElementTheme.Dark;
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			Assert.AreEqual(new CornerRadius(7), dialog.CornerRadius,
+				$"A realized ContentDialog must re-resolve MaterialContentDialogCornerRadius after the radius changes (was {radiusBefore}).");
+		}
+		finally
+		{
+			theme.DefaultSpacing = originalSpacing;
+			theme.DefaultCornerRadius = originalRadius;
+			root.RequestedTheme = ElementTheme.Default;
+			UnitTestsUIContentHelper.Content = null;
+		}
+	}
+
 }

--- a/src/samples/SimpleSampleApp/RuntimeTests/Given_DesignTokens.cs
+++ b/src/samples/SimpleSampleApp/RuntimeTests/Given_DesignTokens.cs
@@ -421,4 +421,78 @@ public class Given_DesignTokens
 			"Simple button MinHeight should be ControlHeightMedium (40)");
 	}
 
+	// ═══════════════════════════════════════════════════════════════════════
+	// 10. RUNTIME SEAM — the scale measures move controls, not only tokens.
+	// Regenerated Space*/Radius* keys reach a control only if its style reads them through
+	// {ThemeResource}; a {StaticResource} setter snapshots the value at parse time. Asserted on
+	// the application theme (the scope a designer edits), restored in finally.
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_ScaleMeasuresChangeAtRuntime_Then_RealizedButtonFollows()
+	{
+		var theme = SemanticThemeHelper.GetTheme();
+		Assert.IsNotNull(theme, "The Simple sample app must have a BaseTheme in its application resources.");
+
+		var originalSpacing = theme.DefaultSpacing;
+		var originalRadius = theme.DefaultCornerRadius;
+		var originalDensity = theme.DefaultDensity;
+
+		var root = new Grid();
+		var button = new Button
+		{
+			Content = "probe",
+			Style = (Style)Application.Current.Resources["SimpleFilledButtonStyle"],
+		};
+		root.Children.Add(button);
+
+		UnitTestsUIContentHelper.Content = root;
+		await UnitTestsUIContentHelper.WaitForLoaded(button);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		try
+		{
+			// Padding = Space300Thickness, CornerRadius = Radius200CornerRadius at the app's defaults.
+			var paddingBefore = button.Padding;
+			var radiusBefore = button.CornerRadius;
+
+			theme.DefaultSpacing = 10;          // Space300 = 30 at Regular
+			theme.DefaultCornerRadius = 1;      // Radius200 = 2
+			theme.DefaultDensity = Density.Compact; // Space300 = 10 × 0.75 × 3 = 22.5
+
+			// Setters re-resolve on a theme-change pass — the public route to content already realized.
+			root.RequestedTheme = ElementTheme.Light;
+			await UnitTestsUIContentHelper.WaitForIdle();
+			root.RequestedTheme = ElementTheme.Dark;
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			Assert.AreEqual(new Thickness(22.5), button.Padding,
+				$"A realized button must re-resolve Space300Thickness after the spacing changes (was {paddingBefore}).");
+			Assert.AreEqual(new CornerRadius(2), button.CornerRadius,
+				$"A realized button must re-resolve Radius200CornerRadius after the radius changes (was {radiusBefore}).");
+
+			// A control created after the change picks the new scale up without any pass.
+			var later = new Button
+			{
+				Content = "later",
+				Style = (Style)Application.Current.Resources["SimpleFilledButtonStyle"],
+			};
+			root.Children.Add(later);
+			await UnitTestsUIContentHelper.WaitForLoaded(later);
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			Assert.AreEqual(new Thickness(22.5), later.Padding, "A button created after the change must use the new spacing.");
+			Assert.AreEqual(new CornerRadius(2), later.CornerRadius, "A button created after the change must use the new radius.");
+		}
+		finally
+		{
+			theme.DefaultSpacing = originalSpacing;
+			theme.DefaultCornerRadius = originalRadius;
+			theme.DefaultDensity = originalDensity;
+			root.RequestedTheme = ElementTheme.Default;
+			UnitTestsUIContentHelper.Content = null;
+		}
+	}
+
 }


### PR DESCRIPTION
GitHub Issue (If applicable): follow-up to #1688 (`DefaultSpacing`) and #1705 (the `DefaultFontFamily` seam); no dedicated issue.

## PR Type

- Bugfix

## Description

**Stack 3/3 — depends on #1707** (`feat(themes): add DefaultFontFamily to BaseTheme and re-resolve the font override`), which this PR's branch is based on; #1707 in turn depends on #1710 (merged). Review only this layer's diff.

`DefaultSpacing`, `DefaultDensity` and `DefaultCornerRadius` regenerate the `Space*` / `Radius*` tokens at runtime, but no control followed: Simple and Material v2 control styles read those tokens — directly or through per-control aliases such as `SimpleButtonCornerRadius` and `MaterialContentDialogPanelPadding` — with `{StaticResource}`, which snapshots the value when the dictionary is parsed. `doc/design-tokens.md` had documented that as a "construction-time" property of the design; it was the same defect #1707's review found for `SimpleButtonFontFamily`, at scale.

- **Sweep.** Alias closure over every `<StaticResource x:Key ResourceKey>` declaration rooted at a generated `Space*` / `Radius*` key, then every `{StaticResource K}` consumer of that closure, across Simple and Material v2: **98 sites in 22 files** (78 Simple, 20 Material v2), all rewritten to `{ThemeResource}`. The diff is exactly those 98 token swaps — no other text, line-ending or BOM changes. Density constants (`ControlHeight*`, `IconSize*`, `TouchTargetMinSize`) are regenerated with fixed values and are left alone.
- **Red / green.** `Given_DesignTokens.When_ScaleMeasuresChangeAtRuntime_Then_RealizedButtonFollows` (Simple head): a realized `SimpleFilledButtonStyle` button kept `Padding` 12 / `CornerRadius` 8 after `DefaultSpacing` = 10, `DefaultDensity` = Compact, `DefaultCornerRadius` = 1 — expected 22.5 / 2; a button created after the change is asserted too. `Given_DesignTokens.When_ScaleMeasuresChangeAtRuntime_Then_RealizedContentDialogFollows` (Material head): a realized `MaterialContentDialogStyle` dialog kept `CornerRadius` 28 — expected 7. Both mutate the application theme (the scope Hot Design edits) and restore it in `finally`; realized content re-resolves on a `RequestedTheme` flip, the same route `FontFamilyTunerControl` uses.
- **Docs.** `doc/design-tokens.md`: the three scale measures are runtime-settable, with the already-realized caveat and the theme-change-pass route, matching the `DefaultFontFamily` wording.

## PR Checklist

- Commits follow Conventional Commits
- [x] Tested the changes where applicable:
	- [x] Desktop (Skia) — full runtime suites headless: Simple head 256 passed / 0 failed; Material head 63 passed / 0 failed
- [x] Updated the documentation as needed:
	- [x] General Doc Update (`doc/design-tokens.md`)
- [x] Contains **No** breaking changes (resource keys and their values are unchanged; only how the styles read them)

## Other information

Sweep method, red/green details and suite counts are recorded in `specs/07-default-spacing/progress.md` (review addendum) and `specs/lessons.md`. Hot Design context: unoplatform/uno.hotdesign#7871 — the property grid edits these three measures on the running theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gjq1PTgqHq3BtLLJbwiguk
