### PR TITLE
fix(samples): move samples to MSTest 4 with the runtime test engine

### DIFF
--- a/src/samples/Directory.Packages.props
+++ b/src/samples/Directory.Packages.props
@@ -9,8 +9,8 @@
     <PackageVersion Include="Uno.ShowMeTheXAML" Version="2.0.0-dev0015" />
     <PackageVersion Include="Uno.ShowMeTheXAML.MSBuild" Version="2.0.0-dev0015" />
     <PackageVersion Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
-    <PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="2.0.0-dev.60" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.6.4" />
+    <PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="2.0.0-dev.85" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.3.3" />
     <!-- Asset-only font packages for ThemesSampleApp so hosted guests' theme fonts resolve.
          Versions mirror src/library/Directory.Packages.props (the theme libraries' own pins). -->
     <PackageVersion Include="Uno.Fonts.Roboto" Version="2.10.0-dev.9" />

--- a/src/samples/SamplesApp.Shared/Entities/SourceSdk.cs
+++ b/src/samples/SamplesApp.Shared/Entities/SourceSdk.cs
@@ -1,5 +1,9 @@
 ﻿using System.ComponentModel;
 
+// MSTest 4.x introduces Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute,
+// which collides with the ComponentModel one these display names use (CS0104).
+using Description = System.ComponentModel.DescriptionAttribute;
+
 namespace Uno.Themes.Samples.Entities;
 
 public enum SourceSdk

--- a/src/samples/SamplesApp.Shared/Helpers/EnumHelper.cs
+++ b/src/samples/SamplesApp.Shared/Helpers/EnumHelper.cs
@@ -14,5 +14,5 @@ public static class EnumHelper
 	/// <summary>
 	/// Get the description value from DescriptionAttribute
 	/// </summary>
-	public static string GetDescription(this Enum @enum) => @enum.GetAttribute<DescriptionAttribute>()?.Description;
+	public static string GetDescription(this Enum @enum) => @enum.GetAttribute<System.ComponentModel.DescriptionAttribute>()?.Description;
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## Description

The [Uno.Themes canary](https://dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_build/results?buildId=233349&view=results) has been red since **2026-09-02** (last green: [#231457](https://dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_build/results?buildId=231457&view=results)). **All 14 jobs** fail at restore, before anything compiles:

```
Warning As Error: Detected package downgrade: MSTest.TestFramework from 4.3.3 to 3.6.4.
  MaterialSampleApp -> Uno.UI.RuntimeTests.Engine 2.0.0-dev.85 -> MSTest.TestFramework (>= 4.3.3)
  MaterialSampleApp -> MSTest.TestFramework (>= 3.6.4)
```

The canary bumps `Uno.UI.RuntimeTests.Engine` to `2.0.0-dev.85`, which requires `MSTest.TestFramework >= 4.3.3`, while `src/samples/Directory.Packages.props` pins `3.6.4`.

### Why the engine moves with MSTest

These two versions are coupled and cannot be bumped independently:

- Engine `2.0.0-dev.60` (the current pin) uses `ExpectedExceptionAttribute`, **removed in MSTest 4**. That file ships as source inside the package (`uno.ui.runtimetests.engine/2.0.0-dev.60/src/Engine/UnitTestMethodInfo.cs`) and compiles into each sample app, so raising MSTest alone fails the build on `master` with `CS0246`.
- Engine `2.0.0-dev.85` is what the canary already resolves to, so this aligns `master` with the canary rather than pinning against it.

### MSTest 4 attribute collision

MSTest 4 introduces `Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute`, which is ambiguous with the `System.ComponentModel` one the samples use for enum display names (`CS0104`):

- `SourceSdk.cs` — resolved with a `using Description = System.ComponentModel.DescriptionAttribute;` alias, keeping the four `[Description(...)]` usages unchanged.
- `EnumHelper.cs` — the single `GetAttribute<DescriptionAttribute>()` call is now fully qualified.

Both are display-name paths; no test or behavioural change.

## PR Checklist

- Commits follow the Conventional Commits specification
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] iOS
	- [x] Android — restore verified under canary package versions
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed — n/a, no API or styling change
- [x] Contains **No** breaking changes

## Other information

**Local verification**

- Reproduced the canary failure with the canary's SDK versions (`Uno.Sdk 7.0.0-dev.2`, `Uno.Sdk.Private 7.0.0-dev.701`) and engine `2.0.0-dev.85`: identical `NU1605`.
- With this change, `dotnet restore` succeeds under those canary versions on both the **Desktop** and **Android** heads — the two places CI dies.
- `master` still builds with its own SDK pins (`Uno.Sdk 6.4.53` / `Uno.Sdk.Private 6.7.0-dev.815`): `dotnet build -c Release` on the Desktop head, **0 errors**.

**Known limitation — this may not be sufficient on its own**

The canary also reports a second `NU1605` on SkiaSharp (`4.151.1` → `4.148.0`, via `Uno.WinUI.Runtime.Skia.Linux.FrameBuffer` / `Uno.WinUI.Lottie` `7.0.0-dev.701`) on the Desktop and Android jobs. **That one did not reproduce locally** — with the canary SDK versions SkiaSharp resolves consistently at `4.151.1` on every head.

SkiaSharp is not pinned anywhere in this repository, and none of the obvious sources produce `4.148.0`: `Uno.Sdk 7.0.0-dev.2` declares `3.119.2`, `Uno.Sdk.Private 7.0.0-dev.701` declares `4.151.1` (matching `Uno.WinUI`'s own floor), and `Uno.UI.RuntimeTests.Engine` has no SkiaSharp dependency. If that error is independent rather than a knock-on of the MSTest failure, the Desktop and Android jobs will still fail after this merges and will need the canary's resolved graph (`Canary.md`) to diagnose.

The full canary *build* stage was not reproduced locally either — that requires the complete bump set (`Uno.Toolkit` `11.0.0-dev.2`, `uno.themes` `9.0.0-dev.2`), and bumping the SDKs alone produces unrelated Toolkit mismatch errors that are an artifact of the partial reproduction. CI currently fails at restore, which is what this change addresses.

## Internal Issue (If applicable):
