### PR TITLE
ci: Set version to '9.0-dev.{height}' for the Uno 7.0 line

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "8.0-dev.{height}",
+  "version": "9.0-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

_Release-line coordination for the Uno Platform 7.0 major — no product issue, tracked with the rest of the 7.0 repo splits._

## PR Type

- Build or CI related changes

## Description

Moves `master` from `8.0-dev.{height}` to `9.0-dev.{height}`, so `master` becomes the Uno Platform **7.0** line for Uno.Themes.

### Why a new major

`master` currently carries Themes' **own** feature major, 8.0 — Color Fidelity (#1697), the `DefaultSpacing` / `Density` split (#1701), and the `DefaultFontFamily` collapse (#1710). Those are all still `net9.0` and Uno **6.x**-compatible, so they are not the 7.0 line. Retargeting to Uno 7.0 (#1722: `Uno.Sdk.Private` 7.0, `net10.0`, the `Uno.UI.Toolkit` -> `Uno.UI.Extras` rename) is binary breaking on top of them, so it needs a **further** major: 9.0.

### Where the 6.x line continues

Uno.Themes 8.0 has **not** shipped a stable release yet, so the 8.0 line stays open rather than being cut. Immediately after this merges, `servicing/8.0` is pushed from `47d42c18` (this PR's parent) with `version.json` **unchanged**, so it continues the same dev sequence from the last published `8.0.0-dev.15` onward. `release/stable/8.0` will be cut from `servicing/8.0` once the remaining 8.0 work has landed.

| Branch | version.json | Packages | Consumers |
|---|---|---|---|
| `master` | `9.0-dev.{height}` | `9.0.0-dev.1` -> N | Uno Platform 7.0 |
| `servicing/8.0` | `8.0-dev.{height}` (unchanged) | `8.0.0-dev.16` -> N | Uno Platform 6.x |
| `release/stable/8.0` *(next week)* | `8.0` | `8.0.1` | Uno 6.7 SR3 |

`servicing/7.2` is retired — its dev line is superseded by `servicing/8.0`, which carries the same content plus the 8.0 features.

### Ordering

This PR merges **first**, before `servicing/8.0` is cut. `servicing/8.0` keeps the same `version` field, so while both branches share it they would compute the same height and could race on `8.0.0-dev.16`. Bumping `master` first removes that overlap entirely.

## PR Checklist

- [x] Tested the changes where applicable: n/a — `version.json` only, no product code
- [x] Updated the documentation as needed: n/a
- [x] Contains **No** breaking changes

The version number itself is a breaking bump, but this PR carries no code change; the breaking work lands via #1722.

## Other information

- `publicReleaseRefSpec` already contains `^refs/heads/servicing/.*$`, so no refspec change is needed.
- Servicing CI plumbing is already on `master` (`d230604e`, `07061873`).
- Branch protection already has a `servicing/*` pattern rule, so `servicing/8.0` is protected on creation.
- #1722 (7.0 retarget) does not touch `version.json`, so it will not conflict with this bump.
